### PR TITLE
Enable travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: java
+jdk:
+  - oraclejdk8
+  
+# gradle projects have "gradle assemble" and "gradle check" run automatically
+# so a script setting is not required to verify the code compiles or run tests
+# script:
+
+# from: https://docs.travis-ci.com/user/languages/java/#Caching
+# A peculiarity of dependency caching in Gradle means that
+#  to avoid uploading the cache after every build 
+#  you need to add the following lines to your .travis.yml:
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/


### PR DESCRIPTION
Adds Travis support. By default Travis runs the "assemble" and "check" tasks for Gradle projects, so no special configuration is needed to run the unit tests.