### PR TITLE
Providers

### DIFF
--- a/src/main/java/org/mitre/synthea/export/Exporter.java
+++ b/src/main/java/org/mitre/synthea/export/Exporter.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.commons.io.FileUtils;
 import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.modules.Person;
 

--- a/src/main/java/org/mitre/synthea/export/Exporter.java
+++ b/src/main/java/org/mitre/synthea/export/Exporter.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.commons.io.FileUtils;
 import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.modules.Person;
 

--- a/src/main/java/org/mitre/synthea/export/HospitalExporter.java
+++ b/src/main/java/org/mitre/synthea/export/HospitalExporter.java
@@ -1,0 +1,74 @@
+package org.mitre.synthea.export;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.hl7.fhir.dstu3.model.Bundle;
+import org.hl7.fhir.dstu3.model.Bundle.BundleEntryComponent;
+import org.hl7.fhir.dstu3.model.Organization;
+import org.hl7.fhir.dstu3.model.Resource;
+import org.mitre.synthea.helpers.Config;
+import org.mitre.synthea.world.Hospital;
+import org.mitre.synthea.world.Provider;
+
+import ca.uhn.fhir.context.FhirContext;
+
+public abstract class HospitalExporter{
+	
+	private static final FhirContext FHIR_CTX = FhirContext.forDstu3();
+	
+	public static void export(){
+		if(Boolean.parseBoolean(Config.get("exporter.fhir.export"))){
+			
+			String bundleJson = "";
+			for(Hospital h : Hospital.getHospitalList()){
+				bundleJson = bundleJson + convertToFHIR(h);
+			}
+			
+			// get output folder
+			List<String> folders = new ArrayList<>();
+			folders.add("fhir");
+			String baseDirectory = Config.get("exporter.baseDirectory");
+			File f = Paths.get(baseDirectory, folders.toArray(new String[0])).toFile();
+			f.mkdirs();
+			Path outFilePath = f.toPath().resolve("hospitalInformation.json");
+			
+			try {
+				Files.write(outFilePath, Collections.singleton(bundleJson), StandardOpenOption.CREATE_NEW);
+			} catch (IOException e) 
+			{
+				e.printStackTrace();
+			}
+		}
+	}
+	
+	public static String convertToFHIR(Hospital h){
+		Bundle bundle = new Bundle();
+		Organization organizationResource = new Organization();
+		
+		organizationResource.addIdentifier()
+			.setSystem("https://github.com/synthetichealth/synthea")
+			.setValue((String) h.getResourceID());
+		
+		BundleEntryComponent hospitalEntry = newEntry(bundle, organizationResource, h.getResourceID());
+		String bundleJson = FHIR_CTX.newJsonParser().setPrettyPrint(true).encodeResourceToString(bundle);
+		return bundleJson;
+	}
+	
+	private static BundleEntryComponent newEntry(Bundle bundle, Resource resource, String resourceID){
+		BundleEntryComponent entry = bundle.addEntry();
+
+		resource.setId(resourceID);
+		entry.setFullUrl("urn:uuid:" + resourceID);
+		
+		entry.setResource(resource);
+		return entry;
+	}
+}

--- a/src/main/java/org/mitre/synthea/export/HospitalExporter.java
+++ b/src/main/java/org/mitre/synthea/export/HospitalExporter.java
@@ -38,10 +38,11 @@ public abstract class HospitalExporter{
 		if(Boolean.parseBoolean(Config.get("exporter.hospital.fhir.export"))){
 			
 			String bundleJson = "";
+			Bundle bundle = new Bundle();
 			for(Hospital h : Hospital.getHospitalList()){
 				// filter - exports only those hospitals in use
 				if(h.getUtilization().get(Provider.ENCOUNTERS) != 0){
-					bundleJson = bundleJson + convertToFHIR(h);
+					bundleJson = convertToFHIR(h, bundle);
 				}
 			}
 			
@@ -68,8 +69,7 @@ public abstract class HospitalExporter{
 		}
 	}
 	
-	public static String convertToFHIR(Hospital h){
-		Bundle bundle = new Bundle();
+	public static String convertToFHIR(Hospital h, Bundle bundle){
 		Organization organizationResource = new Organization();
 		
 		organizationResource.addIdentifier()

--- a/src/main/java/org/mitre/synthea/export/HospitalExporter.java
+++ b/src/main/java/org/mitre/synthea/export/HospitalExporter.java
@@ -7,16 +7,24 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
+import org.hl7.fhir.dstu3.model.Address;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Bundle.BundleEntryComponent;
+import org.hl7.fhir.dstu3.model.Extension;
+import org.hl7.fhir.dstu3.model.IntegerType;
 import org.hl7.fhir.dstu3.model.Organization;
 import org.hl7.fhir.dstu3.model.Resource;
 import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.world.Hospital;
 import org.mitre.synthea.world.Provider;
+
+import com.google.gson.internal.LinkedTreeMap;
 
 import ca.uhn.fhir.context.FhirContext;
 
@@ -24,12 +32,17 @@ public abstract class HospitalExporter{
 	
 	private static final FhirContext FHIR_CTX = FhirContext.forDstu3();
 	
+	private static final String SYNTHEA_URI = "http://synthetichealth.github.io/synthea/";
+	
 	public static void export(){
-		if(Boolean.parseBoolean(Config.get("exporter.fhir.export"))){
+		if(Boolean.parseBoolean(Config.get("exporter.hospital.fhir.export"))){
 			
 			String bundleJson = "";
 			for(Hospital h : Hospital.getHospitalList()){
-				bundleJson = bundleJson + convertToFHIR(h);
+				// filter - exports only those hospitals in use
+				if(h.getUtilization().get(Provider.ENCOUNTERS) != 0){
+					bundleJson = bundleJson + convertToFHIR(h);
+				}
 			}
 			
 			// get output folder
@@ -40,6 +53,12 @@ public abstract class HospitalExporter{
 			f.mkdirs();
 			Path outFilePath = f.toPath().resolve("hospitalInformation.json");
 			
+			// delete previous file if it exists
+			try {
+				Files.delete(outFilePath);
+			} catch (IOException e) {
+			}
+		
 			try {
 				Files.write(outFilePath, Collections.singleton(bundleJson), StandardOpenOption.CREATE_NEW);
 			} catch (IOException e) 
@@ -56,6 +75,45 @@ public abstract class HospitalExporter{
 		organizationResource.addIdentifier()
 			.setSystem("https://github.com/synthetichealth/synthea")
 			.setValue((String) h.getResourceID());
+		
+		LinkedTreeMap hAttributes = h.getAttributes();
+		
+		organizationResource.setName(hAttributes.get("name").toString());
+		
+		Address address = new Address();
+		address.addLine(hAttributes.get("address").toString());
+		address.setCity(hAttributes.get("city").toString());
+		address.setPostalCode(hAttributes.get("city_zip").toString());
+		address.setState(hAttributes.get("state").toString());
+		organizationResource.addAddress(address);
+
+		Extension encountersExtension = new Extension(SYNTHEA_URI + "utilization-encounters-extension");
+		IntegerType encountersValue = new IntegerType(h.getUtilization().get(Provider.ENCOUNTERS));
+		encountersExtension.setValue(encountersValue);
+		organizationResource.addExtension(encountersExtension);
+		
+		Extension proceduresExtension = new Extension(SYNTHEA_URI + "utilization-procedures-extension");
+		IntegerType proceduresValue = new IntegerType(h.getUtilization().get(Provider.PROCEDURES));
+		proceduresExtension.setValue(proceduresValue);
+		organizationResource.addExtension(proceduresExtension);
+		
+		Extension labsExtension = new Extension(SYNTHEA_URI + "utilization-labs-extension");
+		IntegerType labsValue = new IntegerType(h.getUtilization().get(Provider.LABS));
+		labsExtension.setValue(labsValue);
+		organizationResource.addExtension(labsExtension);
+		
+		Extension prescriptionsExtension = new Extension(SYNTHEA_URI + "utilization-prescriptions-extension");
+		IntegerType prescriptionsValue = new IntegerType(h.getUtilization().get(Provider.PRESCRIPTIONS));
+		prescriptionsExtension.setValue(prescriptionsValue);
+		organizationResource.addExtension(prescriptionsExtension);
+		
+		Integer bedCount = h.getBedCount();
+		if(bedCount != null){
+			Extension bedCountExtension = new Extension(SYNTHEA_URI + "bed-count-extension");
+			IntegerType bedCountValue = new IntegerType(bedCount);
+			bedCountExtension.setValue(bedCountValue);
+			organizationResource.addExtension(bedCountExtension);
+		}
 		
 		BundleEntryComponent hospitalEntry = newEntry(bundle, organizationResource, h.getResourceID());
 		String bundleJson = FHIR_CTX.newJsonParser().setPrettyPrint(true).encodeResourceToString(bundle);

--- a/src/main/java/org/mitre/synthea/export/HospitalExporter.java
+++ b/src/main/java/org/mitre/synthea/export/HospitalExporter.java
@@ -34,7 +34,7 @@ public abstract class HospitalExporter{
 	
 	private static final String SYNTHEA_URI = "http://synthetichealth.github.io/synthea/";
 	
-	public static void export(){
+	public static void export(long stop){
 		if(Boolean.parseBoolean(Config.get("exporter.hospital.fhir.export"))){
 			
 			String bundleJson = "";
@@ -52,13 +52,7 @@ public abstract class HospitalExporter{
 			String baseDirectory = Config.get("exporter.baseDirectory");
 			File f = Paths.get(baseDirectory, folders.toArray(new String[0])).toFile();
 			f.mkdirs();
-			Path outFilePath = f.toPath().resolve("hospitalInformation.json");
-			
-			// delete previous file if it exists
-			try {
-				Files.delete(outFilePath);
-			} catch (IOException e) {
-			}
+			Path outFilePath = f.toPath().resolve("hospitalInformation" + stop + ".json");
 		
 			try {
 				Files.write(outFilePath, Collections.singleton(bundleJson), StandardOpenOption.CREATE_NEW);

--- a/src/main/java/org/mitre/synthea/modules/Generator.java
+++ b/src/main/java/org/mitre/synthea/modules/Generator.java
@@ -113,13 +113,6 @@ public class Generator {
 				count.incrementAndGet();
 			});
 		}
-		
-		try{
-			HospitalExporter.export();
-		} catch (Exception e) {
-			e.printStackTrace();
-			throw e;
-		}
 
 		try 
 		{
@@ -130,6 +123,13 @@ public class Generator {
 			}
 		} catch (InterruptedException e)
 		{
+			e.printStackTrace();
+		}
+		
+		// export hospital information
+		try{
+			HospitalExporter.export();
+		} catch (Exception e) {
 			e.printStackTrace();
 		}
 		

--- a/src/main/java/org/mitre/synthea/modules/Generator.java
+++ b/src/main/java/org/mitre/synthea/modules/Generator.java
@@ -14,6 +14,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.mitre.synthea.export.Exporter;
 import org.mitre.synthea.helpers.Config;
+import org.mitre.synthea.world.Hospital;
 
 /**
  * Generator creates a population by running the generic modules each timestep per Person.
@@ -48,6 +49,9 @@ public class Generator {
 		this.stats = Collections.synchronizedMap(new HashMap<String,AtomicInteger>());
 		stats.put("alive", new AtomicInteger(0));
 		stats.put("dead", new AtomicInteger(0));
+		
+		// initialize hospitals
+		Hospital.loadHospitals();
 	}
 	
 	public void run()

--- a/src/main/java/org/mitre/synthea/modules/Generator.java
+++ b/src/main/java/org/mitre/synthea/modules/Generator.java
@@ -13,6 +13,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.mitre.synthea.export.Exporter;
+import org.mitre.synthea.export.HospitalExporter;
 import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.world.Hospital;
 
@@ -111,6 +112,13 @@ public class Generator {
 				AtomicInteger count = stats.get(key);
 				count.incrementAndGet();
 			});
+		}
+		
+		try{
+			HospitalExporter.export();
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw e;
 		}
 
 		try 

--- a/src/main/java/org/mitre/synthea/modules/Generator.java
+++ b/src/main/java/org/mitre/synthea/modules/Generator.java
@@ -128,7 +128,7 @@ public class Generator {
 		
 		// export hospital information
 		try{
-			HospitalExporter.export();
+			HospitalExporter.export(stop);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}

--- a/src/main/java/org/mitre/synthea/modules/HealthRecord.java
+++ b/src/main/java/org/mitre/synthea/modules/HealthRecord.java
@@ -156,10 +156,6 @@ public class HealthRecord {
 			medications = new ArrayList<Medication>();
 			careplans = new ArrayList<CarePlan>();
 		}
-		
-		public void setProvider(Provider p){
-			provider = p;
-		}
 	}
 	
 	public List<Encounter> encounters;

--- a/src/main/java/org/mitre/synthea/modules/HealthRecord.java
+++ b/src/main/java/org/mitre/synthea/modules/HealthRecord.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.mitre.synthea.world.Provider;
+
 import com.google.gson.JsonObject;
 
 /**
@@ -141,6 +143,7 @@ public class HealthRecord {
 		public List<CarePlan> careplans;
 		public String reason;
 		public Code discharge;
+		public Provider provider;
 		
 		public Encounter(long time, String type) {
 			super(time, type);
@@ -152,6 +155,10 @@ public class HealthRecord {
 			immunizations = new ArrayList<Entry>();
 			medications = new ArrayList<Medication>();
 			careplans = new ArrayList<CarePlan>();
+		}
+		
+		public void setProvider(Provider p){
+			provider = p;
 		}
 	}
 	

--- a/src/main/java/org/mitre/synthea/modules/Person.java
+++ b/src/main/java/org/mitre/synthea/modules/Person.java
@@ -1,5 +1,7 @@
 package org.mitre.synthea.modules;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -7,6 +9,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 import org.mitre.synthea.modules.HealthRecord.Code;
+import org.mitre.synthea.world.Hospital;
+import org.mitre.synthea.world.Provider;
+
+import com.vividsolutions.jts.geom.Point;
 
 public class Person {
 	
@@ -144,5 +150,70 @@ public class Person {
 			}
 		}
 		return false;
+	}
+	
+	// Providers API -----------------------------------------------------------
+	public static final String CURRENTPROVIDER = "currentProvider";
+	public static final String PREFERREDAMBULATORYPROVIDER = "preferredAmbulatoryProvider";
+	public static final String PREFERREDINPATIENTPROVIDER = "preferredInpatientProvider";
+	public static final String PREFERREDEMERGENCYPROVIDER = "preferredEmergencyProvider";
+	
+	
+	public Provider getAmbulatoryProvider(){
+		return (Provider) attributes.get(PREFERREDAMBULATORYPROVIDER);
+	}
+	
+	public void setAmbulatoryProvider(Provider provider){
+		if(provider == null){
+			Point personLocation = (Point) attributes.get(Person.COORDINATE);
+			provider = Hospital.findClosestAmbulatory(personLocation);
+		}
+		attributes.put(PREFERREDAMBULATORYPROVIDER, provider);
+	}
+	
+	public Provider getInpatientProvider(){
+		return (Provider) attributes.get(PREFERREDINPATIENTPROVIDER);
+	}
+	
+	public void setInpatientProvider(Provider provider){
+		if(provider == null){
+			Point personLocation = (Point) attributes.get(Person.COORDINATE);
+			provider = Hospital.findClosestInpatient(personLocation);
+		}
+		attributes.put(PREFERREDINPATIENTPROVIDER, provider);
+	}
+	
+	public Provider getEmergencyProvider(){
+		return (Provider) attributes.get(PREFERREDEMERGENCYPROVIDER);
+	}
+	
+	public void setEmergencyProvider(Provider provider){
+		if(provider == null){
+			Point personLocation = (Point) attributes.get(Person.COORDINATE);
+			provider = Hospital.findClosestEmergency(personLocation);
+		}
+		attributes.put(PREFERREDEMERGENCYPROVIDER, provider);
+	}
+	
+	public void addCurrentProvider(String context, Provider provider){
+		if(attributes.containsKey(CURRENTPROVIDER)){
+			Map<String, Provider> currentProviders = (Map) attributes.get(CURRENTPROVIDER);
+			currentProviders.put(context, provider);
+			attributes.put(CURRENTPROVIDER, currentProviders);
+		} else {
+			Map<String, Provider> currentProviders = new HashMap<String, Provider>();
+			currentProviders.put(context, provider);
+			attributes.put(CURRENTPROVIDER, currentProviders);
+		}
+	}
+	
+	public void removeCurrentProvider(String module){
+		Map<String, Provider> currentProviders = (Map) attributes.get(CURRENTPROVIDER);
+		currentProviders.remove(module);
+	}
+	
+	public Provider getCurrentProvider(String module){
+		Map<String, Provider> currentProviders = (Map) attributes.get(CURRENTPROVIDER);
+		return currentProviders.get(module);
 	}
 }

--- a/src/main/java/org/mitre/synthea/modules/Person.java
+++ b/src/main/java/org/mitre/synthea/modules/Person.java
@@ -163,11 +163,13 @@ public class Person {
 		return (Provider) attributes.get(PREFERREDAMBULATORYPROVIDER);
 	}
 	
+	public void setAmbulatoryProvider(){
+		Point personLocation = (Point) attributes.get(Person.COORDINATE);
+		Provider provider = Hospital.findClosestAmbulatory(personLocation);
+		attributes.put(PREFERREDAMBULATORYPROVIDER, provider);
+	}
+	
 	public void setAmbulatoryProvider(Provider provider){
-		if(provider == null){
-			Point personLocation = (Point) attributes.get(Person.COORDINATE);
-			provider = Hospital.findClosestAmbulatory(personLocation);
-		}
 		attributes.put(PREFERREDAMBULATORYPROVIDER, provider);
 	}
 	
@@ -175,16 +177,24 @@ public class Person {
 		return (Provider) attributes.get(PREFERREDINPATIENTPROVIDER);
 	}
 	
+	public void setInpatientProvider(){
+		Point personLocation = (Point) attributes.get(Person.COORDINATE);
+		Provider provider = Hospital.findClosestInpatient(personLocation);
+		attributes.put(PREFERREDINPATIENTPROVIDER, provider);
+	}
+	
 	public void setInpatientProvider(Provider provider){
-		if(provider == null){
-			Point personLocation = (Point) attributes.get(Person.COORDINATE);
-			provider = Hospital.findClosestInpatient(personLocation);
-		}
 		attributes.put(PREFERREDINPATIENTPROVIDER, provider);
 	}
 	
 	public Provider getEmergencyProvider(){
 		return (Provider) attributes.get(PREFERREDEMERGENCYPROVIDER);
+	}
+
+	public void setEmergencyProvider(){
+		Point personLocation = (Point) attributes.get(Person.COORDINATE);
+		Provider provider = Hospital.findClosestEmergency(personLocation);
+		attributes.put(PREFERREDEMERGENCYPROVIDER, provider);
 	}
 	
 	public void setEmergencyProvider(Provider provider){

--- a/src/main/java/org/mitre/synthea/modules/State.java
+++ b/src/main/java/org/mitre/synthea/modules/State.java
@@ -186,9 +186,9 @@ public class State {
 			if(definition.has("wellness") && definition.get("wellness").getAsBoolean()) {
 				Encounter encounter = person.record.currentEncounter(time);
 				
-				// TODO: provider.incrementEncounters() for wellness encounters 
-				
 				if(encounter.type==EncounterType.WELLNESS.toString() && encounter.stop!=0l) {
+					// TODO: provider.incrementEncounters() for wellness encounters 
+					
 					this.exited = time;
 					return true;
 				} else {
@@ -201,7 +201,7 @@ public class State {
 				Encounter encounter = person.record.encounterStart(time, encounter_class);
 				
 				// find closest provider and increment encounters count
-				Provider provider = Provider.findClosestService(person, Provider.AMBULATORY);
+				Provider provider = Provider.findClosestService(person, encounter_class);
 				person.addCurrentProvider(module, provider);
 				provider.incrementEncounters();
 				
@@ -487,7 +487,7 @@ public class State {
 				String units = definition.get("duration").getAsJsonObject().get("unit").getAsString();
 				procedure.stop = procedure.start + Utilities.convertTime(units, (long) duration);
 			}
-			// increment number of prescriptions prescribed by respective hospital
+			// increment number of procedures by respective hospital
 			Provider provider;
 			if(person.getCurrentProvider(module) != null){
 				provider = person.getCurrentProvider(module);

--- a/src/main/java/org/mitre/synthea/modules/State.java
+++ b/src/main/java/org/mitre/synthea/modules/State.java
@@ -192,7 +192,7 @@ public class State {
 					Provider provider = Provider.findClosestService(person, "wellness");
 					person.addCurrentProvider(module, provider);
 					provider.incrementEncounters();
-					encounter.setProvider(provider);
+					encounter.provider = provider;
 					
 					this.exited = time;
 					return true;
@@ -209,7 +209,7 @@ public class State {
 				Provider provider = Provider.findClosestService(person, encounter_class);
 				person.addCurrentProvider(module, provider);
 				provider.incrementEncounters();
-				encounter.setProvider(provider);
+				encounter.provider = provider;
 				
 				encounter.name = this.name;
 				if(definition.has("reason")) {

--- a/src/main/java/org/mitre/synthea/modules/State.java
+++ b/src/main/java/org/mitre/synthea/modules/State.java
@@ -192,6 +192,7 @@ public class State {
 					Provider provider = Provider.findClosestService(person, "wellness");
 					person.addCurrentProvider(module, provider);
 					provider.incrementEncounters();
+					encounter.setProvider(provider);
 					
 					this.exited = time;
 					return true;
@@ -208,6 +209,7 @@ public class State {
 				Provider provider = Provider.findClosestService(person, encounter_class);
 				person.addCurrentProvider(module, provider);
 				provider.incrementEncounters();
+				encounter.setProvider(provider);
 				
 				encounter.name = this.name;
 				if(definition.has("reason")) {

--- a/src/main/java/org/mitre/synthea/modules/State.java
+++ b/src/main/java/org/mitre/synthea/modules/State.java
@@ -187,7 +187,11 @@ public class State {
 				Encounter encounter = person.record.currentEncounter(time);
 				
 				if(encounter.type==EncounterType.WELLNESS.toString() && encounter.stop!=0l) {
-					// TODO: provider.incrementEncounters() for wellness encounters 
+					
+					// find closest provider and increment encounters count
+					Provider provider = Provider.findClosestService(person, "wellness");
+					person.addCurrentProvider(module, provider);
+					provider.incrementEncounters();
 					
 					this.exited = time;
 					return true;
@@ -376,7 +380,6 @@ public class State {
 				medicationProvider = person.getAmbulatoryProvider();
 			}
 			medicationProvider.incrementPrescriptions();
-			
 			this.exited = time;
 			return true;
 		case MEDICATIONEND:

--- a/src/main/java/org/mitre/synthea/world/Hospital.java
+++ b/src/main/java/org/mitre/synthea/world/Hospital.java
@@ -56,16 +56,16 @@ public class Hospital extends Provider{
 	
 	// find closest hospital with ambulatory service
 	public static Hospital findClosestAmbulatory(Point personLocation){
-		Double personLat = personLocation.getY();
-		Double personLong = personLocation.getX();
+		double personLat = personLocation.getY();
+		double personLong = personLocation.getX();
 		
-		Double closestDistance = 100000000.0;
+		double closestDistance = Double.MAX_VALUE;
 		Provider closestHospital = null;
 		for(Provider p : Provider.getServices().get(Provider.AMBULATORY)){
 			Point hospitalLocation = p.getCoordinates();
-			Double hospitalLat = hospitalLocation.getY();
-			Double hospitalLong = hospitalLocation.getX();
-			Double sphericalDistance = haversine(personLat, personLong, hospitalLat, hospitalLong);
+			double hospitalLat = hospitalLocation.getY();
+			double hospitalLong = hospitalLocation.getX();
+			double sphericalDistance = haversine(personLat, personLong, hospitalLat, hospitalLong);
 			if( sphericalDistance < closestDistance ) {
 				closestDistance = sphericalDistance;
 				closestHospital = p;
@@ -76,16 +76,16 @@ public class Hospital extends Provider{
 	
 	// find closest hospital with inpatient service
 	public static Hospital findClosestInpatient(Point personLocation){
-		Double personLat = personLocation.getY();
-		Double personLong = personLocation.getX();
+		double personLat = personLocation.getY();
+		double personLong = personLocation.getX();
 		
-		Double closestDistance = 100000000.0;
+		double closestDistance = Double.MAX_VALUE;
 		Provider closestHospital = null;
 		for(Provider p : Provider.getServices().get(Provider.INPATIENT)){
 			Point hospitalLocation = p.getCoordinates();
-			Double hospitalLat = hospitalLocation.getY();
-			Double hospitalLong = hospitalLocation.getX();
-			Double sphericalDistance = haversine(personLat, personLong, hospitalLat, hospitalLong);
+			double hospitalLat = hospitalLocation.getY();
+			double hospitalLong = hospitalLocation.getX();
+			double sphericalDistance = haversine(personLat, personLong, hospitalLat, hospitalLong);
 			if( sphericalDistance < closestDistance ) {
 				closestDistance = sphericalDistance;
 				closestHospital = p;
@@ -96,16 +96,16 @@ public class Hospital extends Provider{
 	
 	// find closest hospital with emergency service
 	public static Hospital findClosestEmergency(Point personLocation){
-		Double personLat = personLocation.getY();
-		Double personLong = personLocation.getX();
+		double personLat = personLocation.getY();
+		double personLong = personLocation.getX();
 		
-		Double closestDistance = 100000000.0;
+		double closestDistance = Double.MAX_VALUE;
 		Provider closestHospital = null;
 		for(Provider p : Provider.getServices().get(Provider.EMERGENCY)){
 			Point hospitalLocation = p.getCoordinates();
-			Double hospitalLat = hospitalLocation.getY();
-			Double hospitalLong = hospitalLocation.getX();
-			Double sphericalDistance = haversine(personLat, personLong, hospitalLat, hospitalLong);
+			double hospitalLat = hospitalLocation.getY();
+			double hospitalLong = hospitalLocation.getX();
+			double sphericalDistance = haversine(personLat, personLong, hospitalLat, hospitalLong);
 			if( sphericalDistance < closestDistance ) {
 				closestDistance = sphericalDistance;
 				closestHospital = p;

--- a/src/main/java/org/mitre/synthea/world/Hospital.java
+++ b/src/main/java/org/mitre/synthea/world/Hospital.java
@@ -1,0 +1,127 @@
+package org.mitre.synthea.world;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map.Entry;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import com.google.gson.Gson;
+import com.google.gson.internal.LinkedTreeMap;
+import com.vividsolutions.jts.geom.Point;
+
+
+public class Hospital extends Provider{
+	
+	// ArrayList of all hospitals imported
+	private static ArrayList<Hospital> hospitalList = new ArrayList<Hospital>();
+
+	public Hospital(LinkedTreeMap p) {
+		super(p);
+	}
+	
+	public static void clear(){
+		hospitalList.clear();
+	}
+	
+	public static void loadHospitals(){
+		String filename = "/geography/healthcare_facilities.json";
+		try {
+			InputStream stream = Hospital.class.getResourceAsStream(filename);
+			// read all text into a string
+			String json = new BufferedReader(new InputStreamReader(stream)).lines()
+					.parallel().collect(Collectors.joining("\n"));
+			Gson g = new Gson();
+			HashMap<String, LinkedTreeMap> gson = g.fromJson(json, HashMap.class);
+			for(Entry<String, LinkedTreeMap> entry : gson.entrySet()) {
+				LinkedTreeMap value = entry.getValue();
+				String resourceID = UUID.randomUUID().toString();
+				value.put("resourceID", resourceID);
+				Hospital h = new Hospital(value);
+				hospitalList.add(h);
+			}
+		} catch (Exception e) {
+			System.err.println("ERROR: unable to load json: " + filename);
+			e.printStackTrace();
+			throw new ExceptionInInitializerError(e);
+		}
+	}
+	
+	// find closest hospital with ambulatory service
+	public static Hospital findClosestAmbulatory(Point personLocation){
+		Double personLat = personLocation.getY();
+		Double personLong = personLocation.getX();
+		
+		Double closestDistance = 100000000.0;
+		Provider closestHospital = null;
+		for(Provider p : Provider.getServices().get(Provider.AMBULATORY)){
+			Point hospitalLocation = p.getCoordinates();
+			Double hospitalLat = hospitalLocation.getY();
+			Double hospitalLong = hospitalLocation.getX();
+			Double sphericalDistance = haversine(personLat, personLong, hospitalLat, hospitalLong);
+			if( sphericalDistance < closestDistance ) {
+				closestDistance = sphericalDistance;
+				closestHospital = p;
+			}
+		}
+		return (Hospital) closestHospital;
+	}
+	
+	// find closest hospital with inpatient service
+	public static Hospital findClosestInpatient(Point personLocation){
+		Double personLat = personLocation.getY();
+		Double personLong = personLocation.getX();
+		
+		Double closestDistance = 100000000.0;
+		Provider closestHospital = null;
+		for(Provider p : Provider.getServices().get(Provider.INPATIENT)){
+			Point hospitalLocation = p.getCoordinates();
+			Double hospitalLat = hospitalLocation.getY();
+			Double hospitalLong = hospitalLocation.getX();
+			Double sphericalDistance = haversine(personLat, personLong, hospitalLat, hospitalLong);
+			if( sphericalDistance < closestDistance ) {
+				closestDistance = sphericalDistance;
+				closestHospital = p;
+			}
+		}
+		return (Hospital) closestHospital;
+	}
+	
+	// find closest hospital with emergency service
+	public static Hospital findClosestEmergency(Point personLocation){
+		Double personLat = personLocation.getY();
+		Double personLong = personLocation.getX();
+		
+		Double closestDistance = 100000000.0;
+		Provider closestHospital = null;
+		for(Provider p : Provider.getServices().get(Provider.EMERGENCY)){
+			Point hospitalLocation = p.getCoordinates();
+			Double hospitalLat = hospitalLocation.getY();
+			Double hospitalLong = hospitalLocation.getX();
+			Double sphericalDistance = haversine(personLat, personLong, hospitalLat, hospitalLong);
+			if( sphericalDistance < closestDistance ) {
+				closestDistance = sphericalDistance;
+				closestHospital = p;
+			}
+		}
+		return (Hospital) closestHospital;
+	}
+	
+	// Haversine Formula 
+	// from https://rosettacode.org/wiki/Haversine_formula#Java
+    public static final double R = 6372.8; // In kilometers
+    
+    public static double haversine(double lat1, double lon1, double lat2, double lon2) {
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLon = Math.toRadians(lon2 - lon1);
+        lat1 = Math.toRadians(lat1);
+        lat2 = Math.toRadians(lat2);
+ 
+        double a = Math.pow(Math.sin(dLat / 2),2) + Math.pow(Math.sin(dLon / 2),2) * Math.cos(lat1) * Math.cos(lat2);
+        double c = 2 * Math.asin(Math.sqrt(a));
+        return R * c;
+    }
+}

--- a/src/main/java/org/mitre/synthea/world/Hospital.java
+++ b/src/main/java/org/mitre/synthea/world/Hospital.java
@@ -50,6 +50,10 @@ public class Hospital extends Provider{
 		}
 	}
 	
+	public static ArrayList<Hospital> getHospitalList(){
+		return hospitalList;
+	}
+	
 	// find closest hospital with ambulatory service
 	public static Hospital findClosestAmbulatory(Point personLocation){
 		Double personLat = personLocation.getY();

--- a/src/main/java/org/mitre/synthea/world/Provider.java
+++ b/src/main/java/org/mitre/synthea/world/Provider.java
@@ -76,6 +76,10 @@ public class Provider {
 		return attributes.get("resourceID").toString();
 	}
 	
+	public LinkedTreeMap getAttributes(){
+		return attributes;
+	}
+	
 	public Point getCoordinates(){
 		return coordinates;
 	}
@@ -109,8 +113,16 @@ public class Provider {
 		return utilization;
 	}
 	
+	public Integer getBedCount(){
+		if(attributes.containsKey("bed_count")){
+			return Integer.parseInt(attributes.get("bed_count").toString());
+		} else {
+			return null;
+		}
+	}
+	
 	public static Provider findClosestService(Person person, String service){
-		if( service == "outpatient"){
+		if( service.equals("outpatient")){
 			service = AMBULATORY;
 		}
 		switch(service) {

--- a/src/main/java/org/mitre/synthea/world/Provider.java
+++ b/src/main/java/org/mitre/synthea/world/Provider.java
@@ -37,6 +37,8 @@ public class Provider {
 	public Provider(LinkedTreeMap p) {
 		LinkedTreeMap properties = (LinkedTreeMap) p.get("properties");
 		attributes = properties;
+		String resourceID = (String) p.get("resourceID");
+		attributes.put("resourceID", resourceID);
 
 		ArrayList<Double> coorList = (ArrayList<Double>) p.get("coordinates");
 		Point coor = new GeometryFactory().createPoint(new Coordinate(coorList.get(0), coorList.get(1)));
@@ -59,8 +61,7 @@ public class Provider {
 		}
 		
 		utilization = new HashMap<String, Integer>();
-		// TODO: person begins with one wellness encounter, change to 0 when code to count wellness encounters is added
-		utilization.put(ENCOUNTERS, 1);
+		utilization.put(ENCOUNTERS, 0);
 		utilization.put(PROCEDURES, 0);
 		utilization.put(LABS, 0);
 		utilization.put(PRESCRIPTIONS, 0);
@@ -69,6 +70,10 @@ public class Provider {
 	public static void clear(){
 		providerList.clear();
 		services.clear();
+	}
+	
+	public String getResourceID(){
+		return attributes.get("resourceID").toString();
 	}
 	
 	public Point getCoordinates(){

--- a/src/main/java/org/mitre/synthea/world/Provider.java
+++ b/src/main/java/org/mitre/synthea/world/Provider.java
@@ -52,7 +52,7 @@ public class Provider {
 			if (services.containsKey(s)){
 				ArrayList<Provider> l = services.get(s);
 				l.add(this);
-				services.put(s, l);
+				services.put(s,l);
 			} else{
 				ArrayList<Provider> l = new ArrayList<Provider>();
 				l.add(this);
@@ -128,17 +128,17 @@ public class Provider {
 		switch(service) {
 		case AMBULATORY :
 			if( person.getAmbulatoryProvider() == null ){
-				person.setAmbulatoryProvider(null);
+				person.setAmbulatoryProvider();
 			}
 			return person.getAmbulatoryProvider();
 		case INPATIENT :
 			if( person.getInpatientProvider() == null ){
-				person.setInpatientProvider(null);
+				person.setInpatientProvider();
 			}
 			return person.getInpatientProvider();
 		case EMERGENCY :
 			if( person.getEmergencyProvider() == null ){
-				person.setEmergencyProvider(null);
+				person.setEmergencyProvider();
 			}
 			return person.getEmergencyProvider();
 		}

--- a/src/main/java/org/mitre/synthea/world/Provider.java
+++ b/src/main/java/org/mitre/synthea/world/Provider.java
@@ -1,0 +1,135 @@
+package org.mitre.synthea.world;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import javax.swing.text.html.parser.Entity;
+
+import org.mitre.synthea.modules.Person;
+
+import com.google.gson.internal.LinkedTreeMap;
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.Point;
+
+public class Provider {
+	
+	public static final String AMBULATORY = "ambulatory";
+	public static final String INPATIENT = "inpatient";
+	public static final String EMERGENCY = "emergency";
+	public static final String ENCOUNTERS = "encounters";
+	public static final String PROCEDURES = "procedures";
+	public static final String LABS = "labs";
+	public static final String PRESCRIPTIONS = "prescriptions";
+	
+	// ArrayList of all providers imported
+	private static ArrayList<Provider> providerList = new ArrayList<Provider>();
+	// Hash of services to Providers that provide them
+	private static HashMap<String, ArrayList<Provider>> services = new HashMap<String, ArrayList<Provider>>();
+	
+	private LinkedTreeMap attributes;
+	private Point coordinates;
+	private ArrayList<String> services_provided;
+	private Map<String, Integer> utilization;
+	
+	public Provider(LinkedTreeMap p) {
+		LinkedTreeMap properties = (LinkedTreeMap) p.get("properties");
+		attributes = properties;
+
+		ArrayList<Double> coorList = (ArrayList<Double>) p.get("coordinates");
+		Point coor = new GeometryFactory().createPoint(new Coordinate(coorList.get(0), coorList.get(1)));
+		coordinates = coor;
+		
+		services_provided = new ArrayList<String>();
+		String[] servicesList = ( (String) properties.get("services_provided") ).split(" ");
+		for(String s : servicesList){
+			services_provided.add(s);
+			// add provider to hash of services
+			if (services.containsKey(s)){
+				ArrayList<Provider> l = services.get(s);
+				l.add(this);
+				services.put(s, l);
+			} else{
+				ArrayList<Provider> l = new ArrayList<Provider>();
+				l.add(this);
+				services.put(s, l);
+			}
+		}
+		
+		utilization = new HashMap<String, Integer>();
+		// TODO: person begins with one wellness encounter, change to 0 when code to count wellness encounters is added
+		utilization.put(ENCOUNTERS, 1);
+		utilization.put(PROCEDURES, 0);
+		utilization.put(LABS, 0);
+		utilization.put(PRESCRIPTIONS, 0);
+	}
+	
+	public static void clear(){
+		providerList.clear();
+		services.clear();
+	}
+	
+	public Point getCoordinates(){
+		return coordinates;
+	}
+	
+	public boolean hasService(String service){
+		return services_provided.contains(service);
+	}
+	
+	public void incrementEncounters(){
+		int count = utilization.get(ENCOUNTERS) + 1;
+		utilization.put(ENCOUNTERS, count);
+	}
+	
+	public void incrementProcedures(){
+		int count = utilization.get(PROCEDURES) + 1;
+		utilization.put(PROCEDURES, count);
+	}
+	
+	// TODO: increment labs when there are reports
+	public void incrementLabs(){
+		int count = utilization.get(LABS) + 1;
+		utilization.put(LABS, count);
+	}
+	
+	public void incrementPrescriptions(){
+		int count = utilization.get(PRESCRIPTIONS) + 1;
+		utilization.put(PRESCRIPTIONS, count);
+	}
+	
+	public Map<String, Integer> getUtilization(){
+		return utilization;
+	}
+	
+	public static Provider findClosestService(Person person, String service){
+		if( service == "outpatient"){
+			service = AMBULATORY;
+		}
+		switch(service) {
+		case AMBULATORY :
+			if( person.getAmbulatoryProvider() == null ){
+				person.setAmbulatoryProvider(null);
+			}
+			return person.getAmbulatoryProvider();
+		case INPATIENT :
+			if( person.getInpatientProvider() == null ){
+				person.setInpatientProvider(null);
+			}
+			return person.getInpatientProvider();
+		case EMERGENCY :
+			if( person.getEmergencyProvider() == null ){
+				person.setEmergencyProvider(null);
+			}
+			return person.getEmergencyProvider();
+		}
+		// if service is null or not supported by simulation, patient goes to ambulatory hospital
+		return person.getAmbulatoryProvider();
+	}
+	
+	public static HashMap<String, ArrayList<Provider>> getServices(){
+		return services;
+	}
+}

--- a/src/main/java/org/mitre/synthea/world/Provider.java
+++ b/src/main/java/org/mitre/synthea/world/Provider.java
@@ -52,7 +52,6 @@ public class Provider {
 			if (services.containsKey(s)){
 				ArrayList<Provider> l = services.get(s);
 				l.add(this);
-				services.put(s,l);
 			} else{
 				ArrayList<Provider> l = new ArrayList<Provider>();
 				l.add(this);

--- a/src/main/java/org/mitre/synthea/world/Provider.java
+++ b/src/main/java/org/mitre/synthea/world/Provider.java
@@ -122,7 +122,7 @@ public class Provider {
 	}
 	
 	public static Provider findClosestService(Person person, String service){
-		if( service.equals("outpatient")){
+		if( service.equals("outpatient") || service.equals("wellness")){
 			service = AMBULATORY;
 		}
 		switch(service) {

--- a/src/main/resources/geography/healthcare_facilities.json
+++ b/src/main/resources/geography/healthcare_facilities.json
@@ -1243,8 +1243,7 @@
       "city_zip": "02130",
       "state": "MA",
       "country": "US",
-      "services_provided": "inpatient ambulatory",
-      "bed_count": "Not Available"
+      "services_provided": "inpatient ambulatory"
     }
   },
 
@@ -1259,8 +1258,7 @@
       "city_zip": "02146",
       "state": "MA",
       "country": "US",
-      "services_provided": "inpatient ambulatory",
-      "bed_count": "Not Available"
+      "services_provided": "inpatient ambulatory"
     }
   },
 
@@ -1275,8 +1273,7 @@
       "city_zip": "02703",
       "state": "MA",
       "country": "US",
-      "services_provided": "inpatient ambulatory",
-      "bed_count": "Not Available"
+      "services_provided": "inpatient ambulatory"
     }
   },
 
@@ -1307,8 +1304,7 @@
       "city_zip": "02167",
       "state": "MA",
       "country": "US",
-      "services_provided": "inpatient ambulatory",
-      "bed_count": "Not Available"
+      "services_provided": "inpatient ambulatory"
     }
   },
 
@@ -1323,8 +1319,7 @@
       "city_zip": "02559",
       "state": "MA",
       "country": "US",
-      "services_provided": "inpatient ambulatory",
-      "bed_count": "Not Available"
+      "services_provided": "inpatient ambulatory"
     }
   },
 
@@ -1387,8 +1382,7 @@
       "city_zip": "02720",
       "state": "MA",
       "country": "US",
-      "services_provided": "inpatient ambulatory",
-      "bed_count": "Not Available"
+      "services_provided": "inpatient ambulatory"
     }
   },
 
@@ -1403,8 +1397,7 @@
       "city_zip": "02118",
       "state": "MA",
       "country": "US",
-      "services_provided": "inpatient ambulatory",
-      "bed_count": "Not Available"
+      "services_provided": "inpatient ambulatory"
     }
   },
 
@@ -1563,8 +1556,7 @@
       "city_zip": "02346",
       "state": "MA",
       "country": "US",
-      "services_provided": "inpatient ambulatory",
-      "bed_count": "Not Available"
+      "services_provided": "inpatient ambulatory"
     }
   },
 
@@ -1579,8 +1571,7 @@
       "city_zip": "02130",
       "state": "MA",
       "country": "US",
-      "services_provided": "inpatient ambulatory",
-      "bed_count": "Not Available"
+      "services_provided": "inpatient ambulatory"
     }
   },
 
@@ -1659,8 +1650,7 @@
       "city_zip": "02021",
       "state": "MA",
       "country": "US",
-      "services_provided": "inpatient ambulatory",
-      "bed_count": "Not Available"
+      "services_provided": "inpatient ambulatory"
     }
   },
 
@@ -1691,8 +1681,7 @@
       "city_zip": "02747",
       "state": "MA",
       "country": "US",
-      "services_provided": "inpatient ambulatory",
-      "bed_count": "Not Available"
+      "services_provided": "inpatient ambulatory"
     }
   },
 
@@ -1851,8 +1840,7 @@
       "city_zip": "01085",
       "state": "MA",
       "country": "US",
-      "services_provided": "inpatient ambulatory",
-      "bed_count": "Not Available"
+      "services_provided": "inpatient ambulatory"
     }
   },
 
@@ -1867,8 +1855,7 @@
       "city_zip": "02359",
       "state": "MA",
       "country": "US",
-      "services_provided": "inpatient ambulatory",
-      "bed_count": "Not Available"
+      "services_provided": "inpatient ambulatory"
     }
   },
 
@@ -1883,8 +1870,7 @@
       "city_zip": "02090",
       "state": "MA",
       "country": "US",
-      "services_provided": "inpatient ambulatory",
-      "bed_count": "Not Available"
+      "services_provided": "inpatient ambulatory"
     }
   },
 

--- a/src/main/resources/geography/healthcare_facilities.json
+++ b/src/main/resources/geography/healthcare_facilities.json
@@ -1,0 +1,9378 @@
+{
+
+  "﻿ANNA JAQUES HOSPITAL (2006)" : {
+    "coordinates": [ -70.890916, 42.814401 ],
+    "properties": {
+      "DPHid": "2006",
+      "type": "acute_hospital",
+      "name": "﻿ANNA JAQUES HOSPITAL",
+      "address": "25 HIGHLAND AVENUE",
+  	  "city": "Newburyport",
+      "city_zip": "01950",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "111"
+    }
+  },
+
+  "ATHOL MEMORIAL HOSPITAL (2226)" : {
+    "coordinates": [ -72.208684, 42.585088 ],
+    "properties": {
+      "DPHid": "2226",
+      "type": "acute_hospital",
+      "name": "ATHOL MEMORIAL HOSPITAL",
+      "address": "2033 MAIN STREET",
+  	  "city": "Athol",
+      "city_zip": "01331",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "25"
+    }
+  },
+
+  "BAYSTATE FRANKLIN MEDICAL CENTER (2120)" : {
+    "coordinates": [ -72.592547, 42.59584 ],
+    "properties": {
+      "DPHid": "2120",
+      "type": "acute_hospital",
+      "name": "BAYSTATE FRANKLIN MEDICAL CENTER",
+      "address": "164 HIGH STREET",
+  	  "city": "Greenfield",
+      "city_zip": "01301",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "89"
+    }
+  },
+
+  "BAYSTATE MEDICAL CENTER (2339)" : {
+    "coordinates": [ -72.603701, 42.121616 ],
+    "properties": {
+      "DPHid": "2339",
+      "type": "acute_hospital",
+      "name": "BAYSTATE MEDICAL CENTER",
+      "address": "759 CHESTNUT STREET",
+  	  "city": "Springfield",
+      "city_zip": "01199",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "710"
+    }
+  },
+
+  "BAYSTATE WING HOSPITAL AND MEDICAL CENTERS (2181)" : {
+    "coordinates": [ -72.341697, 42.169416 ],
+    "properties": {
+      "DPHid": "2181",
+      "type": "acute_hospital",
+      "name": "BAYSTATE WING HOSPITAL AND MEDICAL CENTERS",
+      "address": "40 WRIGHT STREET",
+  	  "city": "Palmer",
+      "city_zip": "01069",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "74"
+    }
+  },
+
+  "BERKSHIRE MED CTR INC/BERKSHIRE CAM (2313)" : {
+    "coordinates": [ -73.249228, 42.459638 ],
+    "properties": {
+      "DPHid": "2313",
+      "type": "acute_hospital",
+      "name": "BERKSHIRE MED CTR INC/BERKSHIRE CAM",
+      "address": "725 NORTH STREET",
+  	  "city": "Pittsfield",
+      "city_zip": "01201",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "298"
+    }
+  },
+
+  "BETH ISRAEL DEACONESS HOSPITAL - NEEDHAM (2054)" : {
+    "coordinates": [ -71.236667, 42.277237 ],
+    "properties": {
+      "DPHid": "2054",
+      "type": "acute_hospital",
+      "name": "BETH ISRAEL DEACONESS HOSPITAL - NEEDHAM",
+      "address": "148 CHESTNUT STREET",
+  	  "city": "Needham",
+      "city_zip": "02192",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "58"
+    }
+  },
+
+  "BETH ISRAEL DEACONESS HOSPITAL - PLYMOUTH (2082)" : {
+    "coordinates": [ -70.645286, 41.943002 ],
+    "properties": {
+      "DPHid": "2082",
+      "type": "acute_hospital",
+      "name": "BETH ISRAEL DEACONESS HOSPITAL - PLYMOUTH",
+      "address": "275 SANDWICH STREET",
+  	  "city": "Plymouth",
+      "city_zip": "02360",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "160"
+    }
+  },
+
+  "BETH ISRAEL DEACONESS HOSPITAL-MILTON INC (2227)" : {
+    "coordinates": [ -71.077274, 42.25128 ],
+    "properties": {
+      "DPHid": "2227",
+      "type": "acute_hospital",
+      "name": "BETH ISRAEL DEACONESS HOSPITAL-MILTON INC",
+      "address": "199 REEDSDALE ROAD",
+  	  "city": "Milton",
+      "city_zip": "02186",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "88"
+    }
+  },
+
+  "BETH ISRAEL DEACONESS MED CTR/EAST (2069)" : {
+    "coordinates": [ -71.105026, 42.339648 ],
+    "properties": {
+      "DPHid": "2069",
+      "type": "acute_hospital",
+      "name": "BETH ISRAEL DEACONESS MED CTR/EAST",
+      "address": "330 BROOKLINE AVENUE",
+  	  "city": "Boston",
+      "city_zip": "02215",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "248"
+    }
+  },
+
+  "BETH ISRAEL DEACONESS MED CTR/WEST (2092)" : {
+    "coordinates": [ -71.109024, 42.338158 ],
+    "properties": {
+      "DPHid": "2092",
+      "type": "acute_hospital",
+      "name": "BETH ISRAEL DEACONESS MED CTR/WEST",
+      "address": "ONE DEACONESS ROAD",
+  	  "city": "Boston",
+      "city_zip": "02215",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "405"
+    }
+  },
+
+  "BEVERLY HOSP/ADDISION GILBERT CAMPU (2016)" : {
+    "coordinates": [ -70.680653, 42.625213 ],
+    "properties": {
+      "DPHid": "2016",
+      "type": "acute_hospital",
+      "name": "BEVERLY HOSP/ADDISION GILBERT CAMPU",
+      "address": "298 WASHINGTON STREET",
+  	  "city": "Gloucester",
+      "city_zip": "01930",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "79"
+    }
+  },
+
+  "BEVERLY HOSP/BEVERLY CAMPUS (2007)" : {
+    "coordinates": [ -70.875485, 42.564055 ],
+    "properties": {
+      "DPHid": "2007",
+      "type": "acute_hospital",
+      "name": "BEVERLY HOSP/BEVERLY CAMPUS",
+      "address": "85 HERRICK STREET",
+  	  "city": "Beverly",
+      "city_zip": "01915",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "223"
+    }
+  },
+
+  "BOSTON CHILDREN'S HOSPITAL (2139)" : {
+    "coordinates": [ -71.104968, 42.337398 ],
+    "properties": {
+      "DPHid": "2139",
+      "type": "acute_hospital",
+      "name": "BOSTON CHILDREN'S HOSPITAL",
+      "address": "300 LONGWOOD AVENUE",
+  	  "city": "Boston",
+      "city_zip": "02115",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "404"
+    }
+  },
+
+  "BOSTON MED CTR CORP MENINO PAVILION (2307)" : {
+    "coordinates": [ -71.073773, 42.334423 ],
+    "properties": {
+      "DPHid": "2307",
+      "type": "acute_hospital",
+      "name": "BOSTON MED CTR CORP MENINO PAVILION",
+      "address": "830-840 HARRISON AVENUE",
+  	  "city": "Boston",
+      "city_zip": "02118",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "288"
+    }
+  },
+
+  "BOSTON MED CTR CORP NEWTON PAVILION (2084)" : {
+    "coordinates": [ -71.070557, 42.337007 ],
+    "properties": {
+      "DPHid": "2084",
+      "type": "acute_hospital",
+      "name": "BOSTON MED CTR CORP NEWTON PAVILION",
+      "address": "88 EAST NEWTON STREET",
+  	  "city": "Boston",
+      "city_zip": "02118",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "214"
+    }
+  },
+
+  "BRIGHAM AND WOMEN'S FAULKNER HOSPITAL (2048)" : {
+    "coordinates": [ -71.128782, 42.301641 ],
+    "properties": {
+      "DPHid": "2048",
+      "type": "acute_hospital",
+      "name": "BRIGHAM AND WOMEN'S FAULKNER HOSPITAL",
+      "address": "1153 CENTRE STREET",
+  	  "city": "Boston",
+      "city_zip": "02130",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "162"
+    }
+  },
+
+  "BRIGHAM AND WOMEN'S HOSPITAL (2341)" : {
+    "coordinates": [ -71.106707, 42.336089 ],
+    "properties": {
+      "DPHid": "2341",
+      "type": "acute_hospital",
+      "name": "BRIGHAM AND WOMEN'S HOSPITAL",
+      "address": "75 FRANCIS STREET",
+  	  "city": "Boston",
+      "city_zip": "02115",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "763"
+    }
+  },
+
+  "CAPE COD HOSPITAL (2135)" : {
+    "coordinates": [ -70.273323, 41.653436 ],
+    "properties": {
+      "DPHid": "2135",
+      "type": "acute_hospital",
+      "name": "CAPE COD HOSPITAL",
+      "address": "27 PARK STREET PO BOX 640",
+  	  "city": "Barnstable",
+      "city_zip": "02601",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "252"
+    }
+  },
+
+  "CARNEY HOSPITAL (2003)" : {
+    "coordinates": [ -71.065739, 42.277486 ],
+    "properties": {
+      "DPHid": "2003",
+      "type": "acute_hospital",
+      "name": "CARNEY HOSPITAL",
+      "address": "2100 DORCHESTER AVENUE",
+  	  "city": "Boston",
+      "city_zip": "02124",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "159"
+    }
+  },
+
+  "CHA CAMBRIDGE HOSPITAL (2108)" : {
+    "coordinates": [ -71.104404, 42.374498 ],
+    "properties": {
+      "DPHid": "2108",
+      "type": "acute_hospital",
+      "name": "CHA CAMBRIDGE HOSPITAL",
+      "address": "1493 CAMBRIDGE STREET",
+  	  "city": "Cambridge",
+      "city_zip": "02139",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "189"
+    }
+  },
+
+  "CHA EVERETT HOSPITAL (2046)" : {
+    "coordinates": [ -71.039552, 42.409285 ],
+    "properties": {
+      "DPHid": "2046",
+      "type": "acute_hospital",
+      "name": "CHA EVERETT HOSPITAL",
+      "address": "103 GARLAND ST 3RD FL, LEVEL C",
+  	  "city": "Everett",
+      "city_zip": "02149",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "162"
+    }
+  },
+
+  "CLINTON HOSPITAL ASSOCIATION (2126)" : {
+    "coordinates": [ -71.69281, 42.427361 ],
+    "properties": {
+      "DPHid": "2126",
+      "type": "acute_hospital",
+      "name": "CLINTON HOSPITAL ASSOCIATION",
+      "address": "201 HIGHLAND STREET",
+  	  "city": "Clinton",
+      "city_zip": "01510",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "41"
+    }
+  },
+
+  "COOLEY DICKINSON HOSPITAL INC,THE (2155)" : {
+    "coordinates": [ -72.65313, 42.330503 ],
+    "properties": {
+      "DPHid": "2155",
+      "type": "acute_hospital",
+      "name": "COOLEY DICKINSON HOSPITAL INC,THE",
+      "address": "30 LOCUST STREET",
+  	  "city": "Northampton",
+      "city_zip": "01060",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "140"
+    }
+  },
+
+  "DANA-FARBER CANCER INSTITUTE (2335)" : {
+    "coordinates": [ -71.108141, 42.33749 ],
+    "properties": {
+      "DPHid": "2335",
+      "type": "acute_hospital",
+      "name": "DANA-FARBER CANCER INSTITUTE",
+      "address": "450 BROOKLINE AVENUE",
+  	  "city": "Boston",
+      "city_zip": "02215",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "EMERSON HOSPITAL - (2018)" : {
+    "coordinates": [ -71.37746, 42.442736 ],
+    "properties": {
+      "DPHid": "2018",
+      "type": "acute_hospital",
+      "name": "EMERSON HOSPITAL -",
+      "address": "OLD ROAD TO NINE ACRE CORNER",
+  	  "city": "Concord",
+      "city_zip": "01742",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "150"
+    }
+  },
+
+  "FAIRVIEW HOSPITAL (2052)" : {
+    "coordinates": [ -73.371822, 42.191204 ],
+    "properties": {
+      "DPHid": "2052",
+      "type": "acute_hospital",
+      "name": "FAIRVIEW HOSPITAL",
+      "address": "29 LEWIS AVENUE",
+  	  "city": "Great barrington",
+      "city_zip": "01230",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "25"
+    }
+  },
+
+  "FALMOUTH HOSPITAL (2289)" : {
+    "coordinates": [ -70.622165, 41.564207 ],
+    "properties": {
+      "DPHid": "2289",
+      "type": "acute_hospital",
+      "name": "FALMOUTH HOSPITAL",
+      "address": "100 TER HEUN DRIVE",
+  	  "city": "Falmouth",
+      "city_zip": "02540",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "95"
+    }
+  },
+
+  "GOOD SAMARITAN MEDICAL CENTER (2311)" : {
+    "coordinates": [ -71.061552, 42.097829 ],
+    "properties": {
+      "DPHid": "2311",
+      "type": "acute_hospital",
+      "name": "GOOD SAMARITAN MEDICAL CENTER",
+      "address": "235 NORTH PEARL STREET",
+  	  "city": "Brockton",
+      "city_zip": "02301",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "224"
+    }
+  },
+
+  "HALLMARK HEALTH SYSTEM LAWRENCE MEM (2038)" : {
+    "coordinates": [ -71.111105, 42.426297 ],
+    "properties": {
+      "DPHid": "2038",
+      "type": "acute_hospital",
+      "name": "HALLMARK HEALTH SYSTEM LAWRENCE MEM",
+      "address": "170 GOVERNORS AVENUE",
+  	  "city": "Medford",
+      "city_zip": "02155",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "98"
+    }
+  },
+
+  "HALLMARK HEALTH SYSTEM MELROSE-WAKE (2058)" : {
+    "coordinates": [ -71.061108, 42.46018 ],
+    "properties": {
+      "DPHid": "2058",
+      "type": "acute_hospital",
+      "name": "HALLMARK HEALTH SYSTEM MELROSE-WAKE",
+      "address": "585 LEBANON STREET",
+  	  "city": "Melrose",
+      "city_zip": "02176",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "174"
+    }
+  },
+
+  "HARRINGTON MEMORIAL HOSPITAL-1 (2143)" : {
+    "coordinates": [ -72.042037, 42.078496 ],
+    "properties": {
+      "DPHid": "2143",
+      "type": "acute_hospital",
+      "name": "HARRINGTON MEMORIAL HOSPITAL-1",
+      "address": "100 SOUTH STREET",
+  	  "city": "Southbridge",
+      "city_zip": "01550",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "114"
+    }
+  },
+
+  "HEALTHALLIANCE HOSP-LEOMINSTER CAMP (2127)" : {
+    "coordinates": [ -71.761278, 42.541018 ],
+    "properties": {
+      "DPHid": "2127",
+      "type": "acute_hospital",
+      "name": "HEALTHALLIANCE HOSP-LEOMINSTER CAMP",
+      "address": "60 HOSPITAL ROAD",
+  	  "city": "Leominster",
+      "city_zip": "01453",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "122"
+    }
+  },
+
+  "HEYWOOD HOSPITAL - (2036)" : {
+    "coordinates": [ -71.98703, 42.586439 ],
+    "properties": {
+      "DPHid": "2036",
+      "type": "acute_hospital",
+      "name": "HEYWOOD HOSPITAL -",
+      "address": "242 GREEN STREET",
+  	  "city": "Gardner",
+      "city_zip": "01440",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "134"
+    }
+  },
+
+  "HOLY FAMILY HOSPITAL (2225)" : {
+    "coordinates": [ -71.168048, 42.72754 ],
+    "properties": {
+      "DPHid": "2225",
+      "type": "acute_hospital",
+      "name": "HOLY FAMILY HOSPITAL",
+      "address": "70 EAST STREET",
+  	  "city": "Methuen",
+      "city_zip": "01844",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "223"
+    }
+  },
+
+  "HOLY FMLY HOSP @ MERRIMACK VLLY A S (2131)" : {
+    "coordinates": [ -71.044786, 42.764889 ],
+    "properties": {
+      "DPHid": "2131",
+      "type": "acute_hospital",
+      "name": "HOLY FMLY HOSP @ MERRIMACK VLLY A S",
+      "address": "140 LINCOLN AVENUE",
+  	  "city": "Haverhill",
+      "city_zip": "01830",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "124"
+    }
+  },
+
+  "HOLYOKE MEDICAL CENTER (2145)" : {
+    "coordinates": [ -72.62745, 42.20033 ],
+    "properties": {
+      "DPHid": "2145",
+      "type": "acute_hospital",
+      "name": "HOLYOKE MEDICAL CENTER",
+      "address": "575 BEECH STREET",
+  	  "city": "Holyoke",
+      "city_zip": "01040",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "198"
+    }
+  },
+
+  "LAHEY HOSPITAL & MEDICAL CENTER, BURLINGTON (2342)" : {
+    "coordinates": [ -71.204906, 42.484392 ],
+    "properties": {
+      "DPHid": "2342",
+      "type": "acute_hospital",
+      "name": "LAHEY HOSPITAL & MEDICAL CENTER, BURLINGTON",
+      "address": "41 MALL ROAD",
+  	  "city": "Burlington",
+      "city_zip": "01806",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "335"
+    }
+  },
+
+  "LAHEY MEDICAL CTR, PEADODY (INPT ST (2I6I)" : {
+    "coordinates": [ -70.947312, 42.53716 ],
+    "properties": {
+      "DPHid": "2I6I",
+      "type": "acute_hospital",
+      "name": "LAHEY MEDICAL CTR, PEADODY (INPT ST",
+      "address": "1 ESSEX CENTER DRIVE 1 2 3 4 5",
+  	  "city": "Peabody",
+      "city_zip": "01960",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "10"
+    }
+  },
+
+  "LAWRENCE GENERAL HOSPITAL (2099)" : {
+    "coordinates": [ -71.149039, 42.709077 ],
+    "properties": {
+      "DPHid": "2099",
+      "type": "acute_hospital",
+      "name": "LAWRENCE GENERAL HOSPITAL",
+      "address": "ONE GENERAL STREET",
+  	  "city": "Lawrence",
+      "city_zip": "01842",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "189"
+    }
+  },
+
+  "LOWELL GENERAL HOSP SAINTS CAMPUS (2029)" : {
+    "coordinates": [ -71.301177, 42.645683 ],
+    "properties": {
+      "DPHid": "2029",
+      "type": "acute_hospital",
+      "name": "LOWELL GENERAL HOSP SAINTS CAMPUS",
+      "address": "1 HOSPITAL DRIVE",
+  	  "city": "Lowell",
+      "city_zip": "01852",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "157"
+    }
+  },
+
+  "LOWELL GENERAL HOSPITAL (2040)" : {
+    "coordinates": [ -71.342277, 42.647737 ],
+    "properties": {
+      "DPHid": "2040",
+      "type": "acute_hospital",
+      "name": "LOWELL GENERAL HOSPITAL",
+      "address": "295 VARNUM AVENUE",
+  	  "city": "Lowell",
+      "city_zip": "01854",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "239"
+    }
+  },
+
+  "MARLBOROUGH HOSPITAL (2103)" : {
+    "coordinates": [ -71.554083, 42.35437 ],
+    "properties": {
+      "DPHid": "2103",
+      "type": "acute_hospital",
+      "name": "MARLBOROUGH HOSPITAL",
+      "address": "157 UNION STREET",
+  	  "city": "Marlborough",
+      "city_zip": "01752",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "79"
+    }
+  },
+
+  "MARTHA'S VINEYARD HOSPITAL INC (2042)" : {
+    "coordinates": [ -70.580348, 41.460325 ],
+    "properties": {
+      "DPHid": "2042",
+      "type": "acute_hospital",
+      "name": "MARTHA'S VINEYARD HOSPITAL INC",
+      "address": "ONE HOSPITAL ROAD, FIRST FL, W",
+  	  "city": "Oak bluffs",
+      "city_zip": "02557",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "25"
+    }
+  },
+
+  "MASSACHUSETTS EYE AND EAR INFIRMARY - (2167)" : {
+    "coordinates": [ -71.070132, 42.362757 ],
+    "properties": {
+      "DPHid": "2167",
+      "type": "acute_hospital",
+      "name": "MASSACHUSETTS EYE AND EAR INFIRMARY -",
+      "address": "243 CHARLES STREET",
+  	  "city": "Boston",
+      "city_zip": "02114",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "41"
+    }
+  },
+
+  "MASSACHUSETTS GENERAL HOSPITAL (2168)" : {
+    "coordinates": [ -71.068833, 42.363154 ],
+    "properties": {
+      "DPHid": "2168",
+      "type": "acute_hospital",
+      "name": "MASSACHUSETTS GENERAL HOSPITAL",
+      "address": "55 FRUIT STREET",
+  	  "city": "Boston",
+      "city_zip": "02114",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "1035"
+    }
+  },
+
+  "MERCY MEDICAL CENTER CAMPUS (2149)" : {
+    "coordinates": [ -72.593341, 42.114492 ],
+    "properties": {
+      "DPHid": "2149",
+      "type": "acute_hospital",
+      "name": "MERCY MEDICAL CENTER CAMPUS",
+      "address": "271 CAREW STREET",
+  	  "city": "Springfield",
+      "city_zip": "01102",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "229"
+    }
+  },
+
+  "METROWEST MED CTR/FRAM UNION CAMPUS (2020)" : {
+    "coordinates": [ -71.418842, 42.285037 ],
+    "properties": {
+      "DPHid": "2020",
+      "type": "acute_hospital",
+      "name": "METROWEST MED CTR/FRAM UNION CAMPUS",
+      "address": "115 LINCOLN ST",
+  	  "city": "Framingham",
+      "city_zip": "01701",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "147"
+    }
+  },
+
+  "METROWEST MED CTR/L MORSE CAMPUS (2039)" : {
+    "coordinates": [ -71.335103, 42.280518 ],
+    "properties": {
+      "DPHid": "2039",
+      "type": "acute_hospital",
+      "name": "METROWEST MED CTR/L MORSE CAMPUS",
+      "address": "67 UNION STREET",
+  	  "city": "Natick",
+      "city_zip": "01760",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "160"
+    }
+  },
+
+  "MILFORD REGIONAL MEDICAL CENTER (2105)" : {
+    "coordinates": [ -71.528539, 42.133277 ],
+    "properties": {
+      "DPHid": "2105",
+      "type": "acute_hospital",
+      "name": "MILFORD REGIONAL MEDICAL CENTER",
+      "address": "14 PROSPECT STREET",
+  	  "city": "Milford",
+      "city_zip": "01757",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "145"
+    }
+  },
+
+  "MORTON HOSPITAL (2022)" : {
+    "coordinates": [ -71.094852, 41.905755 ],
+    "properties": {
+      "DPHid": "2022",
+      "type": "acute_hospital",
+      "name": "MORTON HOSPITAL",
+      "address": "88 WASHINGTON STREET",
+  	  "city": "Taunton",
+      "city_zip": "02780",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "125"
+    }
+  },
+
+  "MOUNT AUBURN HOSPITAL (2071)" : {
+    "coordinates": [ -71.133732, 42.374371 ],
+    "properties": {
+      "DPHid": "2071",
+      "type": "acute_hospital",
+      "name": "MOUNT AUBURN HOSPITAL",
+      "address": "330 MOUNT AUBURN STREET",
+  	  "city": "Cambridge",
+      "city_zip": "02238",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "217"
+    }
+  },
+
+  "NANTUCKET COTTAGE HOSPITAL (2044)" : {
+    "coordinates": [ -70.101002, 41.275084 ],
+    "properties": {
+      "DPHid": "2044",
+      "type": "acute_hospital",
+      "name": "NANTUCKET COTTAGE HOSPITAL",
+      "address": "57 PROSPECT STREET",
+  	  "city": "Nantucket",
+      "city_zip": "02554",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "19"
+    }
+  },
+
+  "NASHOBA VALLEY MEDICAL CENTER (2298)" : {
+    "coordinates": [ -71.588586, 42.562859 ],
+    "properties": {
+      "DPHid": "2298",
+      "type": "acute_hospital",
+      "name": "NASHOBA VALLEY MEDICAL CENTER",
+      "address": "200 GROTON STREET",
+  	  "city": "Ayer",
+      "city_zip": "01432",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "77"
+    }
+  },
+
+  "NEW ENGLAND BAPTIST HOSPITAL (2059)" : {
+    "coordinates": [ -71.107187, 42.329324 ],
+    "properties": {
+      "DPHid": "2059",
+      "type": "acute_hospital",
+      "name": "NEW ENGLAND BAPTIST HOSPITAL",
+      "address": "125 PARKER HILL AVENUE",
+  	  "city": "Boston",
+      "city_zip": "02120",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "118"
+    }
+  },
+
+  "NEWTON-WELLESLEY HOSPITAL (2075)" : {
+    "coordinates": [ -71.246437, 42.330634 ],
+    "properties": {
+      "DPHid": "2075",
+      "type": "acute_hospital",
+      "name": "NEWTON-WELLESLEY HOSPITAL",
+      "address": "2014 WASHINGTON STREET",
+  	  "city": "Newton",
+      "city_zip": "02162",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "265"
+    }
+  },
+
+  "NOBLE HOSPITAL (2076)" : {
+    "coordinates": [ -72.75906, 42.11802 ],
+    "properties": {
+      "DPHid": "2076",
+      "type": "acute_hospital",
+      "name": "NOBLE HOSPITAL",
+      "address": "115 WEST SILVER STREET, BOX 16",
+  	  "city": "Westfield",
+      "city_zip": "01086",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "97"
+    }
+  },
+
+  "NORTH SHORE MED CTR/SALEM HOSPITAL (2014)" : {
+    "coordinates": [ -70.907116, 42.510773 ],
+    "properties": {
+      "DPHid": "2014",
+      "type": "acute_hospital",
+      "name": "NORTH SHORE MED CTR/SALEM HOSPITAL",
+      "address": "81 HIGHLAND AVENUE",
+  	  "city": "Salem",
+      "city_zip": "01970",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "268"
+    }
+  },
+
+  "NORTH SHORE MED CTR/UNION HOSPITAL (2008)" : {
+    "coordinates": [ -70.979764, 42.501845 ],
+    "properties": {
+      "DPHid": "2008",
+      "type": "acute_hospital",
+      "name": "NORTH SHORE MED CTR/UNION HOSPITAL",
+      "address": "500 LYNNFIELD STREET",
+  	  "city": "Lynn",
+      "city_zip": "01904",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "128"
+    }
+  },
+
+  "NORWOOD HOSPITAL (2114)" : {
+    "coordinates": [ -71.201836, 42.189181 ],
+    "properties": {
+      "DPHid": "2114",
+      "type": "acute_hospital",
+      "name": "NORWOOD HOSPITAL",
+      "address": "800 WASHINGTON STREET",
+  	  "city": "Norwood",
+      "city_zip": "02062",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "215"
+    }
+  },
+
+  "SAINT ANNE'S HOSPITAL (2011)" : {
+    "coordinates": [ -71.163981, 41.692584 ],
+    "properties": {
+      "DPHid": "2011",
+      "type": "acute_hospital",
+      "name": "SAINT ANNE'S HOSPITAL",
+      "address": "795 MIDDLE STREET",
+  	  "city": "Fall river",
+      "city_zip": "02721",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "185"
+    }
+  },
+
+  "SHRINERS' HOSPITAL FOR CHILDREN (THE) (2152)" : {
+    "coordinates": [ -72.592366, 42.121351 ],
+    "properties": {
+      "DPHid": "2152",
+      "type": "acute_hospital",
+      "name": "SHRINERS' HOSPITAL FOR CHILDREN (THE)",
+      "address": "516 CAREW STREET",
+  	  "city": "Springfield",
+      "city_zip": "01104",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "40"
+    }
+  },
+
+  "SHRINERS' HOSPITAL FOR CHILDREN - BOSTON, THE (2316)" : {
+    "coordinates": [ -71.066457, 42.363097 ],
+    "properties": {
+      "DPHid": "2316",
+      "type": "acute_hospital",
+      "name": "SHRINERS' HOSPITAL FOR CHILDREN - BOSTON, THE",
+      "address": "51 BLOSSOM STREET",
+  	  "city": "Boston",
+      "city_zip": "02114",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "30"
+    }
+  },
+
+  "SIGNATURE HEALTHCARE BROCKTON HOSPITAL (2118)" : {
+    "coordinates": [ -70.991421, 42.087425 ],
+    "properties": {
+      "DPHid": "2118",
+      "type": "acute_hospital",
+      "name": "SIGNATURE HEALTHCARE BROCKTON HOSPITAL",
+      "address": "680 CENTRE STREET",
+  	  "city": "Brockton",
+      "city_zip": "02302",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "197"
+    }
+  },
+
+  "SOUTH SHORE HOSPITAL (2107)" : {
+    "coordinates": [ -70.953617, 42.176109 ],
+    "properties": {
+      "DPHid": "2107",
+      "type": "acute_hospital",
+      "name": "SOUTH SHORE HOSPITAL",
+      "address": "55 FOGG ROAD",
+  	  "city": "Weymouth",
+      "city_zip": "02190",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "370"
+    }
+  },
+
+  "SOUTHCOAST HOSPS GRP INC/CHARLTON (2337)" : {
+    "coordinates": [ -71.145874, 41.709806 ],
+    "properties": {
+      "DPHid": "2337",
+      "type": "acute_hospital",
+      "name": "SOUTHCOAST HOSPS GRP INC/CHARLTON",
+      "address": "363 HIGHLAND AVENUE",
+  	  "city": "Fall river",
+      "city_zip": "02720",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "328"
+    }
+  },
+
+  "SOUTHCOAST HOSPS GRP INC/ST LUKES (2010)" : {
+    "coordinates": [ -70.938234, 41.626435 ],
+    "properties": {
+      "DPHid": "2010",
+      "type": "acute_hospital",
+      "name": "SOUTHCOAST HOSPS GRP INC/ST LUKES",
+      "address": "101 PAGE STREET, BOX 3003",
+  	  "city": "New bedford",
+      "city_zip": "02740",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "391"
+    }
+  },
+
+  "SOUTHCOAST HOSPS GRP INC/TOBEY (2106)" : {
+    "coordinates": [ -70.714366, 41.756129 ],
+    "properties": {
+      "DPHid": "2106",
+      "type": "acute_hospital",
+      "name": "SOUTHCOAST HOSPS GRP INC/TOBEY",
+      "address": "43 HIGH STREET",
+  	  "city": "Wareham",
+      "city_zip": "02571",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "74"
+    }
+  },
+
+  "ST ELIZABETH'S MEDICAL CENTER (2085)" : {
+    "coordinates": [ -71.147681, 42.348958 ],
+    "properties": {
+      "DPHid": "2085",
+      "type": "acute_hospital",
+      "name": "ST ELIZABETH'S MEDICAL CENTER",
+      "address": "736 CAMBRIDGE STREET",
+  	  "city": "Boston",
+      "city_zip": "02135",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "252"
+    }
+  },
+
+  "ST VINCENT HOSPITAL (2128)" : {
+    "coordinates": [ -71.796913, 42.264636 ],
+    "properties": {
+      "DPHid": "2128",
+      "type": "acute_hospital",
+      "name": "ST VINCENT HOSPITAL",
+      "address": "123 SUMMER STREET",
+  	  "city": "Worcester",
+      "city_zip": "01608",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "283"
+    }
+  },
+
+  "STURDY MEMORIAL HOSPITAL (2100)" : {
+    "coordinates": [ -71.275673, 41.94183 ],
+    "properties": {
+      "DPHid": "2100",
+      "type": "acute_hospital",
+      "name": "STURDY MEMORIAL HOSPITAL",
+      "address": "211 PARK STREET",
+  	  "city": "Attleboro",
+      "city_zip": "02703",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "132"
+    }
+  },
+
+  "TUFTS MEDICAL CENTER (2299)" : {
+    "coordinates": [ -71.063541, 42.349598 ],
+    "properties": {
+      "DPHid": "2299",
+      "type": "acute_hospital",
+      "name": "TUFTS MEDICAL CENTER",
+      "address": "800 WASHINGTON STREET",
+  	  "city": "Boston",
+      "city_zip": "02111",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "415"
+    }
+  },
+
+  "UMASS MEMORIAL MED CTR/MEM CAMPUS (2124)" : {
+    "coordinates": [ -71.792168, 42.272758 ],
+    "properties": {
+      "DPHid": "2124",
+      "type": "acute_hospital",
+      "name": "UMASS MEMORIAL MED CTR/MEM CAMPUS",
+      "address": "119 BELMONT STREET",
+  	  "city": "Worcester",
+      "city_zip": "01605",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "303"
+    }
+  },
+
+  "UMASS MEMORIAL MED CTR/UNIV CAMPUS (2841)" : {
+    "coordinates": [ -71.761637, 42.277673 ],
+    "properties": {
+      "DPHid": "2841",
+      "type": "acute_hospital",
+      "name": "UMASS MEMORIAL MED CTR/UNIV CAMPUS",
+      "address": "55 LAKE AVENUE NORTH",
+  	  "city": "Worcester",
+      "city_zip": "01655",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "431"
+    }
+  },
+
+  "WINCHESTER HOSPITAL (2094)" : {
+    "coordinates": [ -71.122203, 42.465802 ],
+    "properties": {
+      "DPHid": "2094",
+      "type": "acute_hospital",
+      "name": "WINCHESTER HOSPITAL",
+      "address": "41 HIGHLAND AVENUE",
+  	  "city": "Winchester",
+      "city_zip": "01890",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency inpatient ambulatory",
+      "bed_count": "189"
+    }
+  },
+
+  "ADCARE HOSPITAL OF WORCESTER INC (2202)" : {
+    "coordinates": [ -71.794835, 42.276329 ],
+    "properties": {
+      "DPHid": "2202",
+      "type": "non_acute_hospital",
+      "name": "ADCARE HOSPITAL OF WORCESTER INC",
+      "address": "107 LINCOLN STREET",
+  	  "city": "Worcester",
+      "city_zip": "01605",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "114"
+    }
+  },
+
+  "AMESBURY HEALTH CENTER (2MFU)" : {
+    "coordinates": [ -70.933553, 42.848391 ],
+    "properties": {
+      "DPHid": "2MFU",
+      "type": "non_acute_hospital",
+      "name": "AMESBURY HEALTH CENTER",
+      "address": "24 MORRILL PLACE",
+  	  "city": "Amesbury",
+      "city_zip": "01913",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "12"
+    }
+  },
+
+  "ARBOUR HOSPITAL, THE (2836)" : {
+    "coordinates": [ -71.112267, 42.315774 ],
+    "properties": {
+      "DPHid": "2836",
+      "type": "non_acute_hospital",
+      "name": "ARBOUR HOSPITAL, THE",
+      "address": "49 ROBINWOOD AVENUE",
+  	  "city": "Boston",
+      "city_zip": "02130",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "Not Available"
+    }
+  },
+
+  "ARBOUR HUMAN RESOURCE INSTITUTE (2327)" : {
+    "coordinates": [ -71.1212, 42.35077 ],
+    "properties": {
+      "DPHid": "2327",
+      "type": "non_acute_hospital",
+      "name": "ARBOUR HUMAN RESOURCE INSTITUTE",
+      "address": "227 BABCOCK STREET",
+  	  "city": "Brookline",
+      "city_zip": "02146",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "Not Available"
+    }
+  },
+
+  "ARBOUR-FULLER HOSPITAL (2005)" : {
+    "coordinates": [ -71.360407, 41.924446 ],
+    "properties": {
+      "DPHid": "2005",
+      "type": "non_acute_hospital",
+      "name": "ARBOUR-FULLER HOSPITAL",
+      "address": "200 MAY STREET",
+  	  "city": "Attleboro",
+      "city_zip": "02703",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "Not Available"
+    }
+  },
+
+  "BAY RIDGE HOSP-SAT-BEVERLY HOSP (2M5H)" : {
+    "coordinates": [ -70.956614, 42.471569 ],
+    "properties": {
+      "DPHid": "2M5H",
+      "type": "non_acute_hospital",
+      "name": "BAY RIDGE HOSP-SAT-BEVERLY HOSP",
+      "address": "60 GRANITE STREET",
+  	  "city": "Lynn",
+      "city_zip": "01904",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "62"
+    }
+  },
+
+  "BOURNEWOOD HOSPITAL (2837)" : {
+    "coordinates": [ -71.115881, 42.300587 ],
+    "properties": {
+      "DPHid": "2837",
+      "type": "non_acute_hospital",
+      "name": "BOURNEWOOD HOSPITAL",
+      "address": "300 SOUTH STREET",
+  	  "city": "Brookline",
+      "city_zip": "02167",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "Not Available"
+    }
+  },
+
+  "CAPE COD & ISLANDS COMMUNITY MENTAL HEALTH CENTER (2842)" : {
+    "coordinates": [ -70.601958, 41.6885 ],
+    "properties": {
+      "DPHid": "2842",
+      "type": "non_acute_hospital",
+      "name": "CAPE COD & ISLANDS COMMUNITY MENTAL HEALTH CENTER",
+      "address": "830 COUNTY ROAD",
+  	  "city": "Bourne",
+      "city_zip": "02559",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "Not Available"
+    }
+  },
+
+  "CURAHEALTH BOSTON (2091)" : {
+    "coordinates": [ -71.141856, 42.346594 ],
+    "properties": {
+      "DPHid": "2091",
+      "type": "non_acute_hospital",
+      "name": "CURAHEALTH BOSTON",
+      "address": "1515 COMMONWEALTH AVENUE",
+  	  "city": "Boston",
+      "city_zip": "02135",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "59"
+    }
+  },
+
+  "CURAHEALTH BOSTON NORTH SHORE (2171)" : {
+    "coordinates": [ -70.937946, 42.528916 ],
+    "properties": {
+      "DPHid": "2171",
+      "type": "non_acute_hospital",
+      "name": "CURAHEALTH BOSTON NORTH SHORE",
+      "address": "15 KING STREET",
+  	  "city": "Peabody",
+      "city_zip": "01960",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "50"
+    }
+  },
+
+  "CURAHEALTH STOUGHTON (2282)" : {
+    "coordinates": [ -71.08182, 42.100619 ],
+    "properties": {
+      "DPHid": "2282",
+      "type": "non_acute_hospital",
+      "name": "CURAHEALTH STOUGHTON",
+      "address": "909 SUMNER STREET 1ST FLOOR",
+  	  "city": "Stoughton",
+      "city_zip": "02072",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "198"
+    }
+  },
+
+  "DR JOHN C CORRIGAN MENTAL HEALTH CENTER (2C7R)" : {
+    "coordinates": [ -71.145851, 41.707556 ],
+    "properties": {
+      "DPHid": "2C7R",
+      "type": "non_acute_hospital",
+      "name": "DR JOHN C CORRIGAN MENTAL HEALTH CENTER",
+      "address": "49 HILLSIDE STREET",
+  	  "city": "Fall river",
+      "city_zip": "02720",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "Not Available"
+    }
+  },
+
+  "DR SOLOMON CARTER FULLER MENTAL HEALTH CENTER (2D9E)" : {
+    "coordinates": [ -71.070833, 42.336229 ],
+    "properties": {
+      "DPHid": "2D9E",
+      "type": "non_acute_hospital",
+      "name": "DR SOLOMON CARTER FULLER MENTAL HEALTH CENTER",
+      "address": "85 EAST NEWTON STREET",
+  	  "city": "Boston",
+      "city_zip": "02118",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "Not Available"
+    }
+  },
+
+  "FAIRLAWN REHABILITATION HOSPITAL (2098)" : {
+    "coordinates": [ -71.835281, 42.260216 ],
+    "properties": {
+      "DPHid": "2098",
+      "type": "non_acute_hospital",
+      "name": "FAIRLAWN REHABILITATION HOSPITAL",
+      "address": "189 MAY STREET",
+  	  "city": "Worcester",
+      "city_zip": "01602",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "110"
+    }
+  },
+
+  "FRANCISCAN CHILDREN'S HOSPITAL & REHAB CENTER (2221)" : {
+    "coordinates": [ -71.143391, 42.350153 ],
+    "properties": {
+      "DPHid": "2221",
+      "type": "non_acute_hospital",
+      "name": "FRANCISCAN CHILDREN'S HOSPITAL & REHAB CENTER",
+      "address": "30 WARREN STREET",
+  	  "city": "Boston",
+      "city_zip": "02135",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "112"
+    }
+  },
+
+  "HEALTHSOUTH BRAINTREE REHABILITATION HOSPITAL (2333)" : {
+    "coordinates": [ -71.018739, 42.198835 ],
+    "properties": {
+      "DPHid": "2333",
+      "type": "non_acute_hospital",
+      "name": "HEALTHSOUTH BRAINTREE REHABILITATION HOSPITAL",
+      "address": "250 POND STREET",
+  	  "city": "Braintree",
+      "city_zip": "02184",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "166"
+    }
+  },
+
+  "HEALTHSOUTH NEW ENGLAND REH @BEVERL (2H97)" : {
+    "coordinates": [ -70.887384, 42.560994 ],
+    "properties": {
+      "DPHid": "2H97",
+      "type": "non_acute_hospital",
+      "name": "HEALTHSOUTH NEW ENGLAND REH @BEVERL",
+      "address": "800 CUMMINGS CTR, 1ST FL, #147",
+  	  "city": "Beverly",
+      "city_zip": "01915",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "20"
+    }
+  },
+
+  "HEALTHSOUTH NEW ENGLAND REH @LOWELL (2WE6)" : {
+    "coordinates": [ -71.367831, 42.644395 ],
+    "properties": {
+      "DPHid": "2WE6",
+      "type": "non_acute_hospital",
+      "name": "HEALTHSOUTH NEW ENGLAND REH @LOWELL",
+      "address": "1071 VARNUM AVENUE, GROUND FLO",
+  	  "city": "Lowell",
+      "city_zip": "01854",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "22"
+    }
+  },
+
+  "HEALTHSOUTH NEW ENGLAND REHABILITATION HOSPITAL (2329)" : {
+    "coordinates": [ -71.162057, 42.46331 ],
+    "properties": {
+      "DPHid": "2329",
+      "type": "non_acute_hospital",
+      "name": "HEALTHSOUTH NEW ENGLAND REHABILITATION HOSPITAL",
+      "address": "2 REHABILITATION WAY",
+  	  "city": "Woburn",
+      "city_zip": "01801",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "168"
+    }
+  },
+
+  "HEALTHSOUTH REHABILITATION HOSPITAL OF WESTERN MA (2912)" : {
+    "coordinates": [ -72.472042, 42.15549 ],
+    "properties": {
+      "DPHid": "2912",
+      "type": "non_acute_hospital",
+      "name": "HEALTHSOUTH REHABILITATION HOSPITAL OF WESTERN MA",
+      "address": "222 STATE STREET",
+  	  "city": "Ludlow",
+      "city_zip": "01056",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "53"
+    }
+  },
+
+  "HEBREW REHABILITATION CENTER (2290)" : {
+    "coordinates": [ -71.130978, 42.296791 ],
+    "properties": {
+      "DPHid": "2290",
+      "type": "non_acute_hospital",
+      "name": "HEBREW REHABILITATION CENTER",
+      "address": "1200 CENTRE STREET",
+  	  "city": "Boston",
+      "city_zip": "02131",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "455"
+    }
+  },
+
+  "HEBREW REHABILITATION CTR @ DEDHAM (2D85)" : {
+    "coordinates": [ -71.197006, 42.266913 ],
+    "properties": {
+      "DPHid": "2D85",
+      "type": "non_acute_hospital",
+      "name": "HEBREW REHABILITATION CTR @ DEDHAM",
+      "address": "7000 GREAT MEADOW ROAD",
+  	  "city": "Dedham",
+      "city_zip": "02026",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "220"
+    }
+  },
+
+  "HIGH POINT TREATMENT CENTER (20ZH)" : {
+    "coordinates": [ -70.914597, 41.894393 ],
+    "properties": {
+      "DPHid": "20ZH",
+      "type": "non_acute_hospital",
+      "name": "HIGH POINT TREATMENT CENTER",
+      "address": "52 OAK STREET",
+  	  "city": "Middleborough",
+      "city_zip": "02346",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "Not Available"
+    }
+  },
+
+  "LEMUEL SHATTUCK HOSPITAL (2821)" : {
+    "coordinates": [ -71.101792, 42.299581 ],
+    "properties": {
+      "DPHid": "2821",
+      "type": "non_acute_hospital",
+      "name": "LEMUEL SHATTUCK HOSPITAL",
+      "address": "170 MORTON STREET",
+  	  "city": "Boston",
+      "city_zip": "02130",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "Not Available"
+    }
+  },
+
+  "MCLEAN HOSPITAL CORPORATION (2920)" : {
+    "coordinates": [ -71.191376, 42.394225 ],
+    "properties": {
+      "DPHid": "2920",
+      "type": "non_acute_hospital",
+      "name": "MCLEAN HOSPITAL CORPORATION",
+      "address": "115 MILL STREET",
+  	  "city": "Belmont",
+      "city_zip": "02478",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "294"
+    }
+  },
+
+  "MCLEAN SOUTHEAST (24KZ)" : {
+    "coordinates": [ -70.915668, 41.90238 ],
+    "properties": {
+      "DPHid": "24KZ",
+      "type": "non_acute_hospital",
+      "name": "MCLEAN SOUTHEAST",
+      "address": "23 ISAAC STREET",
+  	  "city": "Middleborough",
+      "city_zip": "02346",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "30"
+    }
+  },
+
+  "NEW ENGLAND SINAI HOSPITAL (2250)" : {
+    "coordinates": [ -71.098819, 42.14465 ],
+    "properties": {
+      "DPHid": "2250",
+      "type": "non_acute_hospital",
+      "name": "NEW ENGLAND SINAI HOSPITAL",
+      "address": "150 YORK STREET, BOX CS9105",
+  	  "city": "Stoughton",
+      "city_zip": "02072",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "157"
+    }
+  },
+
+  "NORCAP LODGE (2KGH)" : {
+    "coordinates": [ -71.240881, 42.049705 ],
+    "properties": {
+      "DPHid": "2KGH",
+      "type": "non_acute_hospital",
+      "name": "NORCAP LODGE",
+      "address": "71 WALNUT STREET",
+  	  "city": "Foxborough",
+      "city_zip": "02035",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "43"
+    }
+  },
+
+  "PAPPAS REHABILITATION HOSPITAL FOR CHILDREN (2822)" : {
+    "coordinates": [ -71.125298, 42.176018 ],
+    "properties": {
+      "DPHid": "2822",
+      "type": "non_acute_hospital",
+      "name": "PAPPAS REHABILITATION HOSPITAL FOR CHILDREN",
+      "address": "3 RANDOLPH STREET",
+  	  "city": "Canton",
+      "city_zip": "02021",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "Not Available"
+    }
+  },
+
+  "PROVIDENCE BEHAVIOR HLTH HOSP CAMPU (2150)" : {
+    "coordinates": [ -72.633513, 42.166209 ],
+    "properties": {
+      "DPHid": "2150",
+      "type": "non_acute_hospital",
+      "name": "PROVIDENCE BEHAVIOR HLTH HOSP CAMPU",
+      "address": "1233 MAIN STREET",
+  	  "city": "Holyoke",
+      "city_zip": "01040",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "131"
+    }
+  },
+
+  "SOUTHCOAST BEHAVIORAL HEALTH (2J6E)" : {
+    "coordinates": [ -70.98532, 41.674167 ],
+    "properties": {
+      "DPHid": "2J6E",
+      "type": "non_acute_hospital",
+      "name": "SOUTHCOAST BEHAVIORAL HEALTH",
+      "address": "581 FAUNCE CORNER ROAD",
+  	  "city": "Dartmouth",
+      "city_zip": "02747",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "Not Available"
+    }
+  },
+
+  "SPAULDING HOSPITAL FOR CONTINUING MED CARE-CAMB (2102)" : {
+    "coordinates": [ -71.10686, 42.375352 ],
+    "properties": {
+      "DPHid": "2102",
+      "type": "non_acute_hospital",
+      "name": "SPAULDING HOSPITAL FOR CONTINUING MED CARE-CAMB",
+      "address": "1575 CAMBRIDGE STREET",
+  	  "city": "Cambridge",
+      "city_zip": "02138",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "180"
+    }
+  },
+
+  "SPAULDING REHABILITATION HOSPITAL (2321)" : {
+    "coordinates": [ -71.049083, 42.378586 ],
+    "properties": {
+      "DPHid": "2321",
+      "type": "non_acute_hospital",
+      "name": "SPAULDING REHABILITATION HOSPITAL",
+      "address": "300 FIRST AVENUE",
+  	  "city": "Boston",
+      "city_zip": "02129",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "132"
+    }
+  },
+
+  "SPAULDING REHABILITATION HOSPITAL - CAPE COD (2FXY)" : {
+    "coordinates": [ -70.468065, 41.732961 ],
+    "properties": {
+      "DPHid": "2FXY",
+      "type": "non_acute_hospital",
+      "name": "SPAULDING REHABILITATION HOSPITAL - CAPE COD",
+      "address": "311 SERVICE ROAD",
+  	  "city": "Sandwich",
+      "city_zip": "02537",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "60"
+    }
+  },
+
+  "TAUNTON STATE HOSPITAL (2815)" : {
+    "coordinates": [ -71.102195, 41.906669 ],
+    "properties": {
+      "DPHid": "2815",
+      "type": "non_acute_hospital",
+      "name": "TAUNTON STATE HOSPITAL",
+      "address": "60 HODGES AVENUE - BOX 151",
+  	  "city": "Taunton",
+      "city_zip": "02780",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "45"
+    }
+  },
+
+  "TEWKSBURY HOSPITAL (2825)" : {
+    "coordinates": [ -71.21687, 42.612167 ],
+    "properties": {
+      "DPHid": "2825",
+      "type": "non_acute_hospital",
+      "name": "TEWKSBURY HOSPITAL",
+      "address": "365 EAST STREET",
+  	  "city": "Tewksbury",
+      "city_zip": "01876",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "675"
+    }
+  },
+
+  "VIBRA HOSP OF WSTN MASS-CNTRL CAMPU (2IMK)" : {
+    "coordinates": [ -71.898751, 42.202024 ],
+    "properties": {
+      "DPHid": "2IMK",
+      "type": "non_acute_hospital",
+      "name": "VIBRA HOSP OF WSTN MASS-CNTRL CAMPU",
+      "address": "111 HUNTOON MEMORIAL HIGHWAY",
+  	  "city": "Leicester",
+      "city_zip": "01542",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "47"
+    }
+  },
+
+  "VIBRA HOSPITAL OF SOUTHEASTERN MASSACHUSETTS (2224)" : {
+    "coordinates": [ -70.945591, 41.739848 ],
+    "properties": {
+      "DPHid": "2224",
+      "type": "non_acute_hospital",
+      "name": "VIBRA HOSPITAL OF SOUTHEASTERN MASSACHUSETTS",
+      "address": "4499 ACUSHNET AVENUE",
+  	  "city": "New bedford",
+      "city_zip": "02745",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "90"
+    }
+  },
+
+  "VIBRA HOSPITAL OF WESTERN MASSACHUSETTS (2223)" : {
+    "coordinates": [ -72.547579, 42.120568 ],
+    "properties": {
+      "DPHid": "2223",
+      "type": "non_acute_hospital",
+      "name": "VIBRA HOSPITAL OF WESTERN MASSACHUSETTS",
+      "address": "1400 STATE STREET",
+  	  "city": "Springfield",
+      "city_zip": "01109",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "127"
+    }
+  },
+
+  "WALDEN BEHAVIORAL CARE, LLC (2ADW)" : {
+    "coordinates": [ -71.249448, 42.369221 ],
+    "properties": {
+      "DPHid": "2ADW",
+      "type": "non_acute_hospital",
+      "name": "WALDEN BEHAVIORAL CARE, LLC",
+      "address": "9 HOPE AVENUE",
+  	  "city": "Waltham",
+      "city_zip": "02453",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "45"
+    }
+  },
+
+  "WESTERN MASSACHUSETTS HOSPITAL (2826)" : {
+    "coordinates": [ -72.701723, 42.110955 ],
+    "properties": {
+      "DPHid": "2826",
+      "type": "non_acute_hospital",
+      "name": "WESTERN MASSACHUSETTS HOSPITAL",
+      "address": "91 EAST MOUNTAIN ROAD",
+  	  "city": "Westfield",
+      "city_zip": "01085",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "Not Available"
+    }
+  },
+
+  "WESTWOOD/PEMBROKE HLTH SYS/PEMBROKE (2032)" : {
+    "coordinates": [ -70.764491, 42.097673 ],
+    "properties": {
+      "DPHid": "2032",
+      "type": "non_acute_hospital",
+      "name": "WESTWOOD/PEMBROKE HLTH SYS/PEMBROKE",
+      "address": "199 OAK STREET",
+  	  "city": "Pembroke",
+      "city_zip": "02359",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "Not Available"
+    }
+  },
+
+  "WESTWOOD/PEMBROKE HLTH SYS/WESTWOOD (2017)" : {
+    "coordinates": [ -71.22408, 42.206853 ],
+    "properties": {
+      "DPHid": "2017",
+      "type": "non_acute_hospital",
+      "name": "WESTWOOD/PEMBROKE HLTH SYS/WESTWOOD",
+      "address": "45 CLAPBOARDTREE STREET",
+  	  "city": "Westwood",
+      "city_zip": "02090",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "Not Available"
+    }
+  },
+
+  "WHITTIER PAVILION (2XOB)" : {
+    "coordinates": [ -71.072897, 42.778587 ],
+    "properties": {
+      "DPHid": "2XOB",
+      "type": "non_acute_hospital",
+      "name": "WHITTIER PAVILION",
+      "address": "76 SUMMER STREET",
+  	  "city": "Haverhill",
+      "city_zip": "01830",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "10"
+    }
+  },
+
+  "WHITTIER REHABILITATION HOSPITAL (293Q)" : {
+    "coordinates": [ -71.567898, 42.27648 ],
+    "properties": {
+      "DPHid": "293Q",
+      "type": "non_acute_hospital",
+      "name": "WHITTIER REHABILITATION HOSPITAL",
+      "address": "150 FLANDERS ROAD",
+  	  "city": "Westborough",
+      "city_zip": "01581",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "88"
+    }
+  },
+
+  "WHITTIER REHABILITATION HOSPITAL - BRADFORD (2292)" : {
+    "coordinates": [ -71.11894, 42.761694 ],
+    "properties": {
+      "DPHid": "2292",
+      "type": "non_acute_hospital",
+      "name": "WHITTIER REHABILITATION HOSPITAL - BRADFORD",
+      "address": "145 WARD HILL AVENUE",
+  	  "city": "Haverhill",
+      "city_zip": "01835",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "60"
+    }
+  },
+
+  "WORCESTER RECOVERY CENTER AND HOSPITAL (2818)" : {
+    "coordinates": [ -71.76664, 42.273722 ],
+    "properties": {
+      "DPHid": "2818",
+      "type": "non_acute_hospital",
+      "name": "WORCESTER RECOVERY CENTER AND HOSPITAL",
+      "address": "309 BELMONT STREET",
+  	  "city": "Worcester",
+      "city_zip": "01604",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "166"
+    }
+  },
+
+  "BOSTON CHILDREN'S AT WALTHAM (2QCZ)" : {
+    "coordinates": [ -71.249448, 42.369221 ],
+    "properties": {
+      "DPHid": "2QCZ",
+      "type": "hospital_inpatient_satellite",
+      "name": "BOSTON CHILDREN'S AT WALTHAM",
+      "address": "9 HOPE AVENUE",
+  	  "city": "Waltham",
+      "city_zip": "02254",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "11"
+    }
+  },
+
+  "DANA FARBER CANCER INST INPATIENT (2PW6)" : {
+    "coordinates": [ -71.106984, 42.336014 ],
+    "properties": {
+      "DPHid": "2PW6",
+      "type": "hospital_inpatient_satellite",
+      "name": "DANA FARBER CANCER INST INPATIENT",
+      "address": "75 FRANCIS ST 6TH FL 6C & 7TH",
+  	  "city": "Boston",
+      "city_zip": "02115",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "27"
+    }
+  },
+
+  "HARRINGTON HEALTHCARE AT WEBSTER (2S32)" : {
+    "coordinates": [ -71.850959, 42.027204 ],
+    "properties": {
+      "DPHid": "2S32",
+      "type": "hospital_inpatient_satellite",
+      "name": "HARRINGTON HEALTHCARE AT WEBSTER",
+      "address": "340 THOMPSON RD, 1970 ADDITION",
+  	  "city": "Webster",
+      "city_zip": "01570",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "16"
+    }
+  },
+
+  "HEALTHSOUTH BRAINTREE REH UNIT @FRA (2QCC)" : {
+    "coordinates": [ -71.39633, 42.307378 ],
+    "properties": {
+      "DPHid": "2QCC",
+      "type": "hospital_inpatient_satellite",
+      "name": "HEALTHSOUTH BRAINTREE REH UNIT @FRA",
+      "address": "125 NEWBURY STREET",
+  	  "city": "Framingham",
+      "city_zip": "01701",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "21"
+    }
+  },
+
+  "NEW ENG SINAI HOSP INPT SAT-CARNEY (2RYJ)" : {
+    "coordinates": [ -71.065976, 42.277578 ],
+    "properties": {
+      "DPHid": "2RYJ",
+      "type": "hospital_inpatient_satellite",
+      "name": "NEW ENG SINAI HOSP INPT SAT-CARNEY",
+      "address": "2100 DORCHESTER AVE THIRD FLOO",
+  	  "city": "Boston",
+      "city_zip": "02124",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "25"
+    }
+  },
+
+  "ST ANNE'S HOSP GERI PSYCH UN @ NESH (2FDZ)" : {
+    "coordinates": [ -71.163938, 41.692775 ],
+    "properties": {
+      "DPHid": "2FDZ",
+      "type": "hospital_inpatient_satellite",
+      "name": "ST ANNE'S HOSP GERI PSYCH UN @ NESH",
+      "address": "150 YORK STREET 2FL & BASEMENT",
+  	  "city": "Stoughton",
+      "city_zip": "02072",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "15"
+    }
+  },
+
+  "ST ELIZABETH'S GERIATRIC PSYCHIATRY (2CIA)" : {
+    "coordinates": [ -71.065739, 42.277486 ],
+    "properties": {
+      "DPHid": "2CIA",
+      "type": "hospital_inpatient_satellite",
+      "name": "ST ELIZABETH'S GERIATRIC PSYCHIATRY",
+      "address": "2100 DORCHESTER AVENUE 4TH FL",
+  	  "city": "Boston",
+      "city_zip": "02124",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "15"
+    }
+  },
+
+  "UMASS MEMORIAL MC PTNT TX & RCVRY C (2AH9)" : {
+    "coordinates": [ -71.814655, 42.259252 ],
+    "properties": {
+      "DPHid": "2AH9",
+      "type": "hospital_inpatient_satellite",
+      "name": "UMASS MEMORIAL MC PTNT TX & RCVRY C",
+      "address": "26 QUEEN STREET",
+  	  "city": "Worcester",
+      "city_zip": "01610",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "inpatient ambulatory",
+      "bed_count": "45"
+    }
+  },
+
+  "BAYSTATE MARY LANE OUTPT CTR - SEF (2PW2)" : {
+    "coordinates": [ -72.242387, 42.253672 ],
+    "properties": {
+      "DPHid": "2PW2",
+      "type": "satellite_emergency_facility",
+      "name": "BAYSTATE MARY LANE OUTPT CTR - SEF",
+      "address": "85 SOUTH STREET",
+  	  "city": "Ware",
+      "city_zip": "01082",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency",
+      "bed_count": "0"
+    }
+  },
+
+  "CHA SOMERVILLE HOSPITAL (2001)" : {
+    "coordinates": [ -71.109061, 42.390335 ],
+    "properties": {
+      "DPHid": "2001",
+      "type": "satellite_emergency_facility",
+      "name": "CHA SOMERVILLE HOSPITAL",
+      "address": "230 HIGHLAND AVENUE",
+  	  "city": "Somerville",
+      "city_zip": "02143",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency",
+      "bed_count": "124"
+    }
+  },
+
+  "EAST BOSTON NEIGHBORHOOD HLTH CTR (21PE)" : {
+    "coordinates": [ -71.038304, 42.372362 ],
+    "properties": {
+      "DPHid": "21PE",
+      "type": "satellite_emergency_facility",
+      "name": "EAST BOSTON NEIGHBORHOOD HLTH CTR",
+      "address": "10 GOVE STREET",
+  	  "city": "Boston",
+      "city_zip": "02128",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency",
+      "bed_count": "0"
+    }
+  },
+
+  "HARRINGTON HEALTHCARE AT HUBBARD (2KRA)" : {
+    "coordinates": [ -71.850189, 42.027953 ],
+    "properties": {
+      "DPHid": "2KRA",
+      "type": "satellite_emergency_facility",
+      "name": "HARRINGTON HEALTHCARE AT HUBBARD",
+      "address": "340 THOMPSON ROAD",
+  	  "city": "Webster",
+      "city_zip": "01570",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency",
+      "bed_count": "0"
+    }
+  },
+
+  "NORTH ADAMS CAMPUS OF BMC AND SEF (25HE)" : {
+    "coordinates": [ -73.109115, 42.707313 ],
+    "properties": {
+      "DPHid": "25HE",
+      "type": "satellite_emergency_facility",
+      "name": "NORTH ADAMS CAMPUS OF BMC AND SEF",
+      "address": "71 HOSPITAL AVENUE",
+  	  "city": "North adams",
+      "city_zip": "01247",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency",
+      "bed_count": "0"
+    }
+  },
+
+  "STEWARD SAT EMERG FACILITY-QUINCY (2QEQ)" : {
+    "coordinates": [ -71.014149, 42.250976 ],
+    "properties": {
+      "DPHid": "2QEQ",
+      "type": "satellite_emergency_facility",
+      "name": "STEWARD SAT EMERG FACILITY-QUINCY",
+      "address": "114 WHITWELL STREET",
+  	  "city": "Quincy",
+      "city_zip": "02169",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "emergency",
+      "bed_count": "0"
+    }
+  },
+
+  "510 MEDICAL PRACTICE BUILDING (2GZG)" : {
+    "coordinates": [ -73.251108, 42.455507 ],
+    "properties": {
+      "DPHid": "2GZG",
+      "type": "hospital_satellite",
+      "name": "510 MEDICAL PRACTICE BUILDING",
+      "address": "510 NORTH STREET",
+  	  "city": "Pittsfield",
+      "city_zip": "01201",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "ADCARE HOSPITAL OUTPATIENT BOSTON (2MO4)" : {
+    "coordinates": [ -71.062384, 42.357716 ],
+    "properties": {
+      "DPHid": "2MO4",
+      "type": "hospital_satellite",
+      "name": "ADCARE HOSPITAL OUTPATIENT BOSTON",
+      "address": "14 BEACON STREET",
+  	  "city": "Boston",
+      "city_zip": "02108",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "ADCARE HOSPITAL OUTPATIENT QUINCY (2TS0)" : {
+    "coordinates": [ -71.002824, 42.249254 ],
+    "properties": {
+      "DPHid": "2TS0",
+      "type": "hospital_satellite",
+      "name": "ADCARE HOSPITAL OUTPATIENT QUINCY",
+      "address": "1419 HANCOCK STREET",
+  	  "city": "Quincy",
+      "city_zip": "02169",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "ADCARE HOSPITAL OUTPT N. DARTMOUTH (2M68)" : {
+    "coordinates": [ -70.989149, 41.648101 ],
+    "properties": {
+      "DPHid": "2M68",
+      "type": "hospital_satellite",
+      "name": "ADCARE HOSPITAL OUTPT N. DARTMOUTH",
+      "address": "88 FAUNCE CORNER ROAD, SUITE #",
+  	  "city": "Dartmouth",
+      "city_zip": "02747",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "ADCARE HOSPITAL OUTPT W.SPRINGFIELD (2I3P)" : {
+    "coordinates": [ -72.618691, 42.105321 ],
+    "properties": {
+      "DPHid": "2I3P",
+      "type": "hospital_satellite",
+      "name": "ADCARE HOSPITAL OUTPT W.SPRINGFIELD",
+      "address": "117 PARK AVENUE",
+  	  "city": "West springfield",
+      "city_zip": "01089",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "ADCARE HOSPITAL OUTPT WORCESTER (2Y6W)" : {
+    "coordinates": [ -71.795486, 42.275413 ],
+    "properties": {
+      "DPHid": "2Y6W",
+      "type": "hospital_satellite",
+      "name": "ADCARE HOSPITAL OUTPT WORCESTER",
+      "address": "95 LINCOLN STREET",
+  	  "city": "Worcester",
+      "city_zip": "01605",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "ANDOVER SURGERY CENTER (2YMQ)" : {
+    "coordinates": [ -71.136078, 42.675889 ],
+    "properties": {
+      "DPHid": "2YMQ",
+      "type": "hospital_satellite",
+      "name": "ANDOVER SURGERY CENTER",
+      "address": "138 HAVERHILL STREET UNITS B&C",
+  	  "city": "Andover",
+      "city_zip": "01810",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "ANNA JAQUES CANCER CENTER (228R)" : {
+    "coordinates": [ -70.892973, 42.813058 ],
+    "properties": {
+      "DPHid": "228R",
+      "type": "hospital_satellite",
+      "name": "ANNA JAQUES CANCER CENTER",
+      "address": "ONE WALLACE BASHAW JR WAY SUIT",
+  	  "city": "Newburyport",
+      "city_zip": "01950",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "ANNA JAQUES HOSP DGST ULTRASND @WHC (2IRK)" : {
+    "coordinates": [ -70.907991, 42.818715 ],
+    "properties": {
+      "DPHid": "2IRK",
+      "type": "hospital_satellite",
+      "name": "ANNA JAQUES HOSP DGST ULTRASND @WHC",
+      "address": "255 LOW STREET",
+  	  "city": "Newburyport",
+      "city_zip": "01950",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "ANNA JAQUES HOSP OUTPATIENT REHAB S (2ZDA)" : {
+    "coordinates": [ -70.901958, 42.820958 ],
+    "properties": {
+      "DPHid": "2ZDA",
+      "type": "hospital_satellite",
+      "name": "ANNA JAQUES HOSP OUTPATIENT REHAB S",
+      "address": "25 STOREY AVENUE",
+  	  "city": "Newburyport",
+      "city_zip": "01950",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "ANNA JAQUES HOSP SATE OFFICES @ MOB (2E4Q)" : {
+    "coordinates": [ -70.8909, 42.814391 ],
+    "properties": {
+      "DPHid": "2E4Q",
+      "type": "hospital_satellite",
+      "name": "ANNA JAQUES HOSP SATE OFFICES @ MOB",
+      "address": "21 HIGHLAND AVE 2ND & 1ST FLOO",
+  	  "city": "Newburyport",
+      "city_zip": "01950",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "ANNA JAQUES HOSPITAL AQUATIC REHABI (2PO5)" : {
+    "coordinates": [ -70.874727, 42.811203 ],
+    "properties": {
+      "DPHid": "2PO5",
+      "type": "hospital_satellite",
+      "name": "ANNA JAQUES HOSPITAL AQUATIC REHABI",
+      "address": "13 MARKET STREET",
+  	  "city": "Newburyport",
+      "city_zip": "01950",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "ANNA JAQUES HOSPITAL ULTRASOUND (2CBG)" : {
+    "coordinates": [ -71.074982, 42.775966 ],
+    "properties": {
+      "DPHid": "2CBG",
+      "type": "hospital_satellite",
+      "name": "ANNA JAQUES HOSPITAL ULTRASOUND",
+      "address": "2 WATER STREET 1ST FLOOR",
+  	  "city": "Haverhill",
+      "city_zip": "01830",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "AQUATIC THER PRG GROTON SCH ATHLE C (2F9L)" : {
+    "coordinates": [ -71.584016, 42.593495 ],
+    "properties": {
+      "DPHid": "2F9L",
+      "type": "hospital_satellite",
+      "name": "AQUATIC THER PRG GROTON SCH ATHLE C",
+      "address": "GROTON SCHOOL FARMERS ROW",
+  	  "city": "Groton",
+      "city_zip": "01450",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "B&W HOSP MOHS DERMATOLOGIC SURGEY C (22MD)" : {
+    "coordinates": [ -71.128149, 42.301563 ],
+    "properties": {
+      "DPHid": "22MD",
+      "type": "hospital_satellite",
+      "name": "B&W HOSP MOHS DERMATOLOGIC SURGEY C",
+      "address": "1153 CENTER STREET (@FAULKNER",
+  	  "city": "Boston",
+      "city_zip": "02130",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "B.I.DEACONESS MC SAT@LITTLE HOUSE (2IQM)" : {
+    "coordinates": [ -71.056534, 42.316804 ],
+    "properties": {
+      "DPHid": "2IQM",
+      "type": "hospital_satellite",
+      "name": "B.I.DEACONESS MC SAT@LITTLE HOUSE",
+      "address": "990 DORCHESTER AVENUE",
+  	  "city": "Boston",
+      "city_zip": "02125",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BARRE FAMILY HEALTH CENTER (2XVP)" : {
+    "coordinates": [ -72.090782, 42.408275 ],
+    "properties": {
+      "DPHid": "2XVP",
+      "type": "hospital_satellite",
+      "name": "BARRE FAMILY HEALTH CENTER",
+      "address": "151 WORCESTER ROAD",
+  	  "city": "Barre",
+      "city_zip": "01005",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BAYSTATE AMBULATORY CC@3300 MAIN ST (27EQ)" : {
+    "coordinates": [ -72.610047, 42.122942 ],
+    "properties": {
+      "DPHid": "27EQ",
+      "type": "hospital_satellite",
+      "name": "BAYSTATE AMBULATORY CC@3300 MAIN ST",
+      "address": "3300 MAIN STREET 1, 2, 3, 4 FL",
+  	  "city": "Springfield",
+      "city_zip": "01107",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BAYSTATE AMBULATRY CC @ 140 HIGH ST (2VWD)" : {
+    "coordinates": [ -83.812361, 39.923464 ],
+    "properties": {
+      "DPHid": "2VWD",
+      "type": "hospital_satellite",
+      "name": "BAYSTATE AMBULATRY CC @ 140 HIGH ST",
+      "address": "140 HIGH STREET 2ND FLOOR & C",
+  	  "city": "Springfield",
+      "city_zip": "01108",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BAYSTATE BRIGHTWOOD HC/CENTRO DE SA (23SW)" : {
+    "coordinates": [ -72.614439, 42.117235 ],
+    "properties": {
+      "DPHid": "23SW",
+      "type": "hospital_satellite",
+      "name": "BAYSTATE BRIGHTWOOD HC/CENTRO DE SA",
+      "address": "380 PLAINFIELD ST",
+  	  "city": "Springfield",
+      "city_zip": "01107",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BAYSTATE CHILD PARTIAL HOSP PROG (2SNV)" : {
+    "coordinates": [ -72.64676, 42.173357 ],
+    "properties": {
+      "DPHid": "2SNV",
+      "type": "hospital_satellite",
+      "name": "BAYSTATE CHILD PARTIAL HOSP PROG",
+      "address": "150 LOWER WESTFIELD ROAD 1ST F",
+  	  "city": "Holyoke",
+      "city_zip": "01040",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BAYSTATE FRANKLIN MED CTR OUTPT SRV (2AC2)" : {
+    "coordinates": [ -72.59403, 42.594706 ],
+    "properties": {
+      "DPHid": "2AC2",
+      "type": "hospital_satellite",
+      "name": "BAYSTATE FRANKLIN MED CTR OUTPT SRV",
+      "address": "48 SANDERSON STREET",
+  	  "city": "Greenfield",
+      "city_zip": "01301",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BAYSTATE HEART & VASCULAR PRG CARDI (28P4)" : {
+    "coordinates": [ -72.667527, 42.334349 ],
+    "properties": {
+      "DPHid": "28P4",
+      "type": "hospital_satellite",
+      "name": "BAYSTATE HEART & VASCULAR PRG CARDI",
+      "address": "10 MAIN STREET",
+  	  "city": "Northampton",
+      "city_zip": "01062",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BAYSTATE MASON SQRE NGHBORHOOD HCC (2Y03)" : {
+    "coordinates": [ -72.563283, 42.110981 ],
+    "properties": {
+      "DPHid": "2Y03",
+      "type": "hospital_satellite",
+      "name": "BAYSTATE MASON SQRE NGHBORHOOD HCC",
+      "address": "11 WILBRAHAM RD 1ST FL",
+  	  "city": "Springfield",
+      "city_zip": "01109",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BAYSTATE MED CTR LAB @361 WHITNEY A (2T4K)" : {
+    "coordinates": [ -72.648061, 42.167015 ],
+    "properties": {
+      "DPHid": "2T4K",
+      "type": "hospital_satellite",
+      "name": "BAYSTATE MED CTR LAB @361 WHITNEY A",
+      "address": "361 WHITNEY AVENUE",
+  	  "city": "Holyoke",
+      "city_zip": "01040",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BAYSTATE MED CTR PAIN MGMNT CTR (2UWT)" : {
+    "coordinates": [ -72.610784, 42.124247 ],
+    "properties": {
+      "DPHid": "2UWT",
+      "type": "hospital_satellite",
+      "name": "BAYSTATE MED CTR PAIN MGMNT CTR",
+      "address": "3400 MAIN STREET 2ND FLOOR",
+  	  "city": "Springfield",
+      "city_zip": "01107",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BAYSTATE MED CTR-BAYSTATE VASCULAR (288X)" : {
+    "coordinates": [ -72.611562, 42.125297 ],
+    "properties": {
+      "DPHid": "288X",
+      "type": "hospital_satellite",
+      "name": "BAYSTATE MED CTR-BAYSTATE VASCULAR",
+      "address": "3500 MAIN STREET",
+  	  "city": "Springfield",
+      "city_zip": "01107",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BAYSTATE ORTHOPEDIC SURGERY CENTER (2MTC)" : {
+    "coordinates": [ -72.615028, 42.124423 ],
+    "properties": {
+      "DPHid": "2MTC",
+      "type": "hospital_satellite",
+      "name": "BAYSTATE ORTHOPEDIC SURGERY CENTER",
+      "address": "50 WASON AVENUE 2FL",
+  	  "city": "Springfield",
+      "city_zip": "01107",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BAYSTATE PRIMARY CARE (LUDLOW) (2BE7)" : {
+    "coordinates": [ -72.483297, 42.160341 ],
+    "properties": {
+      "DPHid": "2BE7",
+      "type": "hospital_satellite",
+      "name": "BAYSTATE PRIMARY CARE (LUDLOW)",
+      "address": "34 HUBBARD STREET",
+  	  "city": "Ludlow",
+      "city_zip": "01056",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BAYSTATE PRIMARY CARE (MONSON) (21XY)" : {
+    "coordinates": [ -72.31545, 42.109219 ],
+    "properties": {
+      "DPHid": "21XY",
+      "type": "hospital_satellite",
+      "name": "BAYSTATE PRIMARY CARE (MONSON)",
+      "address": "2 MAIN STREET",
+  	  "city": "Monson",
+      "city_zip": "01057",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BAYSTATE RADIOLOGY (2Z7R)" : {
+    "coordinates": [ -72.398387, 42.287919 ],
+    "properties": {
+      "DPHid": "2Z7R",
+      "type": "hospital_satellite",
+      "name": "BAYSTATE RADIOLOGY",
+      "address": "95 SARGEANT STREET",
+  	  "city": "Belchertown",
+      "city_zip": "01007",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BAYSTATE REGIONAL CANCER PROGRAM (2QAZ)" : {
+    "coordinates": [ -82.250906, 34.397793 ],
+    "properties": {
+      "DPHid": "2QAZ",
+      "type": "hospital_satellite",
+      "name": "BAYSTATE REGIONAL CANCER PROGRAM",
+      "address": "85 SOUTH ST DAVIS BLDG 4TH FL",
+  	  "city": "Ware",
+      "city_zip": "01082",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BAYSTATE REHAB @ EAST LONGMEADOW (2ZT2)" : {
+    "coordinates": [ -72.522276, 42.074971 ],
+    "properties": {
+      "DPHid": "2ZT2",
+      "type": "hospital_satellite",
+      "name": "BAYSTATE REHAB @ EAST LONGMEADOW",
+      "address": "294 NORTH MAIN ST-BSMNT 101",
+  	  "city": "East longmeadow",
+      "city_zip": "01028",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BAYSTATE REHAB @ THE RAYMOND CENTER (2XAU)" : {
+    "coordinates": [ -72.56232, 42.233648 ],
+    "properties": {
+      "DPHid": "2XAU",
+      "type": "hospital_satellite",
+      "name": "BAYSTATE REHAB @ THE RAYMOND CENTER",
+      "address": "470 GRANBY ROAD 2ND FLOOR",
+  	  "city": "South hadley",
+      "city_zip": "01075",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BAYSTATE REHAB CRE ADULT OUTPT SRVS (24OT)" : {
+    "coordinates": [ -72.611861, 42.123251 ],
+    "properties": {
+      "DPHid": "24OT",
+      "type": "hospital_satellite",
+      "name": "BAYSTATE REHAB CRE ADULT OUTPT SRVS",
+      "address": "360 BIRNIE AVENUE",
+  	  "city": "Springfield",
+      "city_zip": "01199",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BAYSTATE REHABILITATION CARE @ AGAW (2RHL)" : {
+    "coordinates": [ -72.633541, 42.062023 ],
+    "properties": {
+      "DPHid": "2RHL",
+      "type": "hospital_satellite",
+      "name": "BAYSTATE REHABILITATION CARE @ AGAW",
+      "address": "200 SILVER STREET",
+  	  "city": "Agawam",
+      "city_zip": "01001",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BAYSTATE WING HOSP BELCHERTOWN M C (2UA3)" : {
+    "coordinates": [ -72.406418, 42.291376 ],
+    "properties": {
+      "DPHid": "2UA3",
+      "type": "hospital_satellite",
+      "name": "BAYSTATE WING HOSP BELCHERTOWN M C",
+      "address": "20 DANIEL SHAYS HWY",
+  	  "city": "Belchertown",
+      "city_zip": "01007",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BAYSTATE WING HOSP GRISWOLD CTR B H (2SGN)" : {
+    "coordinates": [ -72.341893, 42.168231 ],
+    "properties": {
+      "DPHid": "2SGN",
+      "type": "hospital_satellite",
+      "name": "BAYSTATE WING HOSP GRISWOLD CTR B H",
+      "address": "42 WRIGHT STREET",
+  	  "city": "Palmer",
+      "city_zip": "01069",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BAYSTATE WING HOSP WILBRAHAM DGNS C (24O7)" : {
+    "coordinates": [ -72.472433, 42.150517 ],
+    "properties": {
+      "DPHid": "24O7",
+      "type": "hospital_satellite",
+      "name": "BAYSTATE WING HOSP WILBRAHAM DGNS C",
+      "address": "2034-2040 BOSTON ROAD SUITE 16",
+  	  "city": "Wilbraham",
+      "city_zip": "01095",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BAYSTATE WING HOSP WILBRAHAM MED CT (2ULN)" : {
+    "coordinates": [ -72.458543, 42.151178 ],
+    "properties": {
+      "DPHid": "2ULN",
+      "type": "hospital_satellite",
+      "name": "BAYSTATE WING HOSP WILBRAHAM MED CT",
+      "address": "2344 BOSTON RD",
+  	  "city": "Wilbraham",
+      "city_zip": "01095",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BERKSHIRE MED CTR GYN SVCS & MED PR (2QP5)" : {
+    "coordinates": [ -73.120915, 42.620949 ],
+    "properties": {
+      "DPHid": "2QP5",
+      "type": "hospital_satellite",
+      "name": "BERKSHIRE MED CTR GYN SVCS & MED PR",
+      "address": "2 PARK STREET 2ND FL",
+  	  "city": "Adams",
+      "city_zip": "01220",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BERKSHIRE MED CTR INC/HILLCREST CAM (2231)" : {
+    "coordinates": [ -73.281168, 42.458029 ],
+    "properties": {
+      "DPHid": "2231",
+      "type": "hospital_satellite",
+      "name": "BERKSHIRE MED CTR INC/HILLCREST CAM",
+      "address": "165 TOR COURT ROAD",
+  	  "city": "Pittsfield",
+      "city_zip": "01201",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BERKSHIRE MED CTR MED PRACTC SUITES (2XUV)" : {
+    "coordinates": [ -73.27862, 42.37759 ],
+    "properties": {
+      "DPHid": "2XUV",
+      "type": "hospital_satellite",
+      "name": "BERKSHIRE MED CTR MED PRACTC SUITES",
+      "address": "55 PITTSFIELD ROAD",
+  	  "city": "Lenox",
+      "city_zip": "01240",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BERKSHIRE MED CTR OPT IMAGING &TEST (27U4)" : {
+    "coordinates": [ -73.25039, 42.457083 ],
+    "properties": {
+      "DPHid": "27U4",
+      "type": "hospital_satellite",
+      "name": "BERKSHIRE MED CTR OPT IMAGING &TEST",
+      "address": "610 NORTH STREET 1ST FL",
+  	  "city": "Pittsfield",
+      "city_zip": "01201",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BERKSHIRE MED CTR UROLOGY CENTER (28J3)" : {
+    "coordinates": [ -73.250837, 42.45654 ],
+    "properties": {
+      "DPHid": "28J3",
+      "type": "hospital_satellite",
+      "name": "BERKSHIRE MED CTR UROLOGY CENTER",
+      "address": "41 WAHCONAH STREET FLS 1&2",
+  	  "city": "Pittsfield",
+      "city_zip": "01201",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BERKSHIRE MED CTR VEIN WOUND & HYPR (2J22)" : {
+    "coordinates": [ -73.250261, 42.460503 ],
+    "properties": {
+      "DPHid": "2J22",
+      "type": "hospital_satellite",
+      "name": "BERKSHIRE MED CTR VEIN WOUND & HYPR",
+      "address": "66 WAHCONAH STREET",
+  	  "city": "Pittsfield",
+      "city_zip": "01201",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BERKSHIRE OSTEOPATHIC HEALTH OF BMC (2PTF)" : {
+    "coordinates": [ -73.253891, 42.45287 ],
+    "properties": {
+      "DPHid": "2PTF",
+      "type": "hospital_satellite",
+      "name": "BERKSHIRE OSTEOPATHIC HEALTH OF BMC",
+      "address": "42 SUMMER STREET 3RD FLOOR",
+  	  "city": "Pittsfield",
+      "city_zip": "01201",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BETH ISR DCNS HEALTHCARE CHESTNUT H (27IV)" : {
+    "coordinates": [ -71.068319, 42.352052 ],
+    "properties": {
+      "DPHid": "27IV",
+      "type": "hospital_satellite",
+      "name": "BETH ISR DCNS HEALTHCARE CHESTNUT H",
+      "address": "200 BOYLSTON STREET 5 FL",
+  	  "city": "Boston",
+      "city_zip": "02467",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BETH ISR DEAC HOSP-NEEDHM PT&OT (2RUZ)" : {
+    "coordinates": [ -71.23752, 42.278883 ],
+    "properties": {
+      "DPHid": "2RUZ",
+      "type": "hospital_satellite",
+      "name": "BETH ISR DEAC HOSP-NEEDHM PT&OT",
+      "address": "73 CHESTNUT STREET",
+  	  "city": "Needham",
+      "city_zip": "02492",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BETH ISRAEL DEAC HLTHCRE LEXINGTON (2MNF)" : {
+    "coordinates": [ -71.25096, 42.475533 ],
+    "properties": {
+      "DPHid": "2MNF",
+      "type": "hospital_satellite",
+      "name": "BETH ISRAEL DEAC HLTHCRE LEXINGTON",
+      "address": "482 BEDFORD STREET 1ST,2ND FLO",
+  	  "city": "Lexington",
+      "city_zip": "02421",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BEVERLY HOSPITAL WOUND & HYPERBARIC (22ZE)" : {
+    "coordinates": [ -70.889587, 42.562179 ],
+    "properties": {
+      "DPHid": "22ZE",
+      "type": "hospital_satellite",
+      "name": "BEVERLY HOSPITAL WOUND & HYPERBARIC",
+      "address": "500 CUMMINGS CENTER SUITE 1800",
+  	  "city": "Beverly",
+      "city_zip": "01915",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BIDC HOSP-PLYMOUTH IMGING @ THE PRK (26C9)" : {
+    "coordinates": [ -70.708741, 41.952749 ],
+    "properties": {
+      "DPHid": "26C9",
+      "type": "hospital_satellite",
+      "name": "BIDC HOSP-PLYMOUTH IMGING @ THE PRK",
+      "address": "45 RESNICK ROAD 1ST FL",
+  	  "city": "Plymouth",
+      "city_zip": "02360",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BIDC HOSPITAL - PLYMOUTH REHAB CTR (2GP5)" : {
+    "coordinates": [ -70.68813, 41.979428 ],
+    "properties": {
+      "DPHid": "2GP5",
+      "type": "hospital_satellite",
+      "name": "BIDC HOSPITAL - PLYMOUTH REHAB CTR",
+      "address": "10 CORDAGE PARK SUITE 225",
+  	  "city": "Plymouth",
+      "city_zip": "02360",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BIDC HOSPITAL - PLYMOUTH REHAB CTR (2PN7)" : {
+    "coordinates": [ -70.59975, 41.880159 ],
+    "properties": {
+      "DPHid": "2PN7",
+      "type": "hospital_satellite",
+      "name": "BIDC HOSPITAL - PLYMOUTH REHAB CTR",
+      "address": "3 VILLAGE GREEN NORTH 3 FL STE",
+  	  "city": "Plymouth",
+      "city_zip": "02360",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BIDMC OUTPATIENT FREE CARE PHARMACY (2NG5)" : {
+    "coordinates": [ -71.107235, 42.338624 ],
+    "properties": {
+      "DPHid": "2NG5",
+      "type": "hospital_satellite",
+      "name": "BIDMC OUTPATIENT FREE CARE PHARMACY",
+      "address": "350 LONGWOOD AVENUE",
+  	  "city": "Boston",
+      "city_zip": "02215",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BLACKSTONE VALLEY TECH SBHC @ MILFO (2CE3)" : {
+    "coordinates": [ -71.614751, 42.163357 ],
+    "properties": {
+      "DPHid": "2CE3",
+      "type": "hospital_satellite",
+      "name": "BLACKSTONE VALLEY TECH SBHC @ MILFO",
+      "address": "65 PLEASANT STREET",
+  	  "city": "Upton",
+      "city_zip": "01568",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BMC HILLCREST FAMILY MED PRACTICE (2AYD)" : {
+    "coordinates": [ -73.250996, 42.457235 ],
+    "properties": {
+      "DPHid": "2AYD",
+      "type": "hospital_satellite",
+      "name": "BMC HILLCREST FAMILY MED PRACTICE",
+      "address": "631B NORTH STREET",
+  	  "city": "Pittsfield",
+      "city_zip": "01201",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BMC RADIOLGY @ RYAN CTR BOSTON UNIV (211Y)" : {
+    "coordinates": [ -71.076222, 42.351909 ],
+    "properties": {
+      "DPHid": "211Y",
+      "type": "hospital_satellite",
+      "name": "BMC RADIOLGY @ RYAN CTR BOSTON UNIV",
+      "address": "915 COMMONWEALTH AVE REAR 1ST",
+  	  "city": "Boston",
+      "city_zip": "02115",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BMC SBHC @ BOSTON COMM LEADERSHP AC (2CMW)" : {
+    "coordinates": [ -71.117881, 42.262784 ],
+    "properties": {
+      "DPHid": "2CMW",
+      "type": "hospital_satellite",
+      "name": "BMC SBHC @ BOSTON COMM LEADERSHP AC",
+      "address": "655 METROPOLITAN AVENUE",
+  	  "city": "Boston",
+      "city_zip": "02136",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BOSTON CHILDREN'S @ NORTH DARTMOUTH (2T88)" : {
+    "coordinates": [ -70.991592, 41.670715 ],
+    "properties": {
+      "DPHid": "2T88",
+      "type": "hospital_satellite",
+      "name": "BOSTON CHILDREN'S @ NORTH DARTMOUTH",
+      "address": "500 FAUNCE CORNER ROAD-BLDG 20",
+  	  "city": "Dartmouth",
+      "city_zip": "02747",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BOSTON CHILDREN'S AT LEXINGTON (21EG)" : {
+    "coordinates": [ -71.252117, 42.475517 ],
+    "properties": {
+      "DPHid": "21EG",
+      "type": "hospital_satellite",
+      "name": "BOSTON CHILDREN'S AT LEXINGTON",
+      "address": "482 BEDFORD STREET 1ST AND 2ND",
+  	  "city": "Lexington",
+      "city_zip": "02421",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BOSTON CHILDREN'S AT PEABODY (2TE7)" : {
+    "coordinates": [ -70.953263, 42.526131 ],
+    "properties": {
+      "DPHid": "2TE7",
+      "type": "hospital_satellite",
+      "name": "BOSTON CHILDREN'S AT PEABODY",
+      "address": "10 CENTENNIAL DR 1 & 2 FLS",
+  	  "city": "Peabody",
+      "city_zip": "01960",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BOSTON CHILDREN'S CL @333 LONGWOOD (24MS)" : {
+    "coordinates": [ -71.105432, 42.338491 ],
+    "properties": {
+      "DPHid": "24MS",
+      "type": "hospital_satellite",
+      "name": "BOSTON CHILDREN'S CL @333 LONGWOOD",
+      "address": "333 LONGWOOD AV-STS 520,550,65",
+  	  "city": "Boston",
+      "city_zip": "02115",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BOSTON MC RADIOLOGY @ UPHAMS CORNER (220L)" : {
+    "coordinates": [ -71.068682, 42.311921 ],
+    "properties": {
+      "DPHid": "220L",
+      "type": "hospital_satellite",
+      "name": "BOSTON MC RADIOLOGY @ UPHAMS CORNER",
+      "address": "415 COLUMBIA ROAD 1ST FLOOR",
+  	  "city": "Boston",
+      "city_zip": "02125",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BOSTON MED CTR RADIOLOGY @ MATTAPAN (2IDQ)" : {
+    "coordinates": [ -71.094062, 42.269799 ],
+    "properties": {
+      "DPHid": "2IDQ",
+      "type": "hospital_satellite",
+      "name": "BOSTON MED CTR RADIOLOGY @ MATTAPAN",
+      "address": "1575 BLUE HILL AVENUE 1ST FLOO",
+  	  "city": "Boston",
+      "city_zip": "02126",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BOSTON MED CTR RADIOLOGY @ WHITTIER (2IKH)" : {
+    "coordinates": [ -71.091928, 42.332772 ],
+    "properties": {
+      "DPHid": "2IKH",
+      "type": "hospital_satellite",
+      "name": "BOSTON MED CTR RADIOLOGY @ WHITTIER",
+      "address": "1290 TREMONT STREET SUITE 1F",
+  	  "city": "Boston",
+      "city_zip": "02120",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BOURNE HEALTH CENTER (2NC2)" : {
+    "coordinates": [ -70.597839, 41.740805 ],
+    "properties": {
+      "DPHid": "2NC2",
+      "type": "hospital_satellite",
+      "name": "BOURNE HEALTH CENTER",
+      "address": "1 TROWBRIDGE RD 1ST FL, SUITE",
+  	  "city": "Bourne",
+      "city_zip": "02532",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BOWDOIN STREET HEALTH CENTER (27L0)" : {
+    "coordinates": [ -71.06764, 42.305727 ],
+    "properties": {
+      "DPHid": "27L0",
+      "type": "hospital_satellite",
+      "name": "BOWDOIN STREET HEALTH CENTER",
+      "address": "230 BOWDOIN STREET",
+  	  "city": "Boston",
+      "city_zip": "02122",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BRIGHAM & WOMEN ADVANCED PRIMARY CA (2BL5)" : {
+    "coordinates": [ -71.112641, 42.324811 ],
+    "properties": {
+      "DPHid": "2BL5",
+      "type": "hospital_satellite",
+      "name": "BRIGHAM & WOMEN ADVANCED PRIMARY CA",
+      "address": "301 SOUTH HUNTINGTON AVE",
+  	  "city": "Boston",
+      "city_zip": "02130",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BRIGHAM & WOMEN BEHAV NEUROLOGY GRP (2X58)" : {
+    "coordinates": [ -71.106707, 42.336089 ],
+    "properties": {
+      "DPHid": "2X58",
+      "type": "hospital_satellite",
+      "name": "BRIGHAM & WOMEN BEHAV NEUROLOGY GRP",
+      "address": "221 LONGWOOD AVENUE RFB MEZZAN",
+  	  "city": "Boston",
+      "city_zip": "02115",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BRIGHAM & WOMEN HOSP OPT PSYCH SVC (2DSS)" : {
+    "coordinates": [ -71.102145, 42.337338 ],
+    "properties": {
+      "DPHid": "2DSS",
+      "type": "hospital_satellite",
+      "name": "BRIGHAM & WOMEN HOSP OPT PSYCH SVC",
+      "address": "221 LONGWOOD AVENUE BLI 4TH FL",
+  	  "city": "Boston",
+      "city_zip": "02115",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BRIGHAM & WOMEN IMMUNOLOGY LAB (2YBZ)" : {
+    "coordinates": [ -71.102144, 42.337286 ],
+    "properties": {
+      "DPHid": "2YBZ",
+      "type": "hospital_satellite",
+      "name": "BRIGHAM & WOMEN IMMUNOLOGY LAB",
+      "address": "221 LONGWOOD AVENUE SUITE BL-0",
+  	  "city": "Boston",
+      "city_zip": "02115",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BRIGHAM & WOMEN MRI @ W BRIDGEWATER (2HOA)" : {
+    "coordinates": [ -71.051793, 42.01215 ],
+    "properties": {
+      "DPHid": "2HOA",
+      "type": "hospital_satellite",
+      "name": "BRIGHAM & WOMEN MRI @ W BRIDGEWATER",
+      "address": "711 WEST CENTER STREET",
+  	  "city": "West bridgewater",
+      "city_zip": "02379",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BRIGHAM & WOMEN'S HEALTH CARE CTR (2L3K)" : {
+    "coordinates": [ -71.149664, 42.325946 ],
+    "properties": {
+      "DPHid": "2L3K",
+      "type": "hospital_satellite",
+      "name": "BRIGHAM & WOMEN'S HEALTH CARE CTR",
+      "address": "850 BOYLSTON STREET",
+  	  "city": "Brookline",
+      "city_zip": "02467",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BRIGHAM & WOMEN'S/MASS GEN HLT CARE (2W8L)" : {
+    "coordinates": [ -71.266114, 42.092778 ],
+    "properties": {
+      "DPHid": "2W8L",
+      "type": "hospital_satellite",
+      "name": "BRIGHAM & WOMEN'S/MASS GEN HLT CARE",
+      "address": "20 PATRIOT PLACE",
+  	  "city": "Foxborough",
+      "city_zip": "02035",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BRIGHAM DERMATOLOGY ASSOCIATES (2TKB)" : {
+    "coordinates": [ -71.102144, 42.337286 ],
+    "properties": {
+      "DPHid": "2TKB",
+      "type": "hospital_satellite",
+      "name": "BRIGHAM DERMATOLOGY ASSOCIATES",
+      "address": "221 LONGWOOD AVE 1ST FL STE RF",
+  	  "city": "Boston",
+      "city_zip": "02115",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BRIGHAM MRI RESEARCH CENTER (20YX)" : {
+    "coordinates": [ -71.102144, 42.337286 ],
+    "properties": {
+      "DPHid": "20YX",
+      "type": "hospital_satellite",
+      "name": "BRIGHAM MRI RESEARCH CENTER",
+      "address": "221 LONGWOOD AVENUE GROUND FLO",
+  	  "city": "Boston",
+      "city_zip": "02115",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BRIGHTON HS STUDENT HLTH CNTR (2MKB)" : {
+    "coordinates": [ -71.145516, 42.349138 ],
+    "properties": {
+      "DPHid": "2MKB",
+      "type": "hospital_satellite",
+      "name": "BRIGHTON HS STUDENT HLTH CNTR",
+      "address": "25 WARREN STREET 2ND FLOOR",
+  	  "city": "Boston",
+      "city_zip": "02135",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BRIGHTON MARINE HEALTH CENTER (2JXA)" : {
+    "coordinates": [ -71.274312, 42.457996 ],
+    "properties": {
+      "DPHid": "2JXA",
+      "type": "hospital_satellite",
+      "name": "BRIGHTON MARINE HEALTH CENTER",
+      "address": "HANSCOM AIR FORCE BSE 1609 EGL",
+  	  "city": "Bedford",
+      "city_zip": "01731",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BRIGHTON MARINE PUBLIC HEALTH CENTE (2T24)" : {
+    "coordinates": [ -71.142663, 42.348957 ],
+    "properties": {
+      "DPHid": "2T24",
+      "type": "hospital_satellite",
+      "name": "BRIGHTON MARINE PUBLIC HEALTH CENTE",
+      "address": "77 WARREN STREET",
+  	  "city": "Boston",
+      "city_zip": "02135",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BROCKTON HOSP OUTPATIENT CARE CTR (2FRO)" : {
+    "coordinates": [ -70.988735, 42.091125 ],
+    "properties": {
+      "DPHid": "2FRO",
+      "type": "hospital_satellite",
+      "name": "BROCKTON HOSP OUTPATIENT CARE CTR",
+      "address": "130 QUINCY STREET FIRST & SECO",
+  	  "city": "Brockton",
+      "city_zip": "02301",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BROOKSIDE COMMUNITY HEALTH CENTER (26XT)" : {
+    "coordinates": [ -71.10403, 42.310921 ],
+    "properties": {
+      "DPHid": "26XT",
+      "type": "hospital_satellite",
+      "name": "BROOKSIDE COMMUNITY HEALTH CENTER",
+      "address": "3297 WASHINGTON STREET",
+  	  "city": "Boston",
+      "city_zip": "02130",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "BWH CARE CENTRE AT 1153 CENTRE ST (2GLO)" : {
+    "coordinates": [ -71.128782, 42.301641 ],
+    "properties": {
+      "DPHid": "2GLO",
+      "type": "hospital_satellite",
+      "name": "BWH CARE CENTRE AT 1153 CENTRE ST",
+      "address": "1153 CENTRE STREET, 1ST FLOOR",
+  	  "city": "Boston",
+      "city_zip": "02130",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CANCER CARE CENTER @ HARRINGTON (2UTM)" : {
+    "coordinates": [ -72.043318, 42.078911 ],
+    "properties": {
+      "DPHid": "2UTM",
+      "type": "hospital_satellite",
+      "name": "CANCER CARE CENTER @ HARRINGTON",
+      "address": "55 SAYLE STREET, 2ND FLOOR",
+  	  "city": "Southbridge",
+      "city_zip": "01550",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CANCER CENTER @ BIDMC-NEEDHAM (2UKT)" : {
+    "coordinates": [ -71.236667, 42.277237 ],
+    "properties": {
+      "DPHid": "2UKT",
+      "type": "hospital_satellite",
+      "name": "CANCER CENTER @ BIDMC-NEEDHAM",
+      "address": "148 CHESTNUT STREET",
+  	  "city": "Needham",
+      "city_zip": "02492",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CAPE COD HOSP CARDIAC DIAG & REHAB (2WTJ)" : {
+    "coordinates": [ -70.271982, 41.656271 ],
+    "properties": {
+      "DPHid": "2WTJ",
+      "type": "hospital_satellite",
+      "name": "CAPE COD HOSP CARDIAC DIAG & REHAB",
+      "address": "25 MAIN STREET GRND FL",
+  	  "city": "Barnstable",
+      "city_zip": "02601",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CAPE COD HOSP IMAGING SR FONTAINE M (2G72)" : {
+    "coordinates": [ -70.037061, 41.722677 ],
+    "properties": {
+      "DPHid": "2G72",
+      "type": "hospital_satellite",
+      "name": "CAPE COD HOSP IMAGING SR FONTAINE M",
+      "address": "525 LONG POND DRIVE SUITE 200",
+  	  "city": "Harwich",
+      "city_zip": "02645",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CAPE COD HOSP MED SRVCS @905 ATTUCK (2XG7)" : {
+    "coordinates": [ -70.295491, 41.673461 ],
+    "properties": {
+      "DPHid": "2XG7",
+      "type": "hospital_satellite",
+      "name": "CAPE COD HOSP MED SRVCS @905 ATTUCK",
+      "address": "905 ATTUCKS LANE, 1ST FL SUITE",
+  	  "city": "Barnstable",
+      "city_zip": "02601",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CAPE COD HOSP MOBILE MRI @ FONTAINE (27SF)" : {
+    "coordinates": [ -70.037061, 41.722677 ],
+    "properties": {
+      "DPHid": "27SF",
+      "type": "hospital_satellite",
+      "name": "CAPE COD HOSP MOBILE MRI @ FONTAINE",
+      "address": "525 LONG POND DRIVE STE 700",
+  	  "city": "Harwich",
+      "city_zip": "02645",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CAPE COD HOSP OB/GYN CLINIC (2FNV)" : {
+    "coordinates": [ -70.27297, 41.652052 ],
+    "properties": {
+      "DPHid": "2FNV",
+      "type": "hospital_satellite",
+      "name": "CAPE COD HOSP OB/GYN CLINIC",
+      "address": "40 QUINLAN WAY SUITE 150",
+  	  "city": "Barnstable",
+      "city_zip": "02601",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CAPE COD HOSP PAIN CENTER (2OE1)" : {
+    "coordinates": [ -70.284993, 41.654024 ],
+    "properties": {
+      "DPHid": "2OE1",
+      "type": "hospital_satellite",
+      "name": "CAPE COD HOSP PAIN CENTER",
+      "address": "46 NORTH STREET SUITE 3",
+  	  "city": "Barnstable",
+      "city_zip": "02601",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CAPE COD HOSPITAL REHABILIATION CTR (2ZJ6)" : {
+    "coordinates": [ -69.995029, 41.786268 ],
+    "properties": {
+      "DPHid": "2ZJ6",
+      "type": "hospital_satellite",
+      "name": "CAPE COD HOSPITAL REHABILIATION CTR",
+      "address": "21 OLD COLONY WAY",
+  	  "city": "Orleans",
+      "city_zip": "02653",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CARDINAL CUSHING GENERAL HOSPITAL (29YZ)" : {
+    "coordinates": [ -70.914597, 41.894393 ],
+    "properties": {
+      "DPHid": "29YZ",
+      "type": "hospital_satellite",
+      "name": "CARDINAL CUSHING GENERAL HOSPITAL",
+      "address": "52 OAK STREET",
+  	  "city": "Middleborough",
+      "city_zip": "02346",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CENTER FOR REHAB & SPORTS THERAPIES (28GV)" : {
+    "coordinates": [ -71.389697, 42.460843 ],
+    "properties": {
+      "DPHid": "28GV",
+      "type": "hospital_satellite",
+      "name": "CENTER FOR REHAB & SPORTS THERAPIES",
+      "address": "310 BAKER AVENUE, 1ST FLOOR",
+  	  "city": "Concord",
+      "city_zip": "01742",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CHA ANNA MAY POWERS H C @KEV SCHOOL (27F9)" : {
+    "coordinates": [ -71.044814, 42.408922 ],
+    "properties": {
+      "DPHid": "27F9",
+      "type": "hospital_satellite",
+      "name": "CHA ANNA MAY POWERS H C @KEV SCHOOL",
+      "address": "HAMILTON SCHOOL 20 NICHOLS STR",
+  	  "city": "Everett",
+      "city_zip": "02149",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CHA ASSEMBLY SQUARE CARE CENTER (2ZFA)" : {
+    "coordinates": [ -71.082296, 42.391049 ],
+    "properties": {
+      "DPHid": "2ZFA",
+      "type": "hospital_satellite",
+      "name": "CHA ASSEMBLY SQUARE CARE CENTER",
+      "address": "5 MIDDLESEX AVENUE 1ST FL",
+  	  "city": "Somerville",
+      "city_zip": "02145",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CHA BROADWAY CARE CENTER (2GLN)" : {
+    "coordinates": [ -71.092871, 42.392272 ],
+    "properties": {
+      "DPHid": "2GLN",
+      "type": "hospital_satellite",
+      "name": "CHA BROADWAY CARE CENTER",
+      "address": "300 BROADWAY",
+  	  "city": "Somerville",
+      "city_zip": "02143",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CHA CAMBRIDGE BIRTH CENTER (2YBS)" : {
+    "coordinates": [ -71.105197, 42.374964 ],
+    "properties": {
+      "DPHid": "2YBS",
+      "type": "hospital_satellite",
+      "name": "CHA CAMBRIDGE BIRTH CENTER",
+      "address": "10 CAMELIA AVENUE",
+  	  "city": "Cambridge",
+      "city_zip": "02139",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CHA CAMBRIDGE FAMILY HEALTH NORTH (210E)" : {
+    "coordinates": [ -71.12309, 42.391372 ],
+    "properties": {
+      "DPHid": "210E",
+      "type": "hospital_satellite",
+      "name": "CHA CAMBRIDGE FAMILY HEALTH NORTH",
+      "address": "2067 MASSACHUSETTS AVENUE",
+  	  "city": "Cambridge",
+      "city_zip": "02139",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CHA CENTRAL STREET CARE CENTER (2L29)" : {
+    "coordinates": [ -71.105934, 42.384916 ],
+    "properties": {
+      "DPHid": "2L29",
+      "type": "hospital_satellite",
+      "name": "CHA CENTRAL STREET CARE CENTER",
+      "address": "26 CENTRAL ST 1ST,3RD & 4TH FL",
+  	  "city": "Somerville",
+      "city_zip": "02143",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CHA EAST CAMBRIDGE CARE CENTER (20XX)" : {
+    "coordinates": [ -71.085405, 42.373056 ],
+    "properties": {
+      "DPHid": "20XX",
+      "type": "hospital_satellite",
+      "name": "CHA EAST CAMBRIDGE CARE CENTER",
+      "address": "163 GORE STREET",
+  	  "city": "Cambridge",
+      "city_zip": "02141",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CHA EVERETT CARE CENTER (26SU)" : {
+    "coordinates": [ -71.056503, 42.405415 ],
+    "properties": {
+      "DPHid": "26SU",
+      "type": "hospital_satellite",
+      "name": "CHA EVERETT CARE CENTER",
+      "address": "391 BROADWAY SUITES 201&204",
+  	  "city": "Everett",
+      "city_zip": "02149",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CHA EVERETT TEEN CLINIC AT EHS (2S8D)" : {
+    "coordinates": [ -71.043709, 42.414432 ],
+    "properties": {
+      "DPHid": "2S8D",
+      "type": "hospital_satellite",
+      "name": "CHA EVERETT TEEN CLINIC AT EHS",
+      "address": "100 ELM STREET",
+  	  "city": "Everett",
+      "city_zip": "02149",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CHA HIGHLAND BLDG SOMERVILLE HOSP (2GNV)" : {
+    "coordinates": [ -71.10955, 42.389964 ],
+    "properties": {
+      "DPHid": "2GNV",
+      "type": "hospital_satellite",
+      "name": "CHA HIGHLAND BLDG SOMERVILLE HOSP",
+      "address": "236 HIGHLAND AVENUE 1ST & 2ND",
+  	  "city": "Somerville",
+      "city_zip": "02143",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CHA INMAN STREET CARE CENTER (2GOQ)" : {
+    "coordinates": [ -71.100886, 42.373999 ],
+    "properties": {
+      "DPHid": "2GOQ",
+      "type": "hospital_satellite",
+      "name": "CHA INMAN STREET CARE CENTER",
+      "address": "237 HAMPSHIRE ST 1ST FL",
+  	  "city": "Cambridge",
+      "city_zip": "02139",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CHA MALDEN CARE CENTER (2Y2R)" : {
+    "coordinates": [ -71.072778, 42.419924 ],
+    "properties": {
+      "DPHid": "2Y2R",
+      "type": "hospital_satellite",
+      "name": "CHA MALDEN CARE CENTER",
+      "address": "195 CANAL STREET",
+  	  "city": "Malden",
+      "city_zip": "02148",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CHA REVERE CARE CENTER (2WGF)" : {
+    "coordinates": [ -71.01182, 42.411422 ],
+    "properties": {
+      "DPHid": "2WGF",
+      "type": "hospital_satellite",
+      "name": "CHA REVERE CARE CENTER",
+      "address": "454 BROADWAY 1ST & 3RD FLOORS",
+  	  "city": "Revere",
+      "city_zip": "02151",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CHA TEEN CONNECTION AT SHS (24PK)" : {
+    "coordinates": [ -71.096972, 42.387202 ],
+    "properties": {
+      "DPHid": "24PK",
+      "type": "hospital_satellite",
+      "name": "CHA TEEN CONNECTION AT SHS",
+      "address": "81 HIGHLAND AVE 1ST FL",
+  	  "city": "Somerville",
+      "city_zip": "02143",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CHA TEEN HEALTH CENTER AT CRLS (2Y44)" : {
+    "coordinates": [ -71.110614, 42.374408 ],
+    "properties": {
+      "DPHid": "2Y44",
+      "type": "hospital_satellite",
+      "name": "CHA TEEN HEALTH CENTER AT CRLS",
+      "address": "459 BROADWAY",
+  	  "city": "Cambridge",
+      "city_zip": "02139",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CHA WINDSOR STREET CARE CENTER (2Z55)" : {
+    "coordinates": [ -71.096797, 42.364689 ],
+    "properties": {
+      "DPHid": "2Z55",
+      "type": "hospital_satellite",
+      "name": "CHA WINDSOR STREET CARE CENTER",
+      "address": "119 WINDSOR STREET",
+  	  "city": "Cambridge",
+      "city_zip": "02139",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CHA WOMEN'S IMAGING CTR EVERETT H C (263Z)" : {
+    "coordinates": [ -71.039215, 42.409697 ],
+    "properties": {
+      "DPHid": "263Z",
+      "type": "hospital_satellite",
+      "name": "CHA WOMEN'S IMAGING CTR EVERETT H C",
+      "address": "96 GARLAND STREET",
+  	  "city": "Everett",
+      "city_zip": "02149",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CHARLTON MOBILE SVCS (20CE)" : {
+    "coordinates": [ -71.145874, 41.709806 ],
+    "properties": {
+      "DPHid": "20CE",
+      "type": "hospital_satellite",
+      "name": "CHARLTON MOBILE SVCS",
+      "address": "363 HIGHLAND AVE",
+  	  "city": "Fall river",
+      "city_zip": "02720",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CHEM CENTER RADIATION ONCOL & MRI (2USI)" : {
+    "coordinates": [ -71.104661, 42.481733 ],
+    "properties": {
+      "DPHid": "2USI",
+      "type": "hospital_satellite",
+      "name": "CHEM CENTER RADIATION ONCOL & MRI",
+      "address": "48 MONTVALE AVE",
+  	  "city": "Stoneham",
+      "city_zip": "02180",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CLARK CENTER CAPE COD HEALTHCARE CA (2A71)" : {
+    "coordinates": [ -70.62169, 41.564186 ],
+    "properties": {
+      "DPHid": "2A71",
+      "type": "hospital_satellite",
+      "name": "CLARK CENTER CAPE COD HEALTHCARE CA",
+      "address": "90 TER HEUN DRIVE",
+  	  "city": "Falmouth",
+      "city_zip": "02540",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CODMAN SQUARE HEALTH CENTER (2X34)" : {
+    "coordinates": [ -71.072055, 42.289415 ],
+    "properties": {
+      "DPHid": "2X34",
+      "type": "hospital_satellite",
+      "name": "CODMAN SQUARE HEALTH CENTER",
+      "address": "637 WASHINGTON STREET",
+  	  "city": "Boston",
+      "city_zip": "02124",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "COMMUNITY COUNSELING SVCS MALDEN (2DJE)" : {
+    "coordinates": [ -71.087062, 42.429539 ],
+    "properties": {
+      "DPHid": "2DJE",
+      "type": "hospital_satellite",
+      "name": "COMMUNITY COUNSELING SVCS MALDEN",
+      "address": "178 SAVIN STREET 2ND FLOOR",
+  	  "city": "Malden",
+      "city_zip": "02148",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "COOLEY DCKNSN STH DEERFLD CTR RS&PT (2IQC)" : {
+    "coordinates": [ -72.611126, 42.477366 ],
+    "properties": {
+      "DPHid": "2IQC",
+      "type": "hospital_satellite",
+      "name": "COOLEY DCKNSN STH DEERFLD CTR RS&PT",
+      "address": "21B ELM STREET-1ST FLOOR",
+  	  "city": "Deerfield",
+      "city_zip": "01373",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "COOLEY DICKINSON HOSP REHAB SVCS (2AGB)" : {
+    "coordinates": [ -72.548647, 42.360321 ],
+    "properties": {
+      "DPHid": "2AGB",
+      "type": "hospital_satellite",
+      "name": "COOLEY DICKINSON HOSP REHAB SVCS",
+      "address": "380 RUSSELL STREET",
+  	  "city": "Hadley",
+      "city_zip": "01035",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "COOLEY DICKINSON HOSP REHAB SVCS (2FFG)" : {
+    "coordinates": [ -72.937799, 42.413408 ],
+    "properties": {
+      "DPHid": "2FFG",
+      "type": "hospital_satellite",
+      "name": "COOLEY DICKINSON HOSP REHAB SVCS",
+      "address": "58 OLD NORTH ROAD",
+  	  "city": "Worthington",
+      "city_zip": "01098",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "COOLEY DICKINSON HOSPITAL (29FP)" : {
+    "coordinates": [ -72.533502, 42.368227 ],
+    "properties": {
+      "DPHid": "29FP",
+      "type": "hospital_satellite",
+      "name": "COOLEY DICKINSON HOSPITAL",
+      "address": "170 UNIVERSITY DR STE105 LL 10",
+  	  "city": "Amherst",
+      "city_zip": "01002",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "COOLEY DICKINSON OUTPT CTR SOUTHAMP (2P46)" : {
+    "coordinates": [ -72.699003, 42.253495 ],
+    "properties": {
+      "DPHid": "2P46",
+      "type": "hospital_satellite",
+      "name": "COOLEY DICKINSON OUTPT CTR SOUTHAMP",
+      "address": "10 COLLEGE HIGHWAY",
+  	  "city": "Southampton",
+      "city_zip": "01073",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "COOLEY DICKNSN HOSP OUTPT DIAGNOSTI (2A6I)" : {
+    "coordinates": [ -72.62436, 42.303117 ],
+    "properties": {
+      "DPHid": "2A6I",
+      "type": "hospital_satellite",
+      "name": "COOLEY DICKNSN HOSP OUTPT DIAGNOSTI",
+      "address": "22 ATWOOD DRIVE 1FL",
+  	  "city": "Northampton",
+      "city_zip": "01060",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "COOLEY DICKNSN HOSP PHYSICAL THERAP (2RUO)" : {
+    "coordinates": [ -72.637285, 42.366367 ],
+    "properties": {
+      "DPHid": "2RUO",
+      "type": "hospital_satellite",
+      "name": "COOLEY DICKNSN HOSP PHYSICAL THERAP",
+      "address": "4 WEST STREET 2FL",
+  	  "city": "Hatfield",
+      "city_zip": "01088",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "COOLEY DICKNSN HOSP PHYSICAL THERAP (24NP)" : {
+    "coordinates": [ -72.622795, 42.303124 ],
+    "properties": {
+      "DPHid": "24NP",
+      "type": "hospital_satellite",
+      "name": "COOLEY DICKNSN HOSP PHYSICAL THERAP",
+      "address": "8 ATWOOD DRIVE 1FL",
+  	  "city": "Northampton",
+      "city_zip": "01060",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CRANE CENTER FOR AMBULATORY SURGERY (2GZW)" : {
+    "coordinates": [ -73.250671, 42.459367 ],
+    "properties": {
+      "DPHid": "2GZW",
+      "type": "hospital_satellite",
+      "name": "CRANE CENTER FOR AMBULATORY SURGERY",
+      "address": "24 PARK STREET 2ND FL",
+  	  "city": "Pittsfield",
+      "city_zip": "01201",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CTR ORTHOPEDICS, SPINE & SPORTS MED (2WS4)" : {
+    "coordinates": [ -70.919004, 42.177087 ],
+    "properties": {
+      "DPHid": "2WS4",
+      "type": "hospital_satellite",
+      "name": "CTR ORTHOPEDICS, SPINE & SPORTS MED",
+      "address": "2 POND PARK ROAD",
+  	  "city": "Hingham",
+      "city_zip": "02043",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "CTR WOUND HEALING & DIABETES CARE (2W77)" : {
+    "coordinates": [ -71.236895, 42.288946 ],
+    "properties": {
+      "DPHid": "2W77",
+      "type": "hospital_satellite",
+      "name": "CTR WOUND HEALING & DIABETES CARE",
+      "address": "145 ROSEMARY STREET 1FL SUITE",
+  	  "city": "Needham",
+      "city_zip": "02494",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "D'AMOUR CENTER FOR CANCER CARE (2765)" : {
+    "coordinates": [ -72.610462, 42.123851 ],
+    "properties": {
+      "DPHid": "2765",
+      "type": "hospital_satellite",
+      "name": "D'AMOUR CENTER FOR CANCER CARE",
+      "address": "3350 MAIN STREET",
+  	  "city": "Springfield",
+      "city_zip": "01199",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "DANA FARBER CANCER @ SOUTH SHORE HS (21VY)" : {
+    "coordinates": [ -70.954939, 42.177198 ],
+    "properties": {
+      "DPHid": "21VY",
+      "type": "hospital_satellite",
+      "name": "DANA FARBER CANCER @ SOUTH SHORE HS",
+      "address": "101 COLUMBIAN ST STE #L01, 202",
+  	  "city": "Weymouth",
+      "city_zip": "02190",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "DANA FARBER CANCER CTR @ MILFORD RE (2RRC)" : {
+    "coordinates": [ -71.530105, 42.13291 ],
+    "properties": {
+      "DPHid": "2RRC",
+      "type": "hospital_satellite",
+      "name": "DANA FARBER CANCER CTR @ MILFORD RE",
+      "address": "20 PROSPECT STREET 2ND FLOOR",
+  	  "city": "Milford",
+      "city_zip": "01757",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "DANA FARBER CANCER INST @ LIBBEY PK (2KVO)" : {
+    "coordinates": [ -70.943346, 42.194696 ],
+    "properties": {
+      "DPHid": "2KVO",
+      "type": "hospital_satellite",
+      "name": "DANA FARBER CANCER INST @ LIBBEY PK",
+      "address": "51 PERFORMANCE DRIVE SUITE 103",
+  	  "city": "Weymouth",
+      "city_zip": "02189",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "DANA FARBER CNCR INST @ST ELIZABETH (2KHK)" : {
+    "coordinates": [ -71.151348, 42.374974 ],
+    "properties": {
+      "DPHid": "2KHK",
+      "type": "hospital_satellite",
+      "name": "DANA FARBER CNCR INST @ST ELIZABETH",
+      "address": "736 CAMBRIDGE STREET CUSHING 5",
+  	  "city": "Boston",
+      "city_zip": "02135",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "DANA FARBR CNCR INST @WHITTIER ST H (2KP6)" : {
+    "coordinates": [ -71.091928, 42.332772 ],
+    "properties": {
+      "DPHid": "2KP6",
+      "type": "hospital_satellite",
+      "name": "DANA FARBR CNCR INST @WHITTIER ST H",
+      "address": "1290 TREMONT STREET SUITE 1B",
+  	  "city": "Boston",
+      "city_zip": "02120",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "DFCI-MOBILE MAMMOGRAPHY SERVICE (2OMJ)" : {
+    "coordinates": [ -71.107327, 42.337689 ],
+    "properties": {
+      "DPHid": "2OMJ",
+      "type": "hospital_satellite",
+      "name": "DFCI-MOBILE MAMMOGRAPHY SERVICE",
+      "address": "44 BINNEY STREET",
+  	  "city": "Boston",
+      "city_zip": "02115",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "DIAGNOSTIC FACILITY @ PEARL MED CTR (2F33)" : {
+    "coordinates": [ -71.064808, 42.088916 ],
+    "properties": {
+      "DPHid": "2F33",
+      "type": "hospital_satellite",
+      "name": "DIAGNOSTIC FACILITY @ PEARL MED CTR",
+      "address": "1 PEARL STREET STE 0100 & 0200",
+  	  "city": "Brockton",
+      "city_zip": "02301",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "DIAGNOSTIC IMAGING SVCS @ PENTUCKET (2AI2)" : {
+    "coordinates": [ -71.077788, 42.776009 ],
+    "properties": {
+      "DPHid": "2AI2",
+      "type": "hospital_satellite",
+      "name": "DIAGNOSTIC IMAGING SVCS @ PENTUCKET",
+      "address": "ONE PARKWAY",
+  	  "city": "Haverhill",
+      "city_zip": "01830",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "DOTHOUSE HEALTH INC (2NW7)" : {
+    "coordinates": [ -71.059419, 42.304507 ],
+    "properties": {
+      "DPHid": "2NW7",
+      "type": "hospital_satellite",
+      "name": "DOTHOUSE HEALTH INC",
+      "address": "1353 DORCHESTER AVE.",
+  	  "city": "Boston",
+      "city_zip": "02122",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "DR ANTHONY N ELIAS SBHC @ BEN FRIED (2W3K)" : {
+    "coordinates": [ -71.135536, 41.920944 ],
+    "properties": {
+      "DPHid": "2W3K",
+      "type": "hospital_satellite",
+      "name": "DR ANTHONY N ELIAS SBHC @ BEN FRIED",
+      "address": "500 NORTON AVENUE",
+  	  "city": "Taunton",
+      "city_zip": "02780",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "EAST BOSTON NEIGHBORHOOD HC 20 MAVE (2VFP)" : {
+    "coordinates": [ -71.039564, 42.36972 ],
+    "properties": {
+      "DPHid": "2VFP",
+      "type": "hospital_satellite",
+      "name": "EAST BOSTON NEIGHBORHOOD HC 20 MAVE",
+      "address": "20 MAVERICK SQUARE",
+  	  "city": "Boston",
+      "city_zip": "02128",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "EAST BOSTON NEIGHBORHOOD HLTH CTR (21ZC)" : {
+    "coordinates": [ -71.038549, 42.371589 ],
+    "properties": {
+      "DPHid": "21ZC",
+      "type": "hospital_satellite",
+      "name": "EAST BOSTON NEIGHBORHOOD HLTH CTR",
+      "address": "79 PARIS STREET",
+  	  "city": "Boston",
+      "city_zip": "02128",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "EBHS SCHOOL BASED HEALTH CENTER (29HS)" : {
+    "coordinates": [ -71.035074, 42.381099 ],
+    "properties": {
+      "DPHid": "29HS",
+      "type": "hospital_satellite",
+      "name": "EBHS SCHOOL BASED HEALTH CENTER",
+      "address": "86 WHITE STREET",
+  	  "city": "Boston",
+      "city_zip": "02128",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "EMERSON HOSP MGH RADIATION ONCOL PR (2DGQ)" : {
+    "coordinates": [ -71.37543, 42.452191 ],
+    "properties": {
+      "DPHid": "2DGQ",
+      "type": "hospital_satellite",
+      "name": "EMERSON HOSP MGH RADIATION ONCOL PR",
+      "address": "ROUTE 2 JOHN CUMINGS BLDG",
+  	  "city": "Concord",
+      "city_zip": "01742",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "EMERSON HOSPITAL BREAST CARE CENTER (2F0Y)" : {
+    "coordinates": [ -71.879795, 44.435261 ],
+    "properties": {
+      "DPHid": "2F0Y",
+      "type": "hospital_satellite",
+      "name": "EMERSON HOSPITAL BREAST CARE CENTER",
+      "address": "747 MAIN STREET GROUND FLOOR",
+  	  "city": "Concord",
+      "city_zip": "01742",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "EMERSON HOSPITAL HEALTH CENTER (2EJ8)" : {
+    "coordinates": [ -71.561293, 42.597387 ],
+    "properties": {
+      "DPHid": "2EJ8",
+      "type": "hospital_satellite",
+      "name": "EMERSON HOSPITAL HEALTH CENTER",
+      "address": "100 BOSTON RD 1ST FL STE B",
+  	  "city": "Groton",
+      "city_zip": "01450",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "EMERSON HOSPITAL HEALTH CENTER (2TNZ)" : {
+    "coordinates": [ -71.417453, 42.570502 ],
+    "properties": {
+      "DPHid": "2TNZ",
+      "type": "hospital_satellite",
+      "name": "EMERSON HOSPITAL HEALTH CENTER",
+      "address": "133 LITTLETON RD 3RD FLOOR",
+  	  "city": "Westford",
+      "city_zip": "01886",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "EMERSON HOSPITAL OUTPATIENT SERVICE (2OFT)" : {
+    "coordinates": [ -71.375302, 42.452255 ],
+    "properties": {
+      "DPHid": "2OFT",
+      "type": "hospital_satellite",
+      "name": "EMERSON HOSPITAL OUTPATIENT SERVICE",
+      "address": "131 OLD RD-9 ACRE CRNR-J CUMIN",
+  	  "city": "Concord",
+      "city_zip": "01742",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "EMERSON MEDICAL AT SUDBURY (2KIH)" : {
+    "coordinates": [ -71.428894, 42.360849 ],
+    "properties": {
+      "DPHid": "2KIH",
+      "type": "hospital_satellite",
+      "name": "EMERSON MEDICAL AT SUDBURY",
+      "address": "490 BOSTON POST ROAD FIRST FLO",
+  	  "city": "Sudbury",
+      "city_zip": "01776",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "EMERSON MEDICAL SPECIALTY CENTER (274N)" : {
+    "coordinates": [ -71.385267, 42.460753 ],
+    "properties": {
+      "DPHid": "274N",
+      "type": "hospital_satellite",
+      "name": "EMERSON MEDICAL SPECIALTY CENTER",
+      "address": "54 BAKER AVENUE EXTENSION",
+  	  "city": "Concord",
+      "city_zip": "01742",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "EMPLOYEE HEALTH SERVICES & PT/OT CL (2M2I)" : {
+    "coordinates": [ -71.117599, 41.958459 ],
+    "properties": {
+      "DPHid": "2M2I",
+      "type": "hospital_satellite",
+      "name": "EMPLOYEE HEALTH SERVICES & PT/OT CL",
+      "address": "2005 BAY STREET SUITE 200B",
+  	  "city": "Taunton",
+      "city_zip": "02780",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "FAIRVIEW HOSP MEDICAL OFFICE BLDG (2EWC)" : {
+    "coordinates": [ -73.372268, 42.191833 ],
+    "properties": {
+      "DPHid": "2EWC",
+      "type": "hospital_satellite",
+      "name": "FAIRVIEW HOSP MEDICAL OFFICE BLDG",
+      "address": "27 LEWIS AVENUE",
+  	  "city": "Great barrington",
+      "city_zip": "01230",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "FAIRVIEW HOSPITAL AQUATIC THX PROG (2FJL)" : {
+    "coordinates": [ -73.341032, 42.212266 ],
+    "properties": {
+      "DPHid": "2FJL",
+      "type": "hospital_satellite",
+      "name": "FAIRVIEW HOSPITAL AQUATIC THX PROG",
+      "address": "15 CHRISSEY ROAD",
+  	  "city": "Great barrington",
+      "city_zip": "01230",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "FAIRVIEW HOSPITAL OPT PT & REHAB (2RVT)" : {
+    "coordinates": [ -73.365781, 42.18914 ],
+    "properties": {
+      "DPHid": "2RVT",
+      "type": "hospital_satellite",
+      "name": "FAIRVIEW HOSPITAL OPT PT & REHAB",
+      "address": "10 MAPLE STREET, 1ST  FL STE 1",
+  	  "city": "Great barrington",
+      "city_zip": "01230",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "FAIRVIEW PHYSICAL SPORTS THERAPY CT (2X7L)" : {
+    "coordinates": [ -73.282425, 42.291626 ],
+    "properties": {
+      "DPHid": "2X7L",
+      "type": "hospital_satellite",
+      "name": "FAIRVIEW PHYSICAL SPORTS THERAPY CT",
+      "address": "710 STOCKBRIDGE ROAD",
+  	  "city": "Lee",
+      "city_zip": "01238",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "FALMOUTH HOSP DIAG IMGING @ STONEMA (2RPE)" : {
+    "coordinates": [ -70.488008, 41.717413 ],
+    "properties": {
+      "DPHid": "2RPE",
+      "type": "hospital_satellite",
+      "name": "FALMOUTH HOSP DIAG IMGING @ STONEMA",
+      "address": "2 JAN SEBASTIAN WAY 1ST FL STE",
+  	  "city": "Sandwich",
+      "city_zip": "02563",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "FALMOUTH HOSP IMAGING @ NO FALMOUTH (26CH)" : {
+    "coordinates": [ -70.612597, 41.64129 ],
+    "properties": {
+      "DPHid": "26CH",
+      "type": "hospital_satellite",
+      "name": "FALMOUTH HOSP IMAGING @ NO FALMOUTH",
+      "address": "26 EDGERTON DRIVE",
+  	  "city": "Falmouth",
+      "city_zip": "02556",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "FALMOUTH HOSP IMAGING @CHC CAPE COD (2VI9)" : {
+    "coordinates": [ -70.490841, 41.607378 ],
+    "properties": {
+      "DPHid": "2VI9",
+      "type": "hospital_satellite",
+      "name": "FALMOUTH HOSP IMAGING @CHC CAPE COD",
+      "address": "107 COMMERCIAL STREET",
+  	  "city": "Mashpee",
+      "city_zip": "02649",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "FALMOUTH HOSPITAL OUTPT SURGERY CTR (2OBP)" : {
+    "coordinates": [ -70.611684, 41.640017 ],
+    "properties": {
+      "DPHid": "2OBP",
+      "type": "hospital_satellite",
+      "name": "FALMOUTH HOSPITAL OUTPT SURGERY CTR",
+      "address": "39 EDGERTON DRIVE SUITE A",
+  	  "city": "Falmouth",
+      "city_zip": "02556",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "FALMOUTH HOSPITAL REHABILTATN SVCS (2I68)" : {
+    "coordinates": [ -70.622237, 41.564309 ],
+    "properties": {
+      "DPHid": "2I68",
+      "type": "hospital_satellite",
+      "name": "FALMOUTH HOSPITAL REHABILTATN SVCS",
+      "address": "90 TER HUEN DR FIRST FL SUITE",
+  	  "city": "Falmouth",
+      "city_zip": "02540",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "FAMILY MEDICAL ASSOCIATES (2TA4)" : {
+    "coordinates": [ -71.11116, 42.416016 ],
+    "properties": {
+      "DPHid": "2TA4",
+      "type": "hospital_satellite",
+      "name": "FAMILY MEDICAL ASSOCIATES",
+      "address": "SOUTHSIDE PL 101 MAIN ST STE21",
+  	  "city": "Medford",
+      "city_zip": "02155",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "FOXBORO (299F)" : {
+    "coordinates": [ -71.239396, 42.051412 ],
+    "properties": {
+      "DPHid": "299F",
+      "type": "hospital_satellite",
+      "name": "FOXBORO",
+      "address": "70 WALNUT STREET",
+  	  "city": "Foxborough",
+      "city_zip": "02035",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "FRANKLIN RADIOLOGY CENTER (2RXQ)" : {
+    "coordinates": [ -71.37807, 42.079302 ],
+    "properties": {
+      "DPHid": "2RXQ",
+      "type": "hospital_satellite",
+      "name": "FRANKLIN RADIOLOGY CENTER",
+      "address": "440 EAST CENTRAL ST 1ST FL STE",
+  	  "city": "Franklin",
+      "city_zip": "02038",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "GEORGE B WELLS HUMAN SRVS CTR-E BRO (2IL3)" : {
+    "coordinates": [ -72.040609, 42.227691 ],
+    "properties": {
+      "DPHid": "2IL3",
+      "type": "hospital_satellite",
+      "name": "GEORGE B WELLS HUMAN SRVS CTR-E BRO",
+      "address": "367 EAST MAIN STREET",
+  	  "city": "East brookfield",
+      "city_zip": "01515",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "GLOUCESTER HS STUDENT HEALTH CENTER (2TLD)" : {
+    "coordinates": [ -70.676198, 42.613403 ],
+    "properties": {
+      "DPHid": "2TLD",
+      "type": "hospital_satellite",
+      "name": "GLOUCESTER HS STUDENT HEALTH CENTER",
+      "address": "32 LESLIE O'JOHNSON RD 1STFL R",
+  	  "city": "Gloucester",
+      "city_zip": "01930",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "GOOD SAMARITAN M C @ BROCKTON NEIGH (21UA)" : {
+    "coordinates": [ -71.020169, 42.084495 ],
+    "properties": {
+      "DPHid": "21UA",
+      "type": "hospital_satellite",
+      "name": "GOOD SAMARITAN M C @ BROCKTON NEIGH",
+      "address": "63 MAIN STREET",
+  	  "city": "Brockton",
+      "city_zip": "02301",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "GOOD SAMARITAN M C CARDIAC TESTING (2AED)" : {
+    "coordinates": [ -71.060768, 42.098784 ],
+    "properties": {
+      "DPHid": "2AED",
+      "type": "hospital_satellite",
+      "name": "GOOD SAMARITAN M C CARDIAC TESTING",
+      "address": "830 OAK STREET SUITE 205W",
+  	  "city": "Brockton",
+      "city_zip": "02301",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "GOOD SAMARITAN M C E BRDGEWATER MRI (2ZWX)" : {
+    "coordinates": [ -70.956836, 42.045677 ],
+    "properties": {
+      "DPHid": "2ZWX",
+      "type": "hospital_satellite",
+      "name": "GOOD SAMARITAN M C E BRDGEWATER MRI",
+      "address": "1 COMPASS WAY SUITE 108",
+  	  "city": "East bridgewater",
+      "city_zip": "02333",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "GOOD SAMARITAN M C THE GODDARD CTR (2101)" : {
+    "coordinates": [ -71.08182, 42.100619 ],
+    "properties": {
+      "DPHid": "2101",
+      "type": "hospital_satellite",
+      "name": "GOOD SAMARITAN M C THE GODDARD CTR",
+      "address": "909 SUMNER STREET, 2ND FLOOR",
+  	  "city": "Stoughton",
+      "city_zip": "02072",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "GOOD SAMARITAN NORTH EASTON SURG CT (2YKZ)" : {
+    "coordinates": [ -71.094714, 42.089731 ],
+    "properties": {
+      "DPHid": "2YKZ",
+      "type": "hospital_satellite",
+      "name": "GOOD SAMARITAN NORTH EASTON SURG CT",
+      "address": "15 ROCHE BROTHERS WAY SUITE 21",
+  	  "city": "Easton",
+      "city_zip": "02356",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "GREATER ROSLINDALE MED & DENTAL (2LXF)" : {
+    "coordinates": [ -71.12806, 42.287192 ],
+    "properties": {
+      "DPHid": "2LXF",
+      "type": "hospital_satellite",
+      "name": "GREATER ROSLINDALE MED & DENTAL",
+      "address": "4199 WASHINGTON STREET",
+  	  "city": "Boston",
+      "city_zip": "02131",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "GUILD IMAGING CTR OF NORWOOD HOSP (2E7Z)" : {
+    "coordinates": [ -71.203985, 42.188651 ],
+    "properties": {
+      "DPHid": "2E7Z",
+      "type": "hospital_satellite",
+      "name": "GUILD IMAGING CTR OF NORWOOD HOSP",
+      "address": "825 WASHINGTON STREET SUITE 17",
+  	  "city": "Norwood",
+      "city_zip": "02062",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HAHNEMANN FAMILY HLTH CTR (2F2G)" : {
+    "coordinates": [ -71.792662, 42.281743 ],
+    "properties": {
+      "DPHid": "2F2G",
+      "type": "hospital_satellite",
+      "name": "HAHNEMANN FAMILY HLTH CTR",
+      "address": "197 LINCOLN ST",
+  	  "city": "Worcester",
+      "city_zip": "01605",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HALLMARK HEALTH OUTPATIENT DIAGNOST (2K0Y)" : {
+    "coordinates": [ -71.095089, 42.517882 ],
+    "properties": {
+      "DPHid": "2K0Y",
+      "type": "hospital_satellite",
+      "name": "HALLMARK HEALTH OUTPATIENT DIAGNOST",
+      "address": "30 NEWCROSSING ROAD",
+  	  "city": "Reading",
+      "city_zip": "01867",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HALLMARK HLTH HEMATOLOGY ONCOLOGY C (2O84)" : {
+    "coordinates": [ -71.103829, 42.482571 ],
+    "properties": {
+      "DPHid": "2O84",
+      "type": "hospital_satellite",
+      "name": "HALLMARK HLTH HEMATOLOGY ONCOLOGY C",
+      "address": "41 MONTVALE AVENUE 4TH FL STE",
+  	  "city": "Stoneham",
+      "city_zip": "02180",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HALLMARK HLTH S COMM COUNSELING SVC (2ROL)" : {
+    "coordinates": [ -71.11126, 42.41598 ],
+    "properties": {
+      "DPHid": "2ROL",
+      "type": "hospital_satellite",
+      "name": "HALLMARK HLTH S COMM COUNSELING SVC",
+      "address": "101 MAIN STREET 1ST FL SUITE 1",
+  	  "city": "Medford",
+      "city_zip": "02155",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HARRINGTON BEHAVIORAL HLTH @ DUDLEY (2LNQ)" : {
+    "coordinates": [ -71.908774, 42.041824 ],
+    "properties": {
+      "DPHid": "2LNQ",
+      "type": "hospital_satellite",
+      "name": "HARRINGTON BEHAVIORAL HLTH @ DUDLEY",
+      "address": "171 WEST MAIN STREET FLS 1&2",
+  	  "city": "Dudley",
+      "city_zip": "01571",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HARRINGTON HEALTH CARE @ CHARLTON (2XUY)" : {
+    "coordinates": [ -71.969928, 42.143884 ],
+    "properties": {
+      "DPHid": "2XUY",
+      "type": "hospital_satellite",
+      "name": "HARRINGTON HEALTH CARE @ CHARLTON",
+      "address": "10 NORTH MAIN STREET SUITE 100",
+  	  "city": "Charlton",
+      "city_zip": "01507",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HARRINGTON HEALTHCARE @R169 REHB SV (22L4)" : {
+    "coordinates": [ -71.997204, 42.141156 ],
+    "properties": {
+      "DPHid": "22L4",
+      "type": "hospital_satellite",
+      "name": "HARRINGTON HEALTHCARE @R169 REHB SV",
+      "address": "20 SOUTHBRIDGE ROAD",
+  	  "city": "Charlton",
+      "city_zip": "01507",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HARRINGTON HEALTHCARE AT HUBBARD (2H4R)" : {
+    "coordinates": [ -71.862659, 42.078201 ],
+    "properties": {
+      "DPHid": "2H4R",
+      "type": "hospital_satellite",
+      "name": "HARRINGTON HEALTHCARE AT HUBBARD",
+      "address": "72 CUDWORTH ROAD",
+  	  "city": "Webster",
+      "city_zip": "01570",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HARRINGTON HEALTHCARE AT SPENCER (2WBB)" : {
+    "coordinates": [ -72.023084, 42.231647 ],
+    "properties": {
+      "DPHid": "2WBB",
+      "type": "hospital_satellite",
+      "name": "HARRINGTON HEALTHCARE AT SPENCER",
+      "address": "118 WEST MAIN STREET",
+  	  "city": "Spencer",
+      "city_zip": "01562",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HARRINGTON HOSP BEHAV HLTH SERVICES (2YWR)" : {
+    "coordinates": [ -72.037874, 42.080497 ],
+    "properties": {
+      "DPHid": "2YWR",
+      "type": "hospital_satellite",
+      "name": "HARRINGTON HOSP BEHAV HLTH SERVICES",
+      "address": "29 PINE STREET",
+  	  "city": "Southbridge",
+      "city_zip": "01550",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HARRINGTON MEM HOSP OHS COMPRECARE (2O2X)" : {
+    "coordinates": [ -72.040965, 42.078415 ],
+    "properties": {
+      "DPHid": "2O2X",
+      "type": "hospital_satellite",
+      "name": "HARRINGTON MEM HOSP OHS COMPRECARE",
+      "address": "32 OAKES AVENUE 1ST FLR",
+  	  "city": "Southbridge",
+      "city_zip": "01550",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HARRINGTON MEM HSP HARRI SPCLTY SVS (2UR1)" : {
+    "coordinates": [ -71.85041, 42.028357 ],
+    "properties": {
+      "DPHid": "2UR1",
+      "type": "hospital_satellite",
+      "name": "HARRINGTON MEM HSP HARRI SPCLTY SVS",
+      "address": "336 THOMPSON ROAD",
+  	  "city": "Webster",
+      "city_zip": "01570",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HEALTHALLIANCE FITCHBURG FAMILY PRC (2DJY)" : {
+    "coordinates": [ -71.807689, 42.597331 ],
+    "properties": {
+      "DPHid": "2DJY",
+      "type": "hospital_satellite",
+      "name": "HEALTHALLIANCE FITCHBURG FAMILY PRC",
+      "address": "326 NICHOLS ROAD",
+  	  "city": "Fitchburg",
+      "city_zip": "01420",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HEALTHALLIANCE HOSP-BURBANK CAMPUS (2034)" : {
+    "coordinates": [ -71.805688, 42.597646 ],
+    "properties": {
+      "DPHid": "2034",
+      "type": "hospital_satellite",
+      "name": "HEALTHALLIANCE HOSP-BURBANK CAMPUS",
+      "address": "275 NICHOLS ROAD",
+  	  "city": "Fitchburg",
+      "city_zip": "01420",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HEALTHIMAGE WOMEN'S IMAGING CENTER (2KAB)" : {
+    "coordinates": [ -71.065609, 42.455009 ],
+    "properties": {
+      "DPHid": "2KAB",
+      "type": "hospital_satellite",
+      "name": "HEALTHIMAGE WOMEN'S IMAGING CENTER",
+      "address": "830 MAIN STREET THIRD FLOOR",
+  	  "city": "Melrose",
+      "city_zip": "02176",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HEALTHSOUTH BRAINTREE OCC HLTH & RE (2MMD)" : {
+    "coordinates": [ -71.029655, 42.200356 ],
+    "properties": {
+      "DPHid": "2MMD",
+      "type": "hospital_satellite",
+      "name": "HEALTHSOUTH BRAINTREE OCC HLTH & RE",
+      "address": "100 BAY STATE DRIVE 1ST FLR",
+  	  "city": "Braintree",
+      "city_zip": "02184",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HEALTHSOUTH BRAINTREE REH @PLYMOUTH (2II7)" : {
+    "coordinates": [ -70.689251, 41.978893 ],
+    "properties": {
+      "DPHid": "2II7",
+      "type": "hospital_satellite",
+      "name": "HEALTHSOUTH BRAINTREE REH @PLYMOUTH",
+      "address": "65 CORTAGE PARK CIRCLE, STE 10",
+  	  "city": "Plymouth",
+      "city_zip": "02360",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HEALTHSOUTH BRAINTREE REH @TAUNTON (2OUK)" : {
+    "coordinates": [ -71.0694, 41.906427 ],
+    "properties": {
+      "DPHid": "2OUK",
+      "type": "hospital_satellite",
+      "name": "HEALTHSOUTH BRAINTREE REH @TAUNTON",
+      "address": "CUTTER PLACE 152 DEAN STREET",
+  	  "city": "Taunton",
+      "city_zip": "02780",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HEALTHSOUTH BRAINTREE REH OUTPT@LYN (2XZR)" : {
+    "coordinates": [ -71.034106, 42.512047 ],
+    "properties": {
+      "DPHid": "2XZR",
+      "type": "hospital_satellite",
+      "name": "HEALTHSOUTH BRAINTREE REH OUTPT@LYN",
+      "address": "50 SALEM STREET",
+  	  "city": "Lynnfield",
+      "city_zip": "01940",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HEALTHSOUTH BRAINTREE REH PEDI CTR (2JI4)" : {
+    "coordinates": [ -71.022713, 42.205338 ],
+    "properties": {
+      "DPHid": "2JI4",
+      "type": "hospital_satellite",
+      "name": "HEALTHSOUTH BRAINTREE REH PEDI CTR",
+      "address": "751 GRANITE STREET",
+  	  "city": "Braintree",
+      "city_zip": "02184",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HEALTHSOUTH NEW ENGLAND REH @BILLER (2E3P)" : {
+    "coordinates": [ -71.283493, 42.575111 ],
+    "properties": {
+      "DPHid": "2E3P",
+      "type": "hospital_satellite",
+      "name": "HEALTHSOUTH NEW ENGLAND REH @BILLER",
+      "address": "267 BOSTON ROAD",
+  	  "city": "Billerica",
+      "city_zip": "01862",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HEALTHSOUTH NEW ENGLAND REH @FRAMIN (20LF)" : {
+    "coordinates": [ -71.441925, 42.298826 ],
+    "properties": {
+      "DPHid": "20LF",
+      "type": "hospital_satellite",
+      "name": "HEALTHSOUTH NEW ENGLAND REH @FRAMIN",
+      "address": "1094 WORCESTER ROAD",
+  	  "city": "Framingham",
+      "city_zip": "01702",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HEBREW SENIORLIFE MED GRP @ CTR CMT (2OJ1)" : {
+    "coordinates": [ -71.126676, 42.343526 ],
+    "properties": {
+      "DPHid": "2OJ1",
+      "type": "hospital_satellite",
+      "name": "HEBREW SENIORLIFE MED GRP @ CTR CMT",
+      "address": "100 CENTRE STREET",
+  	  "city": "Brookline",
+      "city_zip": "02446",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HEBREW SENIORLIFE MED GRP @ ORCHARD (2K4N)" : {
+    "coordinates": [ -71.113531, 42.170947 ],
+    "properties": {
+      "DPHid": "2K4N",
+      "type": "hospital_satellite",
+      "name": "HEBREW SENIORLIFE MED GRP @ ORCHARD",
+      "address": "1 DEL POND DRIVE",
+  	  "city": "Canton",
+      "city_zip": "02021",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HEYWOOD HOSP - PARTIAL HOSP PROG (2V9H)" : {
+    "coordinates": [ -71.984496, 42.586297 ],
+    "properties": {
+      "DPHid": "2V9H",
+      "type": "hospital_satellite",
+      "name": "HEYWOOD HOSP - PARTIAL HOSP PROG",
+      "address": "235 GREEN STREET",
+  	  "city": "Gardner",
+      "city_zip": "01440",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HEYWOOD REHABILITATION CENTER (2QO2)" : {
+    "coordinates": [ -71.979848, 42.563083 ],
+    "properties": {
+      "DPHid": "2QO2",
+      "type": "hospital_satellite",
+      "name": "HEYWOOD REHABILITATION CENTER",
+      "address": "69 PEARSON BOULEVARD",
+  	  "city": "Gardner",
+      "city_zip": "01440",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HLTHSOUTH SPORTS MED & REH CTR FRAM (2949)" : {
+    "coordinates": [ -71.441925, 42.298826 ],
+    "properties": {
+      "DPHid": "2949",
+      "type": "hospital_satellite",
+      "name": "HLTHSOUTH SPORTS MED & REH CTR FRAM",
+      "address": "1094 WORCESTER ROAD",
+  	  "city": "Framingham",
+      "city_zip": "01702",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HMH HARRINGTON BEHAVIORAL HEALTH CE (23BS)" : {
+    "coordinates": [ -72.031065, 42.074321 ],
+    "properties": {
+      "DPHid": "23BS",
+      "type": "hospital_satellite",
+      "name": "HMH HARRINGTON BEHAVIORAL HEALTH CE",
+      "address": "176 MAIN STREET",
+  	  "city": "Southbridge",
+      "city_zip": "01550",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HOLY FAM HOSP IMAGING & REHAB SVCS (26Y5)" : {
+    "coordinates": [ -71.166345, 42.726565 ],
+    "properties": {
+      "DPHid": "26Y5",
+      "type": "hospital_satellite",
+      "name": "HOLY FAM HOSP IMAGING & REHAB SVCS",
+      "address": "60 EAST STREET SUITE 3100",
+  	  "city": "Methuen",
+      "city_zip": "01844",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HOLY FAMILY HOSP AMBULATORY SRVS (2SE9)" : {
+    "coordinates": [ -71.129603, 42.747826 ],
+    "properties": {
+      "DPHid": "2SE9",
+      "type": "hospital_satellite",
+      "name": "HOLY FAMILY HOSP AMBULATORY SRVS",
+      "address": "380R MERRIMACK STREET 3FL",
+  	  "city": "Methuen",
+      "city_zip": "01844",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HOLY FAMILY WOMEN'S HEALTH CENTER (2KAN)" : {
+    "coordinates": [ -71.163691, 42.708763 ],
+    "properties": {
+      "DPHid": "2KAN",
+      "type": "hospital_satellite",
+      "name": "HOLY FAMILY WOMEN'S HEALTH CENTER",
+      "address": "101 AMESBURY STREET SUITE 103",
+  	  "city": "Lawrence",
+      "city_zip": "01840",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HOLY FMLY HOSP ENDOCINE & DIABETES (2F99)" : {
+    "coordinates": [ -71.166345, 42.726565 ],
+    "properties": {
+      "DPHid": "2F99",
+      "type": "hospital_satellite",
+      "name": "HOLY FMLY HOSP ENDOCINE & DIABETES",
+      "address": "60 EAST STREET",
+  	  "city": "Methuen",
+      "city_zip": "01844",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HOLYOKE MEDICAL CENTER IMAGING (20O3)" : {
+    "coordinates": [ -72.608324, 42.207209 ],
+    "properties": {
+      "DPHid": "20O3",
+      "type": "hospital_satellite",
+      "name": "HOLYOKE MEDICAL CENTER IMAGING",
+      "address": "230 MAPLE STREET, SUITE B",
+  	  "city": "Holyoke",
+      "city_zip": "01040",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HOLYOKE MEDICAL CTR WOMEN'S CENTER (25JG)" : {
+    "coordinates": [ -72.629288, 42.199533 ],
+    "properties": {
+      "DPHid": "25JG",
+      "type": "hospital_satellite",
+      "name": "HOLYOKE MEDICAL CTR WOMEN'S CENTER",
+      "address": "2 HOSPITAL DRIVE-SUITE 202",
+  	  "city": "Holyoke",
+      "city_zip": "01040",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HOPKINTON RADIOLOGY (2AM7)" : {
+    "coordinates": [ -71.540974, 42.217082 ],
+    "properties": {
+      "DPHid": "2AM7",
+      "type": "hospital_satellite",
+      "name": "HOPKINTON RADIOLOGY",
+      "address": "1 LUMBER STREET STE 101",
+  	  "city": "Hopkinton",
+      "city_zip": "01748",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HRI AT FRANKLIN (29M4)" : {
+    "coordinates": [ -71.378374, 42.080003 ],
+    "properties": {
+      "DPHid": "29M4",
+      "type": "hospital_satellite",
+      "name": "HRI AT FRANKLIN",
+      "address": "421 E. CENTRAL STREET",
+  	  "city": "Franklin",
+      "city_zip": "02038",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HRI AT LAWRENCE (2TC4)" : {
+    "coordinates": [ -71.163691, 42.708763 ],
+    "properties": {
+      "DPHid": "2TC4",
+      "type": "hospital_satellite",
+      "name": "HRI AT LAWRENCE",
+      "address": "101 AMESBURY STREET SUITE 201",
+  	  "city": "Lawrence",
+      "city_zip": "01841",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "HRI OF LOWELL (29A2)" : {
+    "coordinates": [ -71.30748, 42.645687 ],
+    "properties": {
+      "DPHid": "29A2",
+      "type": "hospital_satellite",
+      "name": "HRI OF LOWELL",
+      "address": "10 BRIDGE STREET",
+  	  "city": "Lowell",
+      "city_zip": "01852",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "IMAGING & TRANSPLANT SERVICES (24FI)" : {
+    "coordinates": [ -72.613558, 42.125138 ],
+    "properties": {
+      "DPHid": "24FI",
+      "type": "hospital_satellite",
+      "name": "IMAGING & TRANSPLANT SERVICES",
+      "address": "100 WASON AVENUE GROUND FL",
+  	  "city": "Springfield",
+      "city_zip": "01107",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "JEREMIAH E BURKE STUDENT HLTH CNTR (2ARA)" : {
+    "coordinates": [ -71.142361, 42.343261 ],
+    "properties": {
+      "DPHid": "2ARA",
+      "type": "hospital_satellite",
+      "name": "JEREMIAH E BURKE STUDENT HLTH CNTR",
+      "address": "60 WASHINGTON STREET",
+  	  "city": "Boston",
+      "city_zip": "02124",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "KRAFT FAMILY BLOOD DONOR CTR @ DANA (2D8O)" : {
+    "coordinates": [ -71.107327, 42.337689 ],
+    "properties": {
+      "DPHid": "2D8O",
+      "type": "hospital_satellite",
+      "name": "KRAFT FAMILY BLOOD DONOR CTR @ DANA",
+      "address": "35 BINNEY STREET 1ST FL JIMMY",
+  	  "city": "Boston",
+      "city_zip": "02115",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "LABORATORY FOR MOLECULAR MEDICINE (23ZE)" : {
+    "coordinates": [ -71.100744, 42.360623 ],
+    "properties": {
+      "DPHid": "23ZE",
+      "type": "hospital_satellite",
+      "name": "LABORATORY FOR MOLECULAR MEDICINE",
+      "address": "65 LANDSDOWNE STREET 3RD FLOOR",
+  	  "city": "Cambridge",
+      "city_zip": "02139",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "LAHEY HOSP & MC OPT REHAB SRV@DANVE (2KIF)" : {
+    "coordinates": [ -70.945552, 42.550058 ],
+    "properties": {
+      "DPHid": "2KIF",
+      "type": "hospital_satellite",
+      "name": "LAHEY HOSP & MC OPT REHAB SRV@DANVE",
+      "address": "5 FEDERAL STREET GROUND FLOOR",
+  	  "city": "Danvers",
+      "city_zip": "01923",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "LAHEY HOSP & MC, DPT OF ALLRGY&IMM& (2ARJ)" : {
+    "coordinates": [ -71.203241, 42.486615 ],
+    "properties": {
+      "DPHid": "2ARJ",
+      "type": "hospital_satellite",
+      "name": "LAHEY HOSP & MC, DPT OF ALLRGY&IMM&",
+      "address": "31 MALL ROAD 1ST FLOOR",
+  	  "city": "Burlington",
+      "city_zip": "01805",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "LAHEY HOSP &MC, WEIGHT LOSS CENTER (22U5)" : {
+    "coordinates": [ -71.206386, 42.486837 ],
+    "properties": {
+      "DPHid": "22U5",
+      "type": "hospital_satellite",
+      "name": "LAHEY HOSP &MC, WEIGHT LOSS CENTER",
+      "address": "50 MALL ROAD SUITE G-03",
+  	  "city": "Burlington",
+      "city_zip": "01805",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "LAHEY OUTPATIENT CENTER DANVERS (2ITT)" : {
+    "coordinates": [ -70.971967, 42.584119 ],
+    "properties": {
+      "DPHid": "2ITT",
+      "type": "hospital_satellite",
+      "name": "LAHEY OUTPATIENT CENTER DANVERS",
+      "address": "480 MAPLE STREET FLOORS 1&2",
+  	  "city": "Danvers",
+      "city_zip": "01923",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "LAHEY OUTPT CTR, LEXINGTON -MRI STE (26XF)" : {
+    "coordinates": [ -71.235067, 42.422544 ],
+    "properties": {
+      "DPHid": "26XF",
+      "type": "hospital_satellite",
+      "name": "LAHEY OUTPT CTR, LEXINGTON -MRI STE",
+      "address": "16 HAYDEN AVENUE",
+  	  "city": "Lexington",
+      "city_zip": "02421",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "LAHEY REHAB SERVICES - BURLINGTON (2IHY)" : {
+    "coordinates": [ -71.200592, 42.484554 ],
+    "properties": {
+      "DPHid": "2IHY",
+      "type": "hospital_satellite",
+      "name": "LAHEY REHAB SERVICES - BURLINGTON",
+      "address": "67 SOUTH BEDFORD ST, 1ST FLOOR",
+  	  "city": "Burlington",
+      "city_zip": "01805",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "LATIN ACADEMY STUDENT HEALTH CTR (2FZQ)" : {
+    "coordinates": [ -71.084757, 42.316794 ],
+    "properties": {
+      "DPHid": "2FZQ",
+      "type": "hospital_satellite",
+      "name": "LATIN ACADEMY STUDENT HEALTH CTR",
+      "address": "205 TOWNSEND ST 3RD FL STE 113",
+  	  "city": "Boston",
+      "city_zip": "02121",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "LAWRENCE GEN HOSP @MARSTON MED CTR (2FSZ)" : {
+    "coordinates": [ -71.145651, 42.706489 ],
+    "properties": {
+      "DPHid": "2FSZ",
+      "type": "hospital_satellite",
+      "name": "LAWRENCE GEN HOSP @MARSTON MED CTR",
+      "address": "25 MARSTON STREET SUITE 305",
+  	  "city": "Lawrence",
+      "city_zip": "01842",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "LAWRENCE GEN HOSP WOMEN'S HLTH IMAG (2E9R)" : {
+    "coordinates": [ -71.185047, 42.648022 ],
+    "properties": {
+      "DPHid": "2E9R",
+      "type": "hospital_satellite",
+      "name": "LAWRENCE GEN HOSP WOMEN'S HLTH IMAG",
+      "address": "323 LOWELL STREET 3FL",
+  	  "city": "Andover",
+      "city_zip": "01810",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "LAWRENCE GNRL HOSP OUTPT REHAB THPY (2XWA)" : {
+    "coordinates": [ -71.132231, 42.672731 ],
+    "properties": {
+      "DPHid": "2XWA",
+      "type": "hospital_satellite",
+      "name": "LAWRENCE GNRL HOSP OUTPT REHAB THPY",
+      "address": "165 HAVERHILL ST @ THE YMCA",
+  	  "city": "Andover",
+      "city_zip": "01810",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "LAWRENCE MEM HOSP MED SERVICE (2BNA)" : {
+    "coordinates": [ -71.11126, 42.41598 ],
+    "properties": {
+      "DPHid": "2BNA",
+      "type": "hospital_satellite",
+      "name": "LAWRENCE MEM HOSP MED SERVICE",
+      "address": "101 MAIN STREET SUITE 116",
+  	  "city": "Medford",
+      "city_zip": "02155",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "LGH CTR WOUND HEALING @ DRUM HILL (2DPY)" : {
+    "coordinates": [ -71.365773, 42.626849 ],
+    "properties": {
+      "DPHid": "2DPY",
+      "type": "hospital_satellite",
+      "name": "LGH CTR WOUND HEALING @ DRUM HILL",
+      "address": "10 RESEARCH PLACE SUITE 206",
+  	  "city": "Chelmsford",
+      "city_zip": "01863",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "LIBERTY TREE RADIOLOGY (2AQB)" : {
+    "coordinates": [ -70.944417, 42.552475 ],
+    "properties": {
+      "DPHid": "2AQB",
+      "type": "hospital_satellite",
+      "name": "LIBERTY TREE RADIOLOGY",
+      "address": "140 COMMONWEALTH AVE",
+  	  "city": "Danvers",
+      "city_zip": "01923",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "LMH REHABILITATION SERVICES (22AH)" : {
+    "coordinates": [ -71.11126, 42.41598 ],
+    "properties": {
+      "DPHid": "22AH",
+      "type": "hospital_satellite",
+      "name": "LMH REHABILITATION SERVICES",
+      "address": "101 MAIN STREET SUITES 105&106",
+  	  "city": "Medford",
+      "city_zip": "02155",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "LOWELL GENERAL HOSP OUTP SERVICES (2ITV)" : {
+    "coordinates": [ -71.311467, 42.642182 ],
+    "properties": {
+      "DPHid": "2ITV",
+      "type": "hospital_satellite",
+      "name": "LOWELL GENERAL HOSP OUTP SERVICES",
+      "address": "161 JACKSON STREET, 4TH FLOOR",
+  	  "city": "Lowell",
+      "city_zip": "01852",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "LOWELL GENERAL HOSPITAL REHAB SVS (292N)" : {
+    "coordinates": [ -71.35039, 42.600054 ],
+    "properties": {
+      "DPHid": "292N",
+      "type": "hospital_satellite",
+      "name": "LOWELL GENERAL HOSPITAL REHAB SVS",
+      "address": "43 VILLAGE SQUARE",
+  	  "city": "Chelmsford",
+      "city_zip": "01824",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "LOWELL GENERAL HOSPITAL-WESTFORD (2C5P)" : {
+    "coordinates": [ -71.426218, 42.564287 ],
+    "properties": {
+      "DPHid": "2C5P",
+      "type": "hospital_satellite",
+      "name": "LOWELL GENERAL HOSPITAL-WESTFORD",
+      "address": "198 LITTLETON ROAD 1FL",
+  	  "city": "Westford",
+      "city_zip": "01886",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "LOWELL GENERAL URGENT CARE (2317)" : {
+    "coordinates": [ -71.303917, 42.665342 ],
+    "properties": {
+      "DPHid": "2317",
+      "type": "hospital_satellite",
+      "name": "LOWELL GENERAL URGENT CARE",
+      "address": "1230 BRIDGE ST 1STFL ST1,2NDFL",
+  	  "city": "Lowell",
+      "city_zip": "01850",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "LOWELL GENERAL WOMEN'S CTR HLTH &WL (2CM2)" : {
+    "coordinates": [ -71.127436, 42.673708 ],
+    "properties": {
+      "DPHid": "2CM2",
+      "type": "hospital_satellite",
+      "name": "LOWELL GENERAL WOMEN'S CTR HLTH &WL",
+      "address": "203 TURNPIKE STREET 2ND FL",
+  	  "city": "North andover",
+      "city_zip": "01845",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "LOWELL GNRL DIAGNOSTIC CTR TEWKSBUR (2A1H)" : {
+    "coordinates": [ -71.270272, 42.631211 ],
+    "properties": {
+      "DPHid": "2A1H",
+      "type": "hospital_satellite",
+      "name": "LOWELL GNRL DIAGNOSTIC CTR TEWKSBUR",
+      "address": "600 CLARK ROAD",
+  	  "city": "Tewksbury",
+      "city_zip": "01876",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "LOWELL YOUTH TREATMENT CENTER (2MJ3)" : {
+    "coordinates": [ -71.34493, 42.6461 ],
+    "properties": {
+      "DPHid": "2MJ3",
+      "type": "hospital_satellite",
+      "name": "LOWELL YOUTH TREATMENT CENTER",
+      "address": "391 VARNUM AVENUE",
+  	  "city": "Lowell",
+      "city_zip": "01854",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MADISON PARK HS STUDENT HLTH CENTER (26F1)" : {
+    "coordinates": [ -71.090845, 42.332063 ],
+    "properties": {
+      "DPHid": "26F1",
+      "type": "hospital_satellite",
+      "name": "MADISON PARK HS STUDENT HLTH CENTER",
+      "address": "75 MALCOLM X BLVD 4TH FL STE 3",
+  	  "city": "Boston",
+      "city_zip": "02120",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MALDEN WALK-IN CLINIC (2UGN)" : {
+    "coordinates": [ -71.088392, 42.428068 ],
+    "properties": {
+      "DPHid": "2UGN",
+      "type": "hospital_satellite",
+      "name": "MALDEN WALK-IN CLINIC",
+      "address": "100 HOSPITAL ROAD, GOUND FLOOR",
+  	  "city": "Malden",
+      "city_zip": "02148",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MAMMOGRAPHY SRVS @ LYNN COMM HLTH C (24R7)" : {
+    "coordinates": [ -70.943699, 42.465132 ],
+    "properties": {
+      "DPHid": "24R7",
+      "type": "hospital_satellite",
+      "name": "MAMMOGRAPHY SRVS @ LYNN COMM HLTH C",
+      "address": "269 UNION STREET, FIRST FLOOR",
+  	  "city": "Lynn",
+      "city_zip": "01901",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MANCHESTER RADIOLOGY SERVICES (2IM4)" : {
+    "coordinates": [ -70.763722, 42.592913 ],
+    "properties": {
+      "DPHid": "2IM4",
+      "type": "hospital_satellite",
+      "name": "MANCHESTER RADIOLOGY SERVICES",
+      "address": "195 SCHOOL STREET",
+  	  "city": "Manchester",
+      "city_zip": "01944",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MANSFIELD HEALTH CENTER (27ZS)" : {
+    "coordinates": [ -71.233259, 42.034317 ],
+    "properties": {
+      "DPHid": "27ZS",
+      "type": "hospital_satellite",
+      "name": "MANSFIELD HEALTH CENTER",
+      "address": "200 COPELAND DRIVE",
+  	  "city": "Mansfield",
+      "city_zip": "02048",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MARLBOROUGH HOSP PHYSICAL REHAB SVC (2P1C)" : {
+    "coordinates": [ -71.541076, 42.33581 ],
+    "properties": {
+      "DPHid": "2P1C",
+      "type": "hospital_satellite",
+      "name": "MARLBOROUGH HOSP PHYSICAL REHAB SVC",
+      "address": "340 MAPLE STREET SUITE 302",
+  	  "city": "Marlborough",
+      "city_zip": "01752",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MARLBOROUGH HOSPITAL SPECIALTY CARE (2T68)" : {
+    "coordinates": [ -71.525468, 42.310061 ],
+    "properties": {
+      "DPHid": "2T68",
+      "type": "hospital_satellite",
+      "name": "MARLBOROUGH HOSPITAL SPECIALTY CARE",
+      "address": "28 NEWTON STREET 1ST & 2ND FL",
+  	  "city": "Southborough",
+      "city_zip": "01772",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MARTHA ELIOT HEALTH CENTER (2WRI)" : {
+    "coordinates": [ -71.102188, 42.32448 ],
+    "properties": {
+      "DPHid": "2WRI",
+      "type": "hospital_satellite",
+      "name": "MARTHA ELIOT HEALTH CENTER",
+      "address": "75 BICKFORD STREET",
+  	  "city": "Boston",
+      "city_zip": "02130",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MASS EYE & EAR @ EAST BRIDGEWATER (2IHZ)" : {
+    "coordinates": [ -70.956836, 42.045677 ],
+    "properties": {
+      "DPHid": "2IHZ",
+      "type": "hospital_satellite",
+      "name": "MASS EYE & EAR @ EAST BRIDGEWATER",
+      "address": "ONE COMPASS WAY SUITE 100",
+  	  "city": "East bridgewater",
+      "city_zip": "02333",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MASS EYE & EAR @ JOSLIN (2QGS)" : {
+    "coordinates": [ -71.1083, 42.33864 ],
+    "properties": {
+      "DPHid": "2QGS",
+      "type": "hospital_satellite",
+      "name": "MASS EYE & EAR @ JOSLIN",
+      "address": "1 JOSLIN PLACE",
+  	  "city": "Boston",
+      "city_zip": "02215",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MASS EYE & EAR INF QUINCY ANNEX (2P2X)" : {
+    "coordinates": [ -71.016277, 42.234671 ],
+    "properties": {
+      "DPHid": "2P2X",
+      "type": "hospital_satellite",
+      "name": "MASS EYE & EAR INF QUINCY ANNEX",
+      "address": "500 CONGRESS STREET SUITE 1C",
+  	  "city": "Quincy",
+      "city_zip": "02169",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MASS EYE & EAR INF SO NEW ENG RETIN (24A9)" : {
+    "coordinates": [ -71.308363, 42.00824 ],
+    "properties": {
+      "DPHid": "24A9",
+      "type": "hospital_satellite",
+      "name": "MASS EYE & EAR INF SO NEW ENG RETIN",
+      "address": "30 MAN MAR DRIVE SUITE 2",
+  	  "city": "Plainville",
+      "city_zip": "02762",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MASS EYE & EAR INF VESTIBULAR C @ B (2C4R)" : {
+    "coordinates": [ -71.018739, 42.198835 ],
+    "properties": {
+      "DPHid": "2C4R",
+      "type": "hospital_satellite",
+      "name": "MASS EYE & EAR INF VESTIBULAR C @ B",
+      "address": "250 POND STREET 1ST FL",
+  	  "city": "Braintree",
+      "city_zip": "02184",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MASS EYE & EAR INFIRMARY (2Y3F)" : {
+    "coordinates": [ -71.385267, 42.460753 ],
+    "properties": {
+      "DPHid": "2Y3F",
+      "type": "hospital_satellite",
+      "name": "MASS EYE & EAR INFIRMARY",
+      "address": "54 BAKER STREET SUITE 303",
+  	  "city": "Concord",
+      "city_zip": "01742",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MASS EYE & EAR LONGWOOD (2FY8)" : {
+    "coordinates": [ -71.1075, 42.332858 ],
+    "properties": {
+      "DPHid": "2FY8",
+      "type": "hospital_satellite",
+      "name": "MASS EYE & EAR LONGWOOD",
+      "address": "800 HUNTINGTON AVENUE",
+  	  "city": "Boston",
+      "city_zip": "02115",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MASS GENERAL WALTHAM (2LOD)" : {
+    "coordinates": [ -71.263945, 42.395833 ],
+    "properties": {
+      "DPHid": "2LOD",
+      "type": "hospital_satellite",
+      "name": "MASS GENERAL WALTHAM",
+      "address": "40 2ND AVENUE",
+  	  "city": "Waltham",
+      "city_zip": "02451",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MASS GENERAL/NORTH SHORE CTR OPT CR (2IX0)" : {
+    "coordinates": [ -70.932963, 42.548337 ],
+    "properties": {
+      "DPHid": "2IX0",
+      "type": "hospital_satellite",
+      "name": "MASS GENERAL/NORTH SHORE CTR OPT CR",
+      "address": "102 ENDICOTT STREET 1 & 2 FLS",
+  	  "city": "Danvers",
+      "city_zip": "01923",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MCLEAN AMB TREATMENT CENTER@NAUKEAG (2K5M)" : {
+    "coordinates": [ -71.935746, 42.663065 ],
+    "properties": {
+      "DPHid": "2K5M",
+      "type": "hospital_satellite",
+      "name": "MCLEAN AMB TREATMENT CENTER@NAUKEAG",
+      "address": "216 LAKE ROAD-1ST FLOOR",
+  	  "city": "Ashburnham",
+      "city_zip": "01430",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MCLEAN HOSP CHILD & ADOLESCENT MHO (2QH4)" : {
+    "coordinates": [ -71.155308, 42.391657 ],
+    "properties": {
+      "DPHid": "2QH4",
+      "type": "hospital_satellite",
+      "name": "MCLEAN HOSP CHILD & ADOLESCENT MHO",
+      "address": "799 CONCORD AVENUE, 1ST FLOOR",
+  	  "city": "Cambridge",
+      "city_zip": "02138",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MEDICAL ARTS BUILDING (25XP)" : {
+    "coordinates": [ -73.248731, 42.460565 ],
+    "properties": {
+      "DPHid": "25XP",
+      "type": "hospital_satellite",
+      "name": "MEDICAL ARTS BUILDING",
+      "address": "777 NORTH STREET",
+  	  "city": "Pittsfield",
+      "city_zip": "01201",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MEDICAL CARE CENTER NORTH (2ED8)" : {
+    "coordinates": [ -71.020317, 42.402931 ],
+    "properties": {
+      "DPHid": "2ED8",
+      "type": "hospital_satellite",
+      "name": "MEDICAL CARE CENTER NORTH",
+      "address": "1000 BROADWAY",
+  	  "city": "Chelsea",
+      "city_zip": "02150",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MELROSE WAKEFIELD HOSP REHAB SERVIC (25OM)" : {
+    "coordinates": [ -71.067897, 42.452487 ],
+    "properties": {
+      "DPHid": "25OM",
+      "type": "hospital_satellite",
+      "name": "MELROSE WAKEFIELD HOSP REHAB SERVIC",
+      "address": "22 COREY STREET",
+  	  "city": "Melrose",
+      "city_zip": "02176",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MERCY MEDICAL CENTER - URGENT CARE (2UZE)" : {
+    "coordinates": [ -72.596896, 42.113354 ],
+    "properties": {
+      "DPHid": "2UZE",
+      "type": "hospital_satellite",
+      "name": "MERCY MEDICAL CENTER - URGENT CARE",
+      "address": "175 CAREW STREET, SUITE 140",
+  	  "city": "Springfield",
+      "city_zip": "01104",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MERCY OUTPT CARDIOLOGY/STAFFORD (2C2N)" : {
+    "coordinates": [ -72.59316, 42.114617 ],
+    "properties": {
+      "DPHid": "2C2N",
+      "type": "hospital_satellite",
+      "name": "MERCY OUTPT CARDIOLOGY/STAFFORD",
+      "address": "300 STAFFORD STREET SUITE 101",
+  	  "city": "Springfield",
+      "city_zip": "01104",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "METHADONE MTNCE TREAT PROG (206D)" : {
+    "coordinates": [ -72.613086, 42.205177 ],
+    "properties": {
+      "DPHid": "206D",
+      "type": "hospital_satellite",
+      "name": "METHADONE MTNCE TREAT PROG",
+      "address": "210 ELM STREET",
+  	  "city": "Holyoke",
+      "city_zip": "01040",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "METROWEST HEALTH & WELLNESS CENTER (2A3F)" : {
+    "coordinates": [ -71.444487, 42.299213 ],
+    "properties": {
+      "DPHid": "2A3F",
+      "type": "hospital_satellite",
+      "name": "METROWEST HEALTH & WELLNESS CENTER",
+      "address": "761 WORCESTER ROAD-FLOORS 1, 2",
+  	  "city": "Framingham",
+      "city_zip": "01701",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "METROWEST IMAGING @ F WALTER CROWLE (2M8H)" : {
+    "coordinates": [ -71.398853, 42.082388 ],
+    "properties": {
+      "DPHid": "2M8H",
+      "type": "hospital_satellite",
+      "name": "METROWEST IMAGING @ F WALTER CROWLE",
+      "address": "36 CENTRAL ST 1ST FL",
+  	  "city": "Franklin",
+      "city_zip": "02038",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "METROWEST MED CTR OUTPT PRIMARY CAR (27LZ)" : {
+    "coordinates": [ -71.417591, 42.283346 ],
+    "properties": {
+      "DPHid": "27LZ",
+      "type": "hospital_satellite",
+      "name": "METROWEST MED CTR OUTPT PRIMARY CAR",
+      "address": "61 LINCOLN STREET SUITE 101",
+  	  "city": "Framingham",
+      "city_zip": "01702",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "METROWEST MENTAL HEALTH (2OJD)" : {
+    "coordinates": [ -71.436015, 42.242115 ],
+    "properties": {
+      "DPHid": "2OJD",
+      "type": "hospital_satellite",
+      "name": "METROWEST MENTAL HEALTH",
+      "address": "250 ELIOT STREET",
+  	  "city": "Ashland",
+      "city_zip": "01721",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "METROWEST MENTAL HEALTH (28K2)" : {
+    "coordinates": [ -71.537764, 42.351334 ],
+    "properties": {
+      "DPHid": "28K2",
+      "type": "hospital_satellite",
+      "name": "METROWEST MENTAL HEALTH",
+      "address": "200 EAST MAIN STREET",
+  	  "city": "Marlborough",
+      "city_zip": "01752",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "METROWEST PROFESSIONAL & MEDICAL CT (2P8E)" : {
+    "coordinates": [ -71.499157, 42.158894 ],
+    "properties": {
+      "DPHid": "2P8E",
+      "type": "hospital_satellite",
+      "name": "METROWEST PROFESSIONAL & MEDICAL CT",
+      "address": "321 FORTUNE BOULEVARD 1ST FL",
+  	  "city": "Milford",
+      "city_zip": "01757",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MGH AT BOWDOIN SQUARE (2E7O)" : {
+    "coordinates": [ -71.062156, 42.361832 ],
+    "properties": {
+      "DPHid": "2E7O",
+      "type": "hospital_satellite",
+      "name": "MGH AT BOWDOIN SQUARE",
+      "address": "ONE BOWDOIN SQUARE 7TH & 11TH",
+  	  "city": "Boston",
+      "city_zip": "02114",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MGH BACK BAY HEALTHCARE CENTER (2BD2)" : {
+    "coordinates": [ -71.09004, 42.348644 ],
+    "properties": {
+      "DPHid": "2BD2",
+      "type": "hospital_satellite",
+      "name": "MGH BACK BAY HEALTHCARE CENTER",
+      "address": "388 COMMONWEALTH AVE",
+  	  "city": "Boston",
+      "city_zip": "02115",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MGH BROADWAY PRIMARY CARE-REVERE (2H1B)" : {
+    "coordinates": [ -71.012008, 42.410121 ],
+    "properties": {
+      "DPHid": "2H1B",
+      "type": "hospital_satellite",
+      "name": "MGH BROADWAY PRIMARY CARE-REVERE",
+      "address": "385 BROADWAY",
+  	  "city": "Revere",
+      "city_zip": "02151",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MGH CARDIOVASCULAR DISEASE PREV CTR (2BFA)" : {
+    "coordinates": [ -71.061748, 42.362123 ],
+    "properties": {
+      "DPHid": "2BFA",
+      "type": "hospital_satellite",
+      "name": "MGH CARDIOVASCULAR DISEASE PREV CTR",
+      "address": "25 NEW CHARDON STREET SUITE 30",
+  	  "city": "Boston",
+      "city_zip": "02114",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MGH CHARLESTOWN HLTH CARE CTR (2HGL)" : {
+    "coordinates": [ -71.064249, 42.377157 ],
+    "properties": {
+      "DPHid": "2HGL",
+      "type": "hospital_satellite",
+      "name": "MGH CHARLESTOWN HLTH CARE CTR",
+      "address": "73 HIGH STREET",
+  	  "city": "Boston",
+      "city_zip": "02129",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MGH CHARLESTOWN MONUMENT ST COUNSEL (2TH4)" : {
+    "coordinates": [ -71.059418, 42.379162 ],
+    "properties": {
+      "DPHid": "2TH4",
+      "type": "hospital_satellite",
+      "name": "MGH CHARLESTOWN MONUMENT ST COUNSEL",
+      "address": "76 MONUMENT STREET 1ST FL",
+  	  "city": "Boston",
+      "city_zip": "02129",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MGH CHELSEA HEALTHCARE CTR (2PAQ)" : {
+    "coordinates": [ -71.039158, 42.396117 ],
+    "properties": {
+      "DPHid": "2PAQ",
+      "type": "hospital_satellite",
+      "name": "MGH CHELSEA HEALTHCARE CTR",
+      "address": "151 EVERETT AVE FLS 1-4",
+  	  "city": "Chelsea",
+      "city_zip": "02150",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MGH HEALTH CTR CHELSEA (26AN)" : {
+    "coordinates": [ -71.040147, 42.394292 ],
+    "properties": {
+      "DPHid": "26AN",
+      "type": "hospital_satellite",
+      "name": "MGH HEALTH CTR CHELSEA",
+      "address": "100 EVERETT AVENUE 1ST FLOOR 1",
+  	  "city": "Chelsea",
+      "city_zip": "02150",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MGH OUTPATIENT CARE (2N8Z)" : {
+    "coordinates": [ -71.068186, 42.361367 ],
+    "properties": {
+      "DPHid": "2N8Z",
+      "type": "hospital_satellite",
+      "name": "MGH OUTPATIENT CARE",
+      "address": "275 CAMBRIDGE STREET 3RD FL",
+  	  "city": "Boston",
+      "city_zip": "02114",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MGH RADIATION ONCOLGY@ NEWTON-WELLE (2V2S)" : {
+    "coordinates": [ -71.246437, 42.330634 ],
+    "properties": {
+      "DPHid": "2V2S",
+      "type": "hospital_satellite",
+      "name": "MGH RADIATION ONCOLGY@ NEWTON-WELLE",
+      "address": "2014 WASHINGTON STREET",
+  	  "city": "Newton",
+      "city_zip": "02462",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MGH REVERE HEALTHCARE CENTER (201R)" : {
+    "coordinates": [ -70.992236, 42.407917 ],
+    "properties": {
+      "DPHid": "201R",
+      "type": "hospital_satellite",
+      "name": "MGH REVERE HEALTHCARE CENTER",
+      "address": "300 OCEAN AVE. 3RD FLOOR",
+  	  "city": "Revere",
+      "city_zip": "02151",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MGH REVERE SCHOOL BASED HEALTH CENT (2BMY)" : {
+    "coordinates": [ -71.007891, 42.412153 ],
+    "properties": {
+      "DPHid": "2BMY",
+      "type": "hospital_satellite",
+      "name": "MGH REVERE SCHOOL BASED HEALTH CENT",
+      "address": "101 SCHOOL STREET",
+  	  "city": "Revere",
+      "city_zip": "02151",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MGH SLEEP DISORDERS TESTING UNIT (2OFE)" : {
+    "coordinates": [ -71.066621, 42.361781 ],
+    "properties": {
+      "DPHid": "2OFE",
+      "type": "hospital_satellite",
+      "name": "MGH SLEEP DISORDERS TESTING UNIT",
+      "address": "5 BLOSSOM STREET 2ND FLOOR",
+  	  "city": "Boston",
+      "city_zip": "02114",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MGH SPORTS MEDICINE CENTER (2O0R)" : {
+    "coordinates": [ -71.065728, 42.361547 ],
+    "properties": {
+      "DPHid": "2O0R",
+      "type": "hospital_satellite",
+      "name": "MGH SPORTS MEDICINE CENTER",
+      "address": "175 CAMBRIDGE STREET 4TH FLOOR",
+  	  "city": "Boston",
+      "city_zip": "02114",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MGH-CHARLES RIVER PLAZA (2FO9)" : {
+    "coordinates": [ -71.065347, 42.361712 ],
+    "properties": {
+      "DPHid": "2FO9",
+      "type": "hospital_satellite",
+      "name": "MGH-CHARLES RIVER PLAZA",
+      "address": "165 CAMBRIDGE STREET",
+  	  "city": "Boston",
+      "city_zip": "02115",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MGH-EVERETT FAMILY CARE (2KMC)" : {
+    "coordinates": [ -71.056694, 42.407419 ],
+    "properties": {
+      "DPHid": "2KMC",
+      "type": "hospital_satellite",
+      "name": "MGH-EVERETT FAMILY CARE",
+      "address": "19-23 NORWOOD STREET",
+  	  "city": "Everett",
+      "city_zip": "02149",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MILFORD REG MED CTR CANCER CENTER (2N2J)" : {
+    "coordinates": [ -71.53004, 42.133028 ],
+    "properties": {
+      "DPHid": "2N2J",
+      "type": "hospital_satellite",
+      "name": "MILFORD REG MED CTR CANCER CENTER",
+      "address": "20 PROSPECT STREET 1ST & 2ND F",
+  	  "city": "Milford",
+      "city_zip": "01757",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MILFORD REG MED CTR OCCUPATNAL MEDI (2RA8)" : {
+    "coordinates": [ -71.536684, 42.138189 ],
+    "properties": {
+      "DPHid": "2RA8",
+      "type": "hospital_satellite",
+      "name": "MILFORD REG MED CTR OCCUPATNAL MEDI",
+      "address": "HILL OFFICE PARK 115 WATER STR",
+  	  "city": "Milford",
+      "city_zip": "01757",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MILFORD REG MED CTR REHAB & SPRT MD (2STK)" : {
+    "coordinates": [ -71.519598, 42.127228 ],
+    "properties": {
+      "DPHid": "2STK",
+      "type": "hospital_satellite",
+      "name": "MILFORD REG MED CTR REHAB & SPRT MD",
+      "address": "42 CAPE ROAD PLAZA",
+  	  "city": "Milford",
+      "city_zip": "01757",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MILFORD REGIONAL REHABILITN SVCS (2BY1)" : {
+    "coordinates": [ -71.435608, 42.089662 ],
+    "properties": {
+      "DPHid": "2BY1",
+      "type": "hospital_satellite",
+      "name": "MILFORD REGIONAL REHABILITN SVCS",
+      "address": "2 FORGE PARKWAY",
+  	  "city": "Franklin",
+      "city_zip": "02038",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MILFORD REGNL IN THE BLKSTONE VLLY (2E4G)" : {
+    "coordinates": [ -71.641329, 42.125995 ],
+    "properties": {
+      "DPHid": "2E4G",
+      "type": "hospital_satellite",
+      "name": "MILFORD REGNL IN THE BLKSTONE VLLY",
+      "address": "100 COMMERCE STREET",
+  	  "city": "Northbridge",
+      "city_zip": "01534",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MORTON HEALTH SERVICES (28EL)" : {
+    "coordinates": [ -70.953588, 41.900362 ],
+    "properties": {
+      "DPHid": "28EL",
+      "type": "hospital_satellite",
+      "name": "MORTON HEALTH SERVICES",
+      "address": "511 WEST GROVE ST 2ND FLOOR ST",
+  	  "city": "Middleborough",
+      "city_zip": "02346",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MORTON HOSP SLEEP LAB @ RAYNHAM WOO (2B0I)" : {
+    "coordinates": [ -71.022459, 41.90407 ],
+    "properties": {
+      "DPHid": "2B0I",
+      "type": "hospital_satellite",
+      "name": "MORTON HOSP SLEEP LAB @ RAYNHAM WOO",
+      "address": "675 PARAMOUNT DRIVE SUITE G-1",
+  	  "city": "Raynham",
+      "city_zip": "02767",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MORTON HOSP SPEECH HEARING CLINIC (23V8)" : {
+    "coordinates": [ -71.117599, 41.958459 ],
+    "properties": {
+      "DPHid": "23V8",
+      "type": "hospital_satellite",
+      "name": "MORTON HOSP SPEECH HEARING CLINIC",
+      "address": "2007 BAY STREET SUITE 101",
+  	  "city": "Taunton",
+      "city_zip": "02780",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MOUNT AUBURN MOBILE PET UNIT (295J)" : {
+    "coordinates": [ -71.155308, 42.391657 ],
+    "properties": {
+      "DPHid": "295J",
+      "type": "hospital_satellite",
+      "name": "MOUNT AUBURN MOBILE PET UNIT",
+      "address": "799 CONCORD AVENUE 1ST FLOOR",
+  	  "city": "Cambridge",
+      "city_zip": "02138",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MT AUBURN HOSP EMPL ASST OCCUP & RE (24VQ)" : {
+    "coordinates": [ -71.152359, 42.390688 ],
+    "properties": {
+      "DPHid": "24VQ",
+      "type": "hospital_satellite",
+      "name": "MT AUBURN HOSP EMPL ASST OCCUP & RE",
+      "address": "725 CONCORD AVENUE SUITE 5100",
+  	  "city": "Cambridge",
+      "city_zip": "02138",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MT AUBURN HOSP IMAGING & SPECIMEN C (29HN)" : {
+    "coordinates": [ -71.204593, 42.386316 ],
+    "properties": {
+      "DPHid": "29HN",
+      "type": "hospital_satellite",
+      "name": "MT AUBURN HOSP IMAGING & SPECIMEN C",
+      "address": "355 WAVERLY OAKS ROAD SUITE 15",
+  	  "city": "Waltham",
+      "city_zip": "02452",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MT AUBURN HOSP RADIATION @ ARLINGTN (28IV)" : {
+    "coordinates": [ -71.158119, 42.417794 ],
+    "properties": {
+      "DPHid": "28IV",
+      "type": "hospital_satellite",
+      "name": "MT AUBURN HOSP RADIATION @ ARLINGTN",
+      "address": "22 MILL STREET SUITE 106",
+  	  "city": "Arlington",
+      "city_zip": "02476",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MT AUBURN HOSP REHAB SVS OP & OT (2LBX)" : {
+    "coordinates": [ -71.147092, 42.375675 ],
+    "properties": {
+      "DPHid": "2LBX",
+      "type": "hospital_satellite",
+      "name": "MT AUBURN HOSP REHAB SVS OP & OT",
+      "address": "625 MOUNT AUBURN STREET 1ST FL",
+  	  "city": "Cambridge",
+      "city_zip": "02138",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MT AUBURN HOSPITAL MRI CENTER (2R2S)" : {
+    "coordinates": [ -71.152325, 42.390661 ],
+    "properties": {
+      "DPHid": "2R2S",
+      "type": "hospital_satellite",
+      "name": "MT AUBURN HOSPITAL MRI CENTER",
+      "address": "725 CONCORD AVE GROUND FL",
+  	  "city": "Cambridge",
+      "city_zip": "02138",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "MURDOCK HEALTH CTR MIDDLE SCH/HS (21TU)" : {
+    "coordinates": [ -72.043768, 42.698963 ],
+    "properties": {
+      "DPHid": "21TU",
+      "type": "hospital_satellite",
+      "name": "MURDOCK HEALTH CTR MIDDLE SCH/HS",
+      "address": "3 MEMORIAL DRIVE 2ND FL",
+  	  "city": "Winchendon",
+      "city_zip": "01475",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "NEW ENG BAPT HOSP OPT CARE CTR (2ZGZ)" : {
+    "coordinates": [ -71.171636, 42.225155 ],
+    "properties": {
+      "DPHid": "2ZGZ",
+      "type": "hospital_satellite",
+      "name": "NEW ENG BAPT HOSP OPT CARE CTR",
+      "address": "40 ALLIED DRIVE",
+  	  "city": "Dedham",
+      "city_zip": "02026",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "NEW ENG BAPT HOSP OPT CT @ CHESTNU (2LVL)" : {
+    "coordinates": [ -71.148391, 42.326033 ],
+    "properties": {
+      "DPHid": "2LVL",
+      "type": "hospital_satellite",
+      "name": "NEW ENG BAPT HOSP OPT CT @ CHESTNU",
+      "address": "830 BOYLSTON STREET, BASEMENT",
+  	  "city": "Brookline",
+      "city_zip": "02467",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "NEW ENGLAND BAPTIST RADIOLOGY SUITE (20LS)" : {
+    "coordinates": [ -71.148391, 42.326033 ],
+    "properties": {
+      "DPHid": "20LS",
+      "type": "hospital_satellite",
+      "name": "NEW ENGLAND BAPTIST RADIOLOGY SUITE",
+      "address": "830 BOYLSTON ST STE 208 BSMT L",
+  	  "city": "Brookline",
+      "city_zip": "02467",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "NEW ENGLAND BAPTIST SURGICARE @ BRO (2R3V)" : {
+    "coordinates": [ -71.115066, 42.332646 ],
+    "properties": {
+      "DPHid": "2R3V",
+      "type": "hospital_satellite",
+      "name": "NEW ENGLAND BAPTIST SURGICARE @ BRO",
+      "address": "1 BROOKLINE PLACE SUITE 201",
+  	  "city": "Brookline",
+      "city_zip": "02445",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "NEWTON-WELLESLEY AMB CRE CTR NEWTON (22DB)" : {
+    "coordinates": [ -71.196557, 42.293914 ],
+    "properties": {
+      "DPHid": "22DB",
+      "type": "hospital_satellite",
+      "name": "NEWTON-WELLESLEY AMB CRE CTR NEWTON",
+      "address": "159 WELLS AVENUE",
+  	  "city": "Newton",
+      "city_zip": "02459",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "NEWTON-WELLESLEY AMB CRE CTR-NATICK (28HF)" : {
+    "coordinates": [ -71.396767, 42.281505 ],
+    "properties": {
+      "DPHid": "28HF",
+      "type": "hospital_satellite",
+      "name": "NEWTON-WELLESLEY AMB CRE CTR-NATICK",
+      "address": "307 WEST CENTRAL STREET",
+  	  "city": "Natick",
+      "city_zip": "01760",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "NEWTON-WELLESLEY FAMILY PRACTICE (2QIL)" : {
+    "coordinates": [ -71.26541, 42.13733 ],
+    "properties": {
+      "DPHid": "2QIL",
+      "type": "hospital_satellite",
+      "name": "NEWTON-WELLESLEY FAMILY PRACTICE",
+      "address": "111 NORFOLK STREET",
+  	  "city": "Walpole",
+      "city_zip": "02032",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "NEWTON-WELLESLEY HOSP HAND THERAPY (208T)" : {
+    "coordinates": [ -71.246302, 42.331346 ],
+    "properties": {
+      "DPHid": "208T",
+      "type": "hospital_satellite",
+      "name": "NEWTON-WELLESLEY HOSP HAND THERAPY",
+      "address": "2000 WASHINGTON STREET",
+  	  "city": "Newton",
+      "city_zip": "02466",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "NEWTON-WELLESLEY HOSP HAND THX CHES (2ZR6)" : {
+    "coordinates": [ -71.148391, 42.326033 ],
+    "properties": {
+      "DPHid": "2ZR6",
+      "type": "hospital_satellite",
+      "name": "NEWTON-WELLESLEY HOSP HAND THX CHES",
+      "address": "830 BOYLSTON STREET",
+  	  "city": "Brookline",
+      "city_zip": "02467",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "NEWTON-WELLESLEY OUTPATIENT SURG CT (2ZNC)" : {
+    "coordinates": [ -71.260792, 42.325236 ],
+    "properties": {
+      "DPHid": "2ZNC",
+      "type": "hospital_satellite",
+      "name": "NEWTON-WELLESLEY OUTPATIENT SURG CT",
+      "address": "25 WASHINGTON STREET",
+  	  "city": "Wellesley",
+      "city_zip": "02481",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "NEWTON-WELLESLEY SLEEP CENTER @ NEW (24PB)" : {
+    "coordinates": [ -71.258621, 42.346509 ],
+    "properties": {
+      "DPHid": "24PB",
+      "type": "hospital_satellite",
+      "name": "NEWTON-WELLESLEY SLEEP CENTER @ NEW",
+      "address": "2345 COMMONWEALTH AVENUE",
+  	  "city": "Newton",
+      "city_zip": "02466",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "NEWTON-WELLESLEY URG CR CTR-WALTHAM (2TOK)" : {
+    "coordinates": [ -71.249448, 42.369221 ],
+    "properties": {
+      "DPHid": "2TOK",
+      "type": "hospital_satellite",
+      "name": "NEWTON-WELLESLEY URG CR CTR-WALTHAM",
+      "address": "9 HOPE AVE 1ST FL#150 DEVINCEN",
+  	  "city": "Waltham",
+      "city_zip": "02453",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "NOBLE HOSPITAL SPORT & REHAB CENTER (2XR0)" : {
+    "coordinates": [ -72.744925, 42.120289 ],
+    "properties": {
+      "DPHid": "2XR0",
+      "type": "hospital_satellite",
+      "name": "NOBLE HOSPITAL SPORT & REHAB CENTER",
+      "address": "76 MAIN STREET",
+  	  "city": "Westfield",
+      "city_zip": "01085",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "NORTH SHORE MED CTR OUTPT IMAGING C (280E)" : {
+    "coordinates": [ -70.655504, 42.627016 ],
+    "properties": {
+      "DPHid": "280E",
+      "type": "hospital_satellite",
+      "name": "NORTH SHORE MED CTR OUTPT IMAGING C",
+      "address": "ONE BLACKBURN CIRCLE",
+  	  "city": "Gloucester",
+      "city_zip": "01930",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "NORTH SHORE MED CTR PT SVC CTR BLOO (29C8)" : {
+    "coordinates": [ -71.026069, 42.469759 ],
+    "properties": {
+      "DPHid": "29C8",
+      "type": "hospital_satellite",
+      "name": "NORTH SHORE MED CTR PT SVC CTR BLOO",
+      "address": "1069 BROADWAY 1ST FL",
+  	  "city": "Saugus",
+      "city_zip": "01906",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "NORTH SUBURBAN CENTER (2BGJ)" : {
+    "coordinates": [ -71.100307, 42.482348 ],
+    "properties": {
+      "DPHid": "2BGJ",
+      "type": "hospital_satellite",
+      "name": "NORTH SUBURBAN CENTER",
+      "address": "ONE MONTVALE AVENUE FIFTH FL",
+  	  "city": "Stoneham",
+      "city_zip": "02180",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "NORWOOD HOSP CANCER CRE CTR @ FOXBO (21PH)" : {
+    "coordinates": [ -71.239396, 42.051412 ],
+    "properties": {
+      "DPHid": "21PH",
+      "type": "hospital_satellite",
+      "name": "NORWOOD HOSP CANCER CRE CTR @ FOXBO",
+      "address": "70 WALNUT STREET GROUND FLOOR",
+  	  "city": "Foxborough",
+      "city_zip": "02035",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "NORWOOD OUTPATIENT CENTER (2LMY)" : {
+    "coordinates": [ -71.273634, 42.232412 ],
+    "properties": {
+      "DPHid": "2LMY",
+      "type": "hospital_satellite",
+      "name": "NORWOOD OUTPATIENT CENTER",
+      "address": "45 WALPOLE STREET",
+  	  "city": "Medfield",
+      "city_zip": "02052",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "NSMC MAGNETIC IMAGING (2IEK)" : {
+    "coordinates": [ -70.970245, 42.522078 ],
+    "properties": {
+      "DPHid": "2IEK",
+      "type": "hospital_satellite",
+      "name": "NSMC MAGNETIC IMAGING",
+      "address": "4 CENTENNIAL DRIVE",
+  	  "city": "Peabody",
+      "city_zip": "01960",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "NSMC OUTPATIENT SERVICES (21TE)" : {
+    "coordinates": [ -70.929565, 42.551369 ],
+    "properties": {
+      "DPHid": "21TE",
+      "type": "hospital_satellite",
+      "name": "NSMC OUTPATIENT SERVICES",
+      "address": "ONE HUTCHINSON DRIVE 1ST FL",
+  	  "city": "Danvers",
+      "city_zip": "01923",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "NSMC OUTPT MENTAL HLTH @ UNION HOSP (2EYX)" : {
+    "coordinates": [ -70.978477, 42.501466 ],
+    "properties": {
+      "DPHid": "2EYX",
+      "type": "hospital_satellite",
+      "name": "NSMC OUTPT MENTAL HLTH @ UNION HOSP",
+      "address": "490 LYNNFIELD STREET",
+  	  "city": "Lynn",
+      "city_zip": "01904",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "NSMC PROFESSIONAL SERVICES (2Z1D)" : {
+    "coordinates": [ -70.90603, 42.512985 ],
+    "properties": {
+      "DPHid": "2Z1D",
+      "type": "hospital_satellite",
+      "name": "NSMC PROFESSIONAL SERVICES",
+      "address": "55 HIGHLAND AVE, SUITE 201 & 2",
+  	  "city": "Salem",
+      "city_zip": "01970",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "NSMC ULTRASOUND @ NSPG SWAMPSCOTT (2UR4)" : {
+    "coordinates": [ -70.903362, 42.480375 ],
+    "properties": {
+      "DPHid": "2UR4",
+      "type": "hospital_satellite",
+      "name": "NSMC ULTRASOUND @ NSPG SWAMPSCOTT",
+      "address": "383 PARADISE ROAD",
+  	  "city": "Swampscott",
+      "city_zip": "01907",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "OPPENHEIM MEDICAL BUILDING (2ZNP)" : {
+    "coordinates": [ -70.043018, 41.773268 ],
+    "properties": {
+      "DPHid": "2ZNP",
+      "type": "hospital_satellite",
+      "name": "OPPENHEIM MEDICAL BUILDING",
+      "address": "1629 MAIN STREET 1ST FLOOR",
+  	  "city": "Eastham",
+      "city_zip": "02642",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "OUTPATIENT SVCS CTR (2VAY)" : {
+    "coordinates": [ -70.955118, 42.178972 ],
+    "properties": {
+      "DPHid": "2VAY",
+      "type": "hospital_satellite",
+      "name": "OUTPATIENT SVCS CTR",
+      "address": "780 MAIN ST 1ST FL",
+  	  "city": "Weymouth",
+      "city_zip": "02190",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "OUTPT ENDOCRINOLOGY & METABOLIC SVS (2E1F)" : {
+    "coordinates": [ -71.102144, 42.337286 ],
+    "properties": {
+      "DPHid": "2E1F",
+      "type": "hospital_satellite",
+      "name": "OUTPT ENDOCRINOLOGY & METABOLIC SVS",
+      "address": "221 LONGWOOD AVE 2ND FL",
+  	  "city": "Boston",
+      "city_zip": "02115",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "PATIENT SVC CTR @ DRUM HILL-LOWELL (2NAD)" : {
+    "coordinates": [ -71.365773, 42.626849 ],
+    "properties": {
+      "DPHid": "2NAD",
+      "type": "hospital_satellite",
+      "name": "PATIENT SVC CTR @ DRUM HILL-LOWELL",
+      "address": "10 RESEARCH PL STE 100",
+  	  "city": "Chelmsford",
+      "city_zip": "01863",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "PHYSICAL THERAPY PLUS @ ORCHARD HIL (2742)" : {
+    "coordinates": [ -71.705966, 42.522227 ],
+    "properties": {
+      "DPHid": "2742",
+      "type": "hospital_satellite",
+      "name": "PHYSICAL THERAPY PLUS @ ORCHARD HIL",
+      "address": "100 DUVAL ROAD GROUND FLOOR",
+  	  "city": "Lancaster",
+      "city_zip": "01523",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "PHYSICAL THERAPY SERVICES (2N16)" : {
+    "coordinates": [ -72.583233, 42.602973 ],
+    "properties": {
+      "DPHid": "2N16",
+      "type": "hospital_satellite",
+      "name": "PHYSICAL THERAPY SERVICES",
+      "address": "338 HIGH STREET",
+  	  "city": "Greenfield",
+      "city_zip": "01301",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "PLUMLEY VILLAGE HEALTH SERVICES (2HXI)" : {
+    "coordinates": [ -71.791825, 42.271935 ],
+    "properties": {
+      "DPHid": "2HXI",
+      "type": "hospital_satellite",
+      "name": "PLUMLEY VILLAGE HEALTH SERVICES",
+      "address": "116 BELMONT STREET SUITE 11",
+  	  "city": "Worcester",
+      "city_zip": "01605",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "PRIMARY CARE INTERNISTS (22B2)" : {
+    "coordinates": [ -70.274837, 41.654645 ],
+    "properties": {
+      "DPHid": "22B2",
+      "type": "hospital_satellite",
+      "name": "PRIMARY CARE INTERNISTS",
+      "address": "22 LEWIS BAY ROAD",
+  	  "city": "Barnstable",
+      "city_zip": "02601",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "PT PLUS @ WHITNEY FIELD (2AZ1)" : {
+    "coordinates": [ -71.74812, 42.531675 ],
+    "properties": {
+      "DPHid": "2AZ1",
+      "type": "hospital_satellite",
+      "name": "PT PLUS @ WHITNEY FIELD",
+      "address": "21 CINEMA BOULEVARD",
+  	  "city": "Leominster",
+      "city_zip": "01453",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "RADIOLOGY PROGRAM @HLTHALL CANCER C (23TF)" : {
+    "coordinates": [ -71.805688, 42.597646 ],
+    "properties": {
+      "DPHid": "23TF",
+      "type": "hospital_satellite",
+      "name": "RADIOLOGY PROGRAM @HLTHALL CANCER C",
+      "address": "275 NICHOLS ROAD",
+  	  "city": "Fitchburg",
+      "city_zip": "01420",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "RADIOLOGY SVCS @ LYNN COMM HLTH CTR (2R8A)" : {
+    "coordinates": [ -70.943708, 42.46511 ],
+    "properties": {
+      "DPHid": "2R8A",
+      "type": "hospital_satellite",
+      "name": "RADIOLOGY SVCS @ LYNN COMM HLTH CTR",
+      "address": "269 UNION STREET",
+  	  "city": "Lynn",
+      "city_zip": "01901",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "RONALD MCDONALD CARE MOBLE (2D2C)" : {
+    "coordinates": [ -71.792168, 42.272758 ],
+    "properties": {
+      "DPHid": "2D2C",
+      "type": "hospital_satellite",
+      "name": "RONALD MCDONALD CARE MOBLE",
+      "address": "119 BELMONT STREET",
+  	  "city": "Worcester",
+      "city_zip": "01605",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SAAB FAMILY BUILDING (2EIL)" : {
+    "coordinates": [ -71.300715, 42.645356 ],
+    "properties": {
+      "DPHid": "2EIL",
+      "type": "hospital_satellite",
+      "name": "SAAB FAMILY BUILDING",
+      "address": "2 HOSPITAL DRIVE, 2ND FLOOR",
+  	  "city": "Lowell",
+      "city_zip": "01852",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SCHG REH SVS CTR WOMEN'S HLTH R&R S (2WI1)" : {
+    "coordinates": [ -70.990873, 41.65999 ],
+    "properties": {
+      "DPHid": "2WI1",
+      "type": "hospital_satellite",
+      "name": "SCHG REH SVS CTR WOMEN'S HLTH R&R S",
+      "address": "300 B FAUNCE CORNER RD 1ST FL",
+  	  "city": "Dartmouth",
+      "city_zip": "02747",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SHREWSBURY RADIOLOGY (203U)" : {
+    "coordinates": [ -71.704449, 42.292511 ],
+    "properties": {
+      "DPHid": "203U",
+      "type": "hospital_satellite",
+      "name": "SHREWSBURY RADIOLOGY",
+      "address": "26 JULIO DRIVE STE 104",
+  	  "city": "Shrewsbury",
+      "city_zip": "01545",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SIGNATURE BROCKTON @430 LIBERTY ST (2MR6)" : {
+    "coordinates": [ -70.871574, 42.066097 ],
+    "properties": {
+      "DPHid": "2MR6",
+      "type": "hospital_satellite",
+      "name": "SIGNATURE BROCKTON @430 LIBERTY ST",
+      "address": "430 LIBERTY STREET UNIT D",
+  	  "city": "Hanson",
+      "city_zip": "02341",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SIGNATURE HEALTHCARE BROCKTON HOSP (2YXU)" : {
+    "coordinates": [ -71.061924, 42.05787 ],
+    "properties": {
+      "DPHid": "2YXU",
+      "type": "hospital_satellite",
+      "name": "SIGNATURE HEALTHCARE BROCKTON HOSP",
+      "address": "110 LIBERTY STREET 1ST FLOOR",
+  	  "city": "Brockton",
+      "city_zip": "02301",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SIGNATURE HLTHCR BROCKTON HOSP IMAG (2JEW)" : {
+    "coordinates": [ -71.096257, 42.089203 ],
+    "properties": {
+      "DPHid": "2JEW",
+      "type": "hospital_satellite",
+      "name": "SIGNATURE HLTHCR BROCKTON HOSP IMAG",
+      "address": "31 ROCHE BROTHERS WAY",
+  	  "city": "Easton",
+      "city_zip": "02356",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SIGNATURE HLTHCRE BROCKTON HOSP REH (2MQC)" : {
+    "coordinates": [ -71.067787, 41.960843 ],
+    "properties": {
+      "DPHid": "2MQC",
+      "type": "hospital_satellite",
+      "name": "SIGNATURE HLTHCRE BROCKTON HOSP REH",
+      "address": "1215 BROADWAY MED OFFICE BLDG",
+  	  "city": "Raynham",
+      "city_zip": "02767",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SNOWDEN INTERNATIONAL HS HEALTH CTR (25J9)" : {
+    "coordinates": [ -71.07797, 42.350546 ],
+    "properties": {
+      "DPHid": "25J9",
+      "type": "hospital_satellite",
+      "name": "SNOWDEN INTERNATIONAL HS HEALTH CTR",
+      "address": "150 NEWBURY STREET",
+  	  "city": "Boston",
+      "city_zip": "02116",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SOUTH BOSTON BEHAVIORAL HLTH CENTER (2UTG)" : {
+    "coordinates": [ -71.05574, 42.336319 ],
+    "properties": {
+      "DPHid": "2UTG",
+      "type": "hospital_satellite",
+      "name": "SOUTH BOSTON BEHAVIORAL HLTH CENTER",
+      "address": "58 OLD COLONY AVE.",
+  	  "city": "Boston",
+      "city_zip": "02111",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SOUTH BOSTON CHC SEAPORT PRIMARY CR (2FWJ)" : {
+    "coordinates": [ -71.041188, 42.347999 ],
+    "properties": {
+      "DPHid": "2FWJ",
+      "type": "hospital_satellite",
+      "name": "SOUTH BOSTON CHC SEAPORT PRIMARY CR",
+      "address": "505 CONGRESS STREET, 1ST FLOOR",
+  	  "city": "Boston",
+      "city_zip": "02210",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SOUTH BOSTON COMMUNITY HEALTH CTR (20WO)" : {
+    "coordinates": [ -71.048456, 42.33766 ],
+    "properties": {
+      "DPHid": "20WO",
+      "type": "hospital_satellite",
+      "name": "SOUTH BOSTON COMMUNITY HEALTH CTR",
+      "address": "386 WEST BROADWAY",
+  	  "city": "Boston",
+      "city_zip": "02127",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SOUTH BOSTON COMMUNITY HEALTH CTR (232S)" : {
+    "coordinates": [ -71.048225, 42.336857 ],
+    "properties": {
+      "DPHid": "232S",
+      "type": "hospital_satellite",
+      "name": "SOUTH BOSTON COMMUNITY HEALTH CTR",
+      "address": "409 WEST BROADWAY",
+  	  "city": "Boston",
+      "city_zip": "02127",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SOUTH SHORE HOSP BREAST CARE CENTER (2SSR)" : {
+    "coordinates": [ -70.954939, 42.177198 ],
+    "properties": {
+      "DPHid": "2SSR",
+      "type": "hospital_satellite",
+      "name": "SOUTH SHORE HOSP BREAST CARE CENTER",
+      "address": "101 COLUMBIAN STREET SUITE 201",
+  	  "city": "Weymouth",
+      "city_zip": "02190",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SOUTH SHORE HOSP COHASSET IMAGING S (2Q0T)" : {
+    "coordinates": [ -70.830202, 42.240342 ],
+    "properties": {
+      "DPHid": "2Q0T",
+      "type": "hospital_satellite",
+      "name": "SOUTH SHORE HOSP COHASSET IMAGING S",
+      "address": "223 CHIEF JUSTCE CUSHING HGHWA",
+  	  "city": "Cohasset",
+      "city_zip": "02025",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SOUTH SHORE HOSP CTR PHYS WELLNESS (2ILW)" : {
+    "coordinates": [ -70.943557, 42.195175 ],
+    "properties": {
+      "DPHid": "2ILW",
+      "type": "hospital_satellite",
+      "name": "SOUTH SHORE HOSP CTR PHYS WELLNESS",
+      "address": "51 PERFORMANCE DRIVE",
+  	  "city": "Weymouth",
+      "city_zip": "02190",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SOUTH SHORE HOSP OUTPT PRE-TESTING (20A4)" : {
+    "coordinates": [ -70.956239, 42.178051 ],
+    "properties": {
+      "DPHid": "20A4",
+      "type": "hospital_satellite",
+      "name": "SOUTH SHORE HOSP OUTPT PRE-TESTING",
+      "address": "797 MAIN STREET 1ST FL",
+  	  "city": "Weymouth",
+      "city_zip": "02190",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SOUTH SHORE HOSP'S CTR WOUND CARE & (29UE)" : {
+    "coordinates": [ -70.945574, 42.193953 ],
+    "properties": {
+      "DPHid": "29UE",
+      "type": "hospital_satellite",
+      "name": "SOUTH SHORE HOSP'S CTR WOUND CARE &",
+      "address": "90 LIBBEY INDUSTRIAL PARKWAY",
+  	  "city": "Weymouth",
+      "city_zip": "02190",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SOUTHCOAST CTR PRIMARY & SPECIALTY (2592)" : {
+    "coordinates": [ -70.884305, 41.654512 ],
+    "properties": {
+      "DPHid": "2592",
+      "type": "hospital_satellite",
+      "name": "SOUTHCOAST CTR PRIMARY & SPECIALTY",
+      "address": "208 MILL ROAD",
+  	  "city": "Fairhaven",
+      "city_zip": "02719",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SOUTHCOAST HOSPS GRP CTRS CANCER CR (2J23)" : {
+    "coordinates": [ -70.882008, 41.654232 ],
+    "properties": {
+      "DPHid": "2J23",
+      "type": "hospital_satellite",
+      "name": "SOUTHCOAST HOSPS GRP CTRS CANCER CR",
+      "address": "206 MILL ROAD 1 & 2 FLOORS",
+  	  "city": "Fairhaven",
+      "city_zip": "02719",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SOUTHCOAST HOSPS GRP RADIO & LAB SV (2FXT)" : {
+    "coordinates": [ -71.140253, 41.693296 ],
+    "properties": {
+      "DPHid": "2FXT",
+      "type": "hospital_satellite",
+      "name": "SOUTHCOAST HOSPS GRP RADIO & LAB SV",
+      "address": "387 QUARRY STREET SUITE 104",
+  	  "city": "Fall river",
+      "city_zip": "02720",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SOUTHCOAST HOSPS GRP RADIOL SVCS &L (25YF)" : {
+    "coordinates": [ -70.731498, 41.775491 ],
+    "properties": {
+      "DPHid": "25YF",
+      "type": "hospital_satellite",
+      "name": "SOUTHCOAST HOSPS GRP RADIOL SVCS &L",
+      "address": "100 ROSEBROOK WAY SUITE 101",
+  	  "city": "Wareham",
+      "city_zip": "02571",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SOUTHCOAST HOSPS GRP RADIOL SVCS&LA (2TEV)" : {
+    "coordinates": [ -70.925986, 41.636182 ],
+    "properties": {
+      "DPHid": "2TEV",
+      "type": "hospital_satellite",
+      "name": "SOUTHCOAST HOSPS GRP RADIOL SVCS&LA",
+      "address": "874 PURCHASE ST FIRST FLOOR",
+  	  "city": "New bedford",
+      "city_zip": "02740",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SOUTHCOAST HOSPS GRP RADIOLGY & LAB (2KAG)" : {
+    "coordinates": [ -71.076246, 41.632837 ],
+    "properties": {
+      "DPHid": "2KAG",
+      "type": "hospital_satellite",
+      "name": "SOUTHCOAST HOSPS GRP RADIOLGY & LAB",
+      "address": "827 AMERICAN LEGION HIGHWAY ST",
+  	  "city": "Westport",
+      "city_zip": "02790",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SOUTHCOAST HOSPS GRP RADIOLOGY SRVS (23IA)" : {
+    "coordinates": [ -71.144891, 41.721567 ],
+    "properties": {
+      "DPHid": "23IA",
+      "type": "hospital_satellite",
+      "name": "SOUTHCOAST HOSPS GRP RADIOLOGY SRVS",
+      "address": "1565 NORTH MAIN ST STE 408",
+  	  "city": "Fall river",
+      "city_zip": "02720",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SOUTHCOAST HOSPS GRP RADIOLOGY SVCS (204N)" : {
+    "coordinates": [ -71.138768, 41.714137 ],
+    "properties": {
+      "DPHid": "204N",
+      "type": "hospital_satellite",
+      "name": "SOUTHCOAST HOSPS GRP RADIOLOGY SVCS",
+      "address": "1030 PRESIDENT AVENUE, ANNEX B",
+  	  "city": "Fall river",
+      "city_zip": "02720",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SOUTHCOAST HOSPS GRP RADIOLOGY SVCS (2KNV)" : {
+    "coordinates": [ -71.139382, 41.709489 ],
+    "properties": {
+      "DPHid": "2KNV",
+      "type": "hospital_satellite",
+      "name": "SOUTHCOAST HOSPS GRP RADIOLOGY SVCS",
+      "address": "373 NEW BOSTON ROAD",
+  	  "city": "Fall river",
+      "city_zip": "02720",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SOUTHCOAST HOSPS GRP RADIOLOGY SVCS (2TBT)" : {
+    "coordinates": [ -71.144658, 41.708842 ],
+    "properties": {
+      "DPHid": "2TBT",
+      "type": "hospital_satellite",
+      "name": "SOUTHCOAST HOSPS GRP RADIOLOGY SVCS",
+      "address": "300 HANOVER STREET SUITE 2B",
+  	  "city": "Fall river",
+      "city_zip": "02720",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SOUTHCOAST HOSPS GRP REHAB SERVICES (2DF0)" : {
+    "coordinates": [ -70.990876, 41.659981 ],
+    "properties": {
+      "DPHid": "2DF0",
+      "type": "hospital_satellite",
+      "name": "SOUTHCOAST HOSPS GRP REHAB SERVICES",
+      "address": "300 FAUNCE CORNER RD BLDG C SU",
+  	  "city": "Dartmouth",
+      "city_zip": "02747",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SOUTHCOAST HOSPS GRP REHAB SRVS (2CBQ)" : {
+    "coordinates": [ -70.956207, 41.624565 ],
+    "properties": {
+      "DPHid": "2CBQ",
+      "type": "hospital_satellite",
+      "name": "SOUTHCOAST HOSPS GRP REHAB SRVS",
+      "address": "480 HAWTHORN STREET SUITES 100",
+  	  "city": "Dartmouth",
+      "city_zip": "02747",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SOUTHCOAST HOSPS GRP REHAB SRVS (2CX1)" : {
+    "coordinates": [ -70.740698, 41.777626 ],
+    "properties": {
+      "DPHid": "2CX1",
+      "type": "hospital_satellite",
+      "name": "SOUTHCOAST HOSPS GRP REHAB SRVS",
+      "address": "1 RECOVERY ROAD",
+  	  "city": "Wareham",
+      "city_zip": "02571",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SOUTHCOAST HOSPS GRP REHAB SVCS (2R93)" : {
+    "coordinates": [ -70.96414, 41.635868 ],
+    "properties": {
+      "DPHid": "2R93",
+      "type": "hospital_satellite",
+      "name": "SOUTHCOAST HOSPS GRP REHAB SVCS",
+      "address": "49 STATE RD MASHPEE BLDG",
+  	  "city": "Dartmouth",
+      "city_zip": "02747",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SOUTHCOAST HOSPS GRP REHAB TRUESDAL (2861)" : {
+    "coordinates": [ -71.13862, 41.714498 ],
+    "properties": {
+      "DPHid": "2861",
+      "type": "hospital_satellite",
+      "name": "SOUTHCOAST HOSPS GRP REHAB TRUESDAL",
+      "address": "263 STANLEY STREET GROUND FLOO",
+  	  "city": "Fall river",
+      "city_zip": "02720",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SOUTHCOAST HOSPS GRP REHABTN SERVCS (2JTV)" : {
+    "coordinates": [ -70.987511, 41.633672 ],
+    "properties": {
+      "DPHid": "2JTV",
+      "type": "hospital_satellite",
+      "name": "SOUTHCOAST HOSPS GRP REHABTN SERVCS",
+      "address": "1 POSA PLACE",
+  	  "city": "Dartmouth",
+      "city_zip": "02747",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SOUTHCOAST HOSPS GRP REHB SR WAREHA (237X)" : {
+    "coordinates": [ -70.711701, 41.772852 ],
+    "properties": {
+      "DPHid": "237X",
+      "type": "hospital_satellite",
+      "name": "SOUTHCOAST HOSPS GRP REHB SR WAREHA",
+      "address": "WAREHAM YMCA 33 CHARGE POND RO",
+  	  "city": "Wareham",
+      "city_zip": "02571",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SOUTHCOAST HOSPS GRP REHB SRVS HANO (2RBC)" : {
+    "coordinates": [ -71.144152, 41.708085 ],
+    "properties": {
+      "DPHid": "2RBC",
+      "type": "hospital_satellite",
+      "name": "SOUTHCOAST HOSPS GRP REHB SRVS HANO",
+      "address": "235 HANOVER STREET, 4TH FLOOR",
+  	  "city": "Fall river",
+      "city_zip": "02720",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SOUTHCOAST HOSPS GRP SURGERY CENTER (2401)" : {
+    "coordinates": [ -70.991893, 41.661019 ],
+    "properties": {
+      "DPHid": "2401",
+      "type": "hospital_satellite",
+      "name": "SOUTHCOAST HOSPS GRP SURGERY CENTER",
+      "address": "300 D FAUNCE CORNER ROAD",
+  	  "city": "Dartmouth",
+      "city_zip": "02747",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SOUTHERN JAMAICA PLAIN HLH CTR (27EO)" : {
+    "coordinates": [ -71.113714, 42.313264 ],
+    "properties": {
+      "DPHid": "27EO",
+      "type": "hospital_satellite",
+      "name": "SOUTHERN JAMAICA PLAIN HLH CTR",
+      "address": "640 CENTRE STREET",
+  	  "city": "Boston",
+      "city_zip": "02130",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SOUTHERN NEW ENG SURGERY CTR-ST ANN (2WCU)" : {
+    "coordinates": [ -71.364274, 41.907126 ],
+    "properties": {
+      "DPHid": "2WCU",
+      "type": "hospital_satellite",
+      "name": "SOUTHERN NEW ENG SURGERY CTR-ST ANN",
+      "address": "738 WASHINGTON STREET",
+  	  "city": "Attleboro",
+      "city_zip": "02703",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SPAULDING AQUATICS PRGRM - YARMOUTH (2L4P)" : {
+    "coordinates": [ -70.259273, 41.66079 ],
+    "properties": {
+      "DPHid": "2L4P",
+      "type": "hospital_satellite",
+      "name": "SPAULDING AQUATICS PRGRM - YARMOUTH",
+      "address": "579 BUCK ISLAND RD (@MAYFLOWER",
+  	  "city": "Yarmouth",
+      "city_zip": "02673",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SPAULDING ELN M WARD OUTPT CT CHD-S (2RM4)" : {
+    "coordinates": [ -70.489435, 41.71174 ],
+    "properties": {
+      "DPHid": "2RM4",
+      "type": "hospital_satellite",
+      "name": "SPAULDING ELN M WARD OUTPT CT CHD-S",
+      "address": "280-D ROUTE 130 SUITE 7",
+  	  "city": "Sandwich",
+      "city_zip": "02644",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SPAULDING MALDEN (2LD1)" : {
+    "coordinates": [ -71.068243, 42.425653 ],
+    "properties": {
+      "DPHid": "2LD1",
+      "type": "hospital_satellite",
+      "name": "SPAULDING MALDEN",
+      "address": "350 MAIN STREET",
+  	  "city": "Malden",
+      "city_zip": "02148",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SPAULDING OUTPATIENT CTR - BRIGHTON (2C1G)" : {
+    "coordinates": [ -71.146471, 42.3577 ],
+    "properties": {
+      "DPHid": "2C1G",
+      "type": "hospital_satellite",
+      "name": "SPAULDING OUTPATIENT CTR - BRIGHTON",
+      "address": "20 GUEST STREET SUITE 150",
+  	  "city": "Boston",
+      "city_zip": "02135",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SPAULDING OUTPATIENT CTR - CAPE ANN (2SAH)" : {
+    "coordinates": [ -70.655504, 42.627016 ],
+    "properties": {
+      "DPHid": "2SAH",
+      "type": "hospital_satellite",
+      "name": "SPAULDING OUTPATIENT CTR - CAPE ANN",
+      "address": "1 BLACKBURN DRIVE",
+  	  "city": "Gloucester",
+      "city_zip": "01930",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SPAULDING OUTPATIENT CTR - DOWNTOWN (2ZGV)" : {
+    "coordinates": [ -71.058188, 42.357266 ],
+    "properties": {
+      "DPHid": "2ZGV",
+      "type": "hospital_satellite",
+      "name": "SPAULDING OUTPATIENT CTR - DOWNTOWN",
+      "address": "294 WASHINGTON STREET 2NDFL ST",
+  	  "city": "Boston",
+      "city_zip": "02108",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SPAULDING OUTPATIENT CTR - FRAMINGH (2SRG)" : {
+    "coordinates": [ -71.420057, 42.297414 ],
+    "properties": {
+      "DPHid": "2SRG",
+      "type": "hospital_satellite",
+      "name": "SPAULDING OUTPATIENT CTR - FRAMINGH",
+      "address": "570 WORCESTER ROAD",
+  	  "city": "Framingham",
+      "city_zip": "01702",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SPAULDING OUTPATIENT CTR - HANOVER (2UPY)" : {
+    "coordinates": [ -70.839496, 42.140666 ],
+    "properties": {
+      "DPHid": "2UPY",
+      "type": "hospital_satellite",
+      "name": "SPAULDING OUTPATIENT CTR - HANOVER",
+      "address": "75 MILL STREET 1ST FLOOR",
+  	  "city": "Hanover",
+      "city_zip": "02339",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SPAULDING OUTPATIENT CTR - LYNN (2RCJ)" : {
+    "coordinates": [ -70.951805, 42.478639 ],
+    "properties": {
+      "DPHid": "2RCJ",
+      "type": "hospital_satellite",
+      "name": "SPAULDING OUTPATIENT CTR - LYNN",
+      "address": "583 CHESTNUT STREET, 3RD FLOOR",
+  	  "city": "Lynn",
+      "city_zip": "01904",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SPAULDING OUTPATIENT CTR - MEDFORD (28SS)" : {
+    "coordinates": [ -71.11126, 42.41598 ],
+    "properties": {
+      "DPHid": "28SS",
+      "type": "hospital_satellite",
+      "name": "SPAULDING OUTPATIENT CTR - MEDFORD",
+      "address": "101 MAIN STREET SSUITES 101/11",
+  	  "city": "Medford",
+      "city_zip": "02155",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SPAULDING OUTPATIENT CTR - ORLEANS (2IDH)" : {
+    "coordinates": [ -69.99836, 41.784671 ],
+    "properties": {
+      "DPHid": "2IDH",
+      "type": "hospital_satellite",
+      "name": "SPAULDING OUTPATIENT CTR - ORLEANS",
+      "address": "65 OLD COLONY WAY SUITE 2",
+  	  "city": "Orleans",
+      "city_zip": "02653",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SPAULDING OUTPATIENT CTR - PEABODY (2YFH)" : {
+    "coordinates": [ -70.970245, 42.522078 ],
+    "properties": {
+      "DPHid": "2YFH",
+      "type": "hospital_satellite",
+      "name": "SPAULDING OUTPATIENT CTR - PEABODY",
+      "address": "4 CENTENNIAL DRIVE",
+  	  "city": "Peabody",
+      "city_zip": "01960",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SPAULDING OUTPATIENT CTR - PLYMOUTH (2BG1)" : {
+    "coordinates": [ -70.708644, 41.949391 ],
+    "properties": {
+      "DPHid": "2BG1",
+      "type": "hospital_satellite",
+      "name": "SPAULDING OUTPATIENT CTR - PLYMOUTH",
+      "address": "1 SCOBEE CIRCLE 1ST FL",
+  	  "city": "Plymouth",
+      "city_zip": "02360",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SPAULDING OUTPATIENT CTR - QUINCY (29VK)" : {
+    "coordinates": [ -70.997083, 42.252978 ],
+    "properties": {
+      "DPHid": "29VK",
+      "type": "hospital_satellite",
+      "name": "SPAULDING OUTPATIENT CTR - QUINCY",
+      "address": "79 CODDINGTON AVENUE, 2ND FLOO",
+  	  "city": "Quincy",
+      "city_zip": "02169",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SPAULDING OUTPATIENT CTR - SALEM (22GS)" : {
+    "coordinates": [ -70.888075, 42.518193 ],
+    "properties": {
+      "DPHid": "22GS",
+      "type": "hospital_satellite",
+      "name": "SPAULDING OUTPATIENT CTR - SALEM",
+      "address": "35 CONGRESS STREET, 2ND FL. ST",
+  	  "city": "Salem",
+      "city_zip": "01970",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SPAULDING OUTPATIENT CTR - WELLESLE (21Y1)" : {
+    "coordinates": [ -71.253749, 42.32471 ],
+    "properties": {
+      "DPHid": "21Y1",
+      "type": "hospital_satellite",
+      "name": "SPAULDING OUTPATIENT CTR - WELLESLE",
+      "address": "65 WALNUT STREET",
+  	  "city": "Wellesley",
+      "city_zip": "02481",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SPAULDING OUTPATIENT CTR - WESTBORO (28LO)" : {
+    "coordinates": [ -71.603291, 42.283442 ],
+    "properties": {
+      "DPHid": "28LO",
+      "type": "hospital_satellite",
+      "name": "SPAULDING OUTPATIENT CTR - WESTBORO",
+      "address": "112 TURNPIKE ROAD",
+  	  "city": "Westborough",
+      "city_zip": "01581",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SPAULDING OUTPATIENT CTR - YARMOUH (2QFD)" : {
+    "coordinates": [ -70.257296, 41.68129 ],
+    "properties": {
+      "DPHid": "2QFD",
+      "type": "hospital_satellite",
+      "name": "SPAULDING OUTPATIENT CTR - YARMOUH",
+      "address": "130 ANSEL HALLET ROAD",
+  	  "city": "Yarmouth",
+      "city_zip": "02675",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SPAULDING OUTPATIENT CTR -BRAINTREE (2GTS)" : {
+    "coordinates": [ -71.023458, 42.217312 ],
+    "properties": {
+      "DPHid": "2GTS",
+      "type": "hospital_satellite",
+      "name": "SPAULDING OUTPATIENT CTR -BRAINTREE",
+      "address": "300 GRANITE ST 1ST FL",
+  	  "city": "Braintree",
+      "city_zip": "02184",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SPAULDING OUTPATIENT CTR -CAMBRIDGE (2RCQ)" : {
+    "coordinates": [ -93.245851, 45.572692 ],
+    "properties": {
+      "DPHid": "2RCQ",
+      "type": "hospital_satellite",
+      "name": "SPAULDING OUTPATIENT CTR -CAMBRIDGE",
+      "address": "1575 CAMBRIDGE STREET, FIRST F",
+  	  "city": "Cambridge",
+      "city_zip": "02138",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SPAULDING OUTPATIENT CTR-MIDDLETON (21B7)" : {
+    "coordinates": [ -71.009332, 42.583935 ],
+    "properties": {
+      "DPHid": "21B7",
+      "type": "hospital_satellite",
+      "name": "SPAULDING OUTPATIENT CTR-MIDDLETON",
+      "address": "147 SOUTH MAIN STREET",
+  	  "city": "Middleton",
+      "city_zip": "01949",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SPAULDING OUTPT CTR CHLD - LEXINGTO (2LMW)" : {
+    "coordinates": [ -71.258898, 42.471432 ],
+    "properties": {
+      "DPHid": "2LMW",
+      "type": "hospital_satellite",
+      "name": "SPAULDING OUTPT CTR CHLD - LEXINGTO",
+      "address": "1 MAGUIRE ROAD 1ST FL",
+  	  "city": "Lexington",
+      "city_zip": "02421",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SPAULDING OUTPT CTR-MARBLEHEAD JCC (23DT)" : {
+    "coordinates": [ -70.873961, 42.484845 ],
+    "properties": {
+      "DPHid": "23DT",
+      "type": "hospital_satellite",
+      "name": "SPAULDING OUTPT CTR-MARBLEHEAD JCC",
+      "address": "4 COMMUNITY ROAD",
+  	  "city": "Marblehead",
+      "city_zip": "01945",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SPAULDING OUTPT CTR-MARBLEHEAD YMCA (2IJM)" : {
+    "coordinates": [ -70.891659, 42.490286 ],
+    "properties": {
+      "DPHid": "2IJM",
+      "type": "hospital_satellite",
+      "name": "SPAULDING OUTPT CTR-MARBLEHEAD YMCA",
+      "address": "40 LEGGS HILL ROAD",
+  	  "city": "Marblehead",
+      "city_zip": "01945",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SPORTS MED&PHYS THERPY ASSOC OF NCH (26FX)" : {
+    "coordinates": [ -70.092128, 41.273077 ],
+    "properties": {
+      "DPHid": "26FX",
+      "type": "hospital_satellite",
+      "name": "SPORTS MED&PHYS THERPY ASSOC OF NCH",
+      "address": "6 BAYBERRY COURT, GROUND LEVEL",
+  	  "city": "Nantucket",
+      "city_zip": "02554",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SPORTS MEDICINE & REHAB SERVICES (2CKB)" : {
+    "coordinates": [ -70.87535, 42.562712 ],
+    "properties": {
+      "DPHid": "2CKB",
+      "type": "hospital_satellite",
+      "name": "SPORTS MEDICINE & REHAB SERVICES",
+      "address": "77 HERRICK STREET- SUITE 202",
+  	  "city": "Beverly",
+      "city_zip": "01915",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "ST ANNE'S HOSP AMB CRE CTR HAWTHORN (2N34)" : {
+    "coordinates": [ -70.987245, 41.672593 ],
+    "properties": {
+      "DPHid": "2N34",
+      "type": "hospital_satellite",
+      "name": "ST ANNE'S HOSP AMB CRE CTR HAWTHORN",
+      "address": "535 FAUNCE CORNER ROAD",
+  	  "city": "Dartmouth",
+      "city_zip": "02747",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "ST ANNE'S HOSP DIAGNOSTIC IMAGING S (2Q1H)" : {
+    "coordinates": [ -70.920661, 41.656199 ],
+    "properties": {
+      "DPHid": "2Q1H",
+      "type": "hospital_satellite",
+      "name": "ST ANNE'S HOSP DIAGNOSTIC IMAGING S",
+      "address": "119 COGGESHALL STREET",
+  	  "city": "New bedford",
+      "city_zip": "02746",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "ST ANNE'S HOSPITAL DIAGNOSTIC IMAGI (2PXT)" : {
+    "coordinates": [ -71.150419, 41.699318 ],
+    "properties": {
+      "DPHid": "2PXT",
+      "type": "hospital_satellite",
+      "name": "ST ANNE'S HOSPITAL DIAGNOSTIC IMAGI",
+      "address": "289 PLEASANT ST BLDG 4",
+  	  "city": "Fall river",
+      "city_zip": "02721",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "ST ANNE'S HOSPITAL PAIN MANAGMT CTR (2HWT)" : {
+    "coordinates": [ -71.221528, 41.759675 ],
+    "properties": {
+      "DPHid": "2HWT",
+      "type": "hospital_satellite",
+      "name": "ST ANNE'S HOSPITAL PAIN MANAGMT CTR",
+      "address": "440 SWANSEA MALL DRIVE 2ND FL",
+  	  "city": "Swansea",
+      "city_zip": "02777",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "ST ANNE'S HOSPITAL REGIONAL CANCER (21H5)" : {
+    "coordinates": [ -70.986713, 41.672033 ],
+    "properties": {
+      "DPHid": "21H5",
+      "type": "hospital_satellite",
+      "name": "ST ANNE'S HOSPITAL REGIONAL CANCER",
+      "address": "537 FAUNCE CORNER ROAD",
+  	  "city": "Dartmouth",
+      "city_zip": "02747",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "ST ANNE'S OUTPATIENT CENTER (270P)" : {
+    "coordinates": [ -71.158838, 41.699904 ],
+    "properties": {
+      "DPHid": "270P",
+      "type": "hospital_satellite",
+      "name": "ST ANNE'S OUTPATIENT CENTER",
+      "address": "222 MILLIKEN BLVD 1ST ST A&B 4",
+  	  "city": "Fall river",
+      "city_zip": "02721",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "ST VINCENT AMBULATORY CARE CENTER (202I)" : {
+    "coordinates": [ -71.801386, 42.276738 ],
+    "properties": {
+      "DPHid": "202I",
+      "type": "hospital_satellite",
+      "name": "ST VINCENT AMBULATORY CARE CENTER",
+      "address": "108 GROVE STREET SUITE 101",
+  	  "city": "Worcester",
+      "city_zip": "01605",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "ST VINCENT CANCER & WELLNESS CENTER (221Q)" : {
+    "coordinates": [ -71.831238, 42.578815 ],
+    "properties": {
+      "DPHid": "221Q",
+      "type": "hospital_satellite",
+      "name": "ST VINCENT CANCER & WELLNESS CENTER",
+      "address": "ONE EATON PLACE FLS 1, 2, & 3",
+  	  "city": "Worcester",
+      "city_zip": "01608",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "ST VINCENT HOSP DIAG IMAGING & PT (2GNR)" : {
+    "coordinates": [ -71.82631, 42.214945 ],
+    "properties": {
+      "DPHid": "2GNR",
+      "type": "hospital_satellite",
+      "name": "ST VINCENT HOSP DIAG IMAGING & PT",
+      "address": "250 HAMPTON STREET 1FL",
+  	  "city": "Auburn",
+      "city_zip": "01501",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "ST VINCENT HOSP PARTIAL HOSP PROGR (2F5S)" : {
+    "coordinates": [ -71.78969, 42.286784 ],
+    "properties": {
+      "DPHid": "2F5S",
+      "type": "hospital_satellite",
+      "name": "ST VINCENT HOSP PARTIAL HOSP PROGR",
+      "address": "299 LINCOLN STREET STE 101",
+  	  "city": "Worcester",
+      "city_zip": "01605",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "ST VINCENT HOSP PHYS THRPY GROVE ST (2I5I)" : {
+    "coordinates": [ -71.808159, 42.289615 ],
+    "properties": {
+      "DPHid": "2I5I",
+      "type": "hospital_satellite",
+      "name": "ST VINCENT HOSP PHYS THRPY GROVE ST",
+      "address": "WORCESTER FITNESS CTR 440 GROV",
+  	  "city": "Worcester",
+      "city_zip": "01605",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "ST VINCENT HOSPITAL PAIN MANAGEMENT (2XPY)" : {
+    "coordinates": [ -71.80999, 42.304813 ],
+    "properties": {
+      "DPHid": "2XPY",
+      "type": "hospital_satellite",
+      "name": "ST VINCENT HOSPITAL PAIN MANAGEMENT",
+      "address": "102 SHORE DRIVE # 502",
+  	  "city": "Worcester",
+      "city_zip": "01605",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "ST VINCENT HOSPITAL WOMEN'S CENTER (2CLJ)" : {
+    "coordinates": [ -71.800654, 42.249356 ],
+    "properties": {
+      "DPHid": "2CLJ",
+      "type": "hospital_satellite",
+      "name": "ST VINCENT HOSPITAL WOMEN'S CENTER",
+      "address": "237 MILLBURY STREET",
+  	  "city": "Worcester",
+      "city_zip": "01610",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "STUDENT HLTH CNTR @ CHELSEA HS (269N)" : {
+    "coordinates": [ -71.040274, 42.400561 ],
+    "properties": {
+      "DPHid": "269N",
+      "type": "hospital_satellite",
+      "name": "STUDENT HLTH CNTR @ CHELSEA HS",
+      "address": "299 EVERETT AVENUE",
+  	  "city": "Chelsea",
+      "city_zip": "02150",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "STURDY MEM HOSP HLTH CTR @ ATTLEBOR (24TR)" : {
+    "coordinates": [ -71.302001, 41.939364 ],
+    "properties": {
+      "DPHid": "24TR",
+      "type": "hospital_satellite",
+      "name": "STURDY MEM HOSP HLTH CTR @ ATTLEBOR",
+      "address": "100 RATHBUN WILLARD DRIVE, 1ST",
+  	  "city": "Attleboro",
+      "city_zip": "02703",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "SURGERY CTR @ DRUM HILL LOWELL GEN (2Z7G)" : {
+    "coordinates": [ -71.365773, 42.626849 ],
+    "properties": {
+      "DPHid": "2Z7G",
+      "type": "hospital_satellite",
+      "name": "SURGERY CTR @ DRUM HILL LOWELL GEN",
+      "address": "10 RESEARCH PL STE 101",
+  	  "city": "Chelmsford",
+      "city_zip": "01863",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "TECHBOSTON ACADEMY SCHOOL HLTH CTR (2V6Z)" : {
+    "coordinates": [ -71.076013, 42.285125 ],
+    "properties": {
+      "DPHid": "2V6Z",
+      "type": "hospital_satellite",
+      "name": "TECHBOSTON ACADEMY SCHOOL HLTH CTR",
+      "address": "9 PEACEVALE RD 2ND FL",
+  	  "city": "Boston",
+      "city_zip": "02124",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "TRI-RIVER FAMILY HEALTH CENTER (24KL)" : {
+    "coordinates": [ -71.623525, 42.096979 ],
+    "properties": {
+      "DPHid": "24KL",
+      "type": "hospital_satellite",
+      "name": "TRI-RIVER FAMILY HEALTH CENTER",
+      "address": "281 EAST HARTFORD AVENUE",
+  	  "city": "Uxbridge",
+      "city_zip": "01569",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "TUFTS MED CTR SAT MRI @ LEM SHAT (272X)" : {
+    "coordinates": [ -71.101792, 42.299581 ],
+    "properties": {
+      "DPHid": "272X",
+      "type": "hospital_satellite",
+      "name": "TUFTS MED CTR SAT MRI @ LEM SHAT",
+      "address": "170 MORTON ST -LEMUEL SHATTUCK",
+  	  "city": "Boston",
+      "city_zip": "02130",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "TUFTS NORFOLK IMAGING (22O0)" : {
+    "coordinates": [ -71.295877, 42.090038 ],
+    "properties": {
+      "DPHid": "22O0",
+      "type": "hospital_satellite",
+      "name": "TUFTS NORFOLK IMAGING",
+      "address": "31 PINE STREET",
+  	  "city": "Norfolk",
+      "city_zip": "02056",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "UMASS MEM MED CTR MILFORD RADIOLOGY (2JVJ)" : {
+    "coordinates": [ -71.533139, 42.137845 ],
+    "properties": {
+      "DPHid": "2JVJ",
+      "type": "hospital_satellite",
+      "name": "UMASS MEM MED CTR MILFORD RADIOLOGY",
+      "address": "91 WATER STREET 1ST FLOOR",
+  	  "city": "Milford",
+      "city_zip": "01757",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "UMASS MEM SAT MOLECULAR DIAGNOS LAB (2WBT)" : {
+    "coordinates": [ -71.728094, 42.286779 ],
+    "properties": {
+      "DPHid": "2WBT",
+      "type": "hospital_satellite",
+      "name": "UMASS MEM SAT MOLECULAR DIAGNOS LAB",
+      "address": "222 MAPLE STREET",
+  	  "city": "Shrewsbury",
+      "city_zip": "01545",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "UMASS MEMORIAL AMBULATORY CARE CENT (25X3)" : {
+    "coordinates": [ -71.761637, 42.277673 ],
+    "properties": {
+      "DPHid": "25X3",
+      "type": "hospital_satellite",
+      "name": "UMASS MEMORIAL AMBULATORY CARE CENT",
+      "address": "55 LAKE AVENUE NORTH",
+  	  "city": "Worcester",
+      "city_zip": "01655",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "UMASS MEMORIAL ENDOSCOPY CENTER (2TSB)" : {
+    "coordinates": [ -71.790316, 42.265618 ],
+    "properties": {
+      "DPHid": "2TSB",
+      "type": "hospital_satellite",
+      "name": "UMASS MEMORIAL ENDOSCOPY CENTER",
+      "address": "21 EASTERN AVENUE 2ND FL",
+  	  "city": "Worcester",
+      "city_zip": "01605",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "UMASS MEMORIAL MED CTR INC IMAG SVC (242B)" : {
+    "coordinates": [ -71.784669, 42.266966 ],
+    "properties": {
+      "DPHid": "242B",
+      "type": "hospital_satellite",
+      "name": "UMASS MEMORIAL MED CTR INC IMAG SVC",
+      "address": "214 SHREWSBURY STREET",
+  	  "city": "Worcester",
+      "city_zip": "01604",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "UMASS MEMORIAL MED CTR/HAHNEMANN (2077)" : {
+    "coordinates": [ -71.790409, 42.285706 ],
+    "properties": {
+      "DPHid": "2077",
+      "type": "hospital_satellite",
+      "name": "UMASS MEMORIAL MED CTR/HAHNEMANN",
+      "address": "281 LINCOLN STREET",
+  	  "city": "Worcester",
+      "city_zip": "01605",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "UMASS MMC CANCER @MARLBORO HOSP (2IEH)" : {
+    "coordinates": [ -71.554083, 42.35437 ],
+    "properties": {
+      "DPHid": "2IEH",
+      "type": "hospital_satellite",
+      "name": "UMASS MMC CANCER @MARLBORO HOSP",
+      "address": "157 UNION STREET",
+  	  "city": "Marlborough",
+      "city_zip": "01752",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "UNION SQUARE FAMILY HEALTH (2IEX)" : {
+    "coordinates": [ -71.098004, 42.380782 ],
+    "properties": {
+      "DPHid": "2IEX",
+      "type": "hospital_satellite",
+      "name": "UNION SQUARE FAMILY HEALTH",
+      "address": "337 SOMERVILLE AVE 1ST FL",
+  	  "city": "Somerville",
+      "city_zip": "02143",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "URGENT CARE LEOMINSTER (2MX2)" : {
+    "coordinates": [ -71.763314, 42.548875 ],
+    "properties": {
+      "DPHid": "2MX2",
+      "type": "hospital_satellite",
+      "name": "URGENT CARE LEOMINSTER",
+      "address": "510 NORTH MAIN STREET",
+  	  "city": "Leominster",
+      "city_zip": "01453",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "URGI-CARE CENTER (2Q2A)" : {
+    "coordinates": [ -71.088392, 42.428068 ],
+    "properties": {
+      "DPHid": "2Q2A",
+      "type": "hospital_satellite",
+      "name": "URGI-CARE CENTER",
+      "address": "100 HOSPITAL RD FLOORS 1-3",
+  	  "city": "Medford",
+      "city_zip": "02155",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "WELDON OUTPT REHABTN & WELLNESS CTR (21HD)" : {
+    "coordinates": [ -72.51546, 42.066009 ],
+    "properties": {
+      "DPHid": "21HD",
+      "type": "hospital_satellite",
+      "name": "WELDON OUTPT REHABTN & WELLNESS CTR",
+      "address": "45 CRANE AVENUE",
+  	  "city": "East longmeadow",
+      "city_zip": "01028",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "WESTBORO RADIOLOGY (29ZK)" : {
+    "coordinates": [ -71.599994, 42.284065 ],
+    "properties": {
+      "DPHid": "29ZK",
+      "type": "hospital_satellite",
+      "name": "WESTBORO RADIOLOGY",
+      "address": "154 EAST MAIN ST STE 5",
+  	  "city": "Westborough",
+      "city_zip": "01581",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "WILKENS MEDICAL COMPLEX (2KPV)" : {
+    "coordinates": [ -70.591888, 41.576991 ],
+    "properties": {
+      "DPHid": "2KPV",
+      "type": "hospital_satellite",
+      "name": "WILKENS MEDICAL COMPLEX",
+      "address": "35 GONSALVES ROAD",
+  	  "city": "Barnstable",
+      "city_zip": "02630",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "WILLIAM ARNOLD-CAROL A WARFLD MD PC (2CZA)" : {
+    "coordinates": [ -71.115066, 42.332646 ],
+    "properties": {
+      "DPHid": "2CZA",
+      "type": "hospital_satellite",
+      "name": "WILLIAM ARNOLD-CAROL A WARFLD MD PC",
+      "address": "1 BROOKLINE PLACE SUITE 105",
+  	  "city": "Brookline",
+      "city_zip": "02445",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "WILLIAMSTOWN MEDICAL ASSOC OF BMC (2QIO)" : {
+    "coordinates": [ -73.190758, 42.704858 ],
+    "properties": {
+      "DPHid": "2QIO",
+      "type": "hospital_satellite",
+      "name": "WILLIAMSTOWN MEDICAL ASSOC OF BMC",
+      "address": "197 ADAMS ROAD",
+  	  "city": "Williamstown",
+      "city_zip": "01267",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "WINCHENDON HEALTH CENTER (28QS)" : {
+    "coordinates": [ -72.042609, 42.66421 ],
+    "properties": {
+      "DPHid": "28QS",
+      "type": "hospital_satellite",
+      "name": "WINCHENDON HEALTH CENTER",
+      "address": "55 HOSPITAL DRIVE",
+  	  "city": "Winchendon",
+      "city_zip": "01475",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "WINCHESTER HOSP 620 WASHINGTON ST (2ON1)" : {
+    "coordinates": [ -71.126561, 42.470059 ],
+    "properties": {
+      "DPHid": "2ON1",
+      "type": "hospital_satellite",
+      "name": "WINCHESTER HOSP 620 WASHINGTON ST",
+      "address": "620 WASHINGTON STREET SUITE 10",
+  	  "city": "Winchester",
+      "city_zip": "01890",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "WINCHESTER HOSP COMM HEALTH INST (273D)" : {
+    "coordinates": [ -71.08188, 42.379405 ],
+    "properties": {
+      "DPHid": "273D",
+      "type": "hospital_satellite",
+      "name": "WINCHESTER HOSP COMM HEALTH INST",
+      "address": "75 RIVERSIDE AVENUE FIRST FL S",
+  	  "city": "Medford",
+      "city_zip": "02155",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "WINCHESTER HOSP OCCUP THRPY @ RUSSE (20ML)" : {
+    "coordinates": [ -71.143381, 42.463094 ],
+    "properties": {
+      "DPHid": "20ML",
+      "type": "hospital_satellite",
+      "name": "WINCHESTER HOSP OCCUP THRPY @ RUSSE",
+      "address": "955 MAIN STREET, STE G5",
+  	  "city": "Winchester",
+      "city_zip": "01890",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "WINCHESTER HOSP ORTHOPEDICS PLUS (2GKR)" : {
+    "coordinates": [ -71.154224, 42.475727 ],
+    "properties": {
+      "DPHid": "2GKR",
+      "type": "hospital_satellite",
+      "name": "WINCHESTER HOSP ORTHOPEDICS PLUS",
+      "address": "23 WARREN AVE STE 160 BLDG 23",
+  	  "city": "Woburn",
+      "city_zip": "01801",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "WINCHESTER HOSP PAIN MANAGEMENT CTR (2FVD)" : {
+    "coordinates": [ -71.127138, 42.505204 ],
+    "properties": {
+      "DPHid": "2FVD",
+      "type": "hospital_satellite",
+      "name": "WINCHESTER HOSP PAIN MANAGEMENT CTR",
+      "address": "444 WASHINGTON ST FIRST FL STE",
+  	  "city": "Woburn",
+      "city_zip": "01801",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "WINCHESTER HOSP PHYSICAL THRPY@RUS (224V)" : {
+    "coordinates": [ -71.143381, 42.463094 ],
+    "properties": {
+      "DPHid": "224V",
+      "type": "hospital_satellite",
+      "name": "WINCHESTER HOSP PHYSICAL THRPY@RUS",
+      "address": "955 MAIN STREET SUITE #G2B",
+  	  "city": "Winchester",
+      "city_zip": "01890",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "WINCHESTER HOSP SLEEP DISORDER CTR (26Z8)" : {
+    "coordinates": [ -71.156116, 42.501915 ],
+    "properties": {
+      "DPHid": "26Z8",
+      "type": "hospital_satellite",
+      "name": "WINCHESTER HOSP SLEEP DISORDER CTR",
+      "address": "12 ALFRED ST 1ST FL BALDWIN PA",
+  	  "city": "Woburn",
+      "city_zip": "01801",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "WINCHESTER HOSP WOUND HEALING CTR (2578)" : {
+    "coordinates": [ -71.107011, 42.417051 ],
+    "properties": {
+      "DPHid": "2578",
+      "type": "hospital_satellite",
+      "name": "WINCHESTER HOSP WOUND HEALING CTR",
+      "address": "75 RIVERSIDE AVENUE, FIRST FL",
+  	  "city": "Medford",
+      "city_zip": "02155",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "WINCHESTER HOSPITAL ENDOSCOPY CENTE (2PAP)" : {
+    "coordinates": [ -71.13572, 42.506799 ],
+    "properties": {
+      "DPHid": "2PAP",
+      "type": "hospital_satellite",
+      "name": "WINCHESTER HOSPITAL ENDOSCOPY CENTE",
+      "address": "10P COMMERCE WAY",
+  	  "city": "Woburn",
+      "city_zip": "01801",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "WINCHESTER HOSPITAL FAMILY (27VC)" : {
+    "coordinates": [ -71.144131, 42.580388 ],
+    "properties": {
+      "DPHid": "27VC",
+      "type": "hospital_satellite",
+      "name": "WINCHESTER HOSPITAL FAMILY",
+      "address": "500 SALEM STREET",
+  	  "city": "Wilmington",
+      "city_zip": "01887",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "WINCHESTER HOSPITAL ORTHOPAEDICS PL (2P8R)" : {
+    "coordinates": [ -71.099205, 42.51664 ],
+    "properties": {
+      "DPHid": "2P8R",
+      "type": "hospital_satellite",
+      "name": "WINCHESTER HOSPITAL ORTHOPAEDICS PL",
+      "address": "20 POND MEADOW DRIVE SUITE 108",
+  	  "city": "Reading",
+      "city_zip": "01867",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "WINCHESTER HOSPITAL OUTPATIENT CENT (2G6O)" : {
+    "coordinates": [ -71.115099, 42.482135 ],
+    "properties": {
+      "DPHid": "2G6O",
+      "type": "hospital_satellite",
+      "name": "WINCHESTER HOSPITAL OUTPATIENT CENT",
+      "address": "200 UNICORN PARK DRIVE",
+  	  "city": "Woburn",
+      "city_zip": "01801",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "WINCHESTER HOSPITAL ULTRASOUND LAB (2MKF)" : {
+    "coordinates": [ -71.145208, 42.465292 ],
+    "properties": {
+      "DPHid": "2MKF",
+      "type": "hospital_satellite",
+      "name": "WINCHESTER HOSPITAL ULTRASOUND LAB",
+      "address": "1021 MAIN STREET",
+  	  "city": "Winchester",
+      "city_zip": "01890",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "WINCHESTER IMAGING CTR (2VGH)" : {
+    "coordinates": [ -71.156857, 42.501549 ],
+    "properties": {
+      "DPHid": "2VGH",
+      "type": "hospital_satellite",
+      "name": "WINCHESTER IMAGING CTR",
+      "address": "7 ALFRED STREET FIRST FLOOR ST",
+  	  "city": "Woburn",
+      "city_zip": "01801",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "WINCHESTER IMAGING READING (26LZ)" : {
+    "coordinates": [ -71.099205, 42.51664 ],
+    "properties": {
+      "DPHid": "26LZ",
+      "type": "hospital_satellite",
+      "name": "WINCHESTER IMAGING READING",
+      "address": "20 POND MEADOW DR FIRST FL STE",
+  	  "city": "Reading",
+      "city_zip": "01867",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "WINCHESTER IMAGING WOODLAND ROAD (2L36)" : {
+    "coordinates": [ -71.089361, 42.452615 ],
+    "properties": {
+      "DPHid": "2L36",
+      "type": "hospital_satellite",
+      "name": "WINCHESTER IMAGING WOODLAND ROAD",
+      "address": "3 WOODLAND ROAD SUITE 300 3FL",
+  	  "city": "Stoneham",
+      "city_zip": "02180",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "WINTHROP COMM HEALTH CENTER (2NI9)" : {
+    "coordinates": [ -70.993678, 42.38262 ],
+    "properties": {
+      "DPHid": "2NI9",
+      "type": "hospital_satellite",
+      "name": "WINTHROP COMM HEALTH CENTER",
+      "address": "17 MAIN STREET, GROUND FLOOR",
+  	  "city": "Winthrop",
+      "city_zip": "02152",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "WOMAN'S IMAGING CENTER (2C4V)" : {
+    "coordinates": [ -71.350832, 42.60279 ],
+    "properties": {
+      "DPHid": "2C4V",
+      "type": "hospital_satellite",
+      "name": "WOMAN'S IMAGING CENTER",
+      "address": "4 MEETING HOUSE ROAD-UNIT #13",
+  	  "city": "Chelmsford",
+      "city_zip": "01824",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "WOUND CENTER @ GOOD SAMARITAN MED C (2G05)" : {
+    "coordinates": [ -71.08182, 42.100619 ],
+    "properties": {
+      "DPHid": "2G05",
+      "type": "hospital_satellite",
+      "name": "WOUND CENTER @ GOOD SAMARITAN MED C",
+      "address": "909 SUMNER STREET 1ST FLOOR",
+  	  "city": "Stoughton",
+      "city_zip": "02072",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  },
+
+  "YAWKEY CTR FOR OUTPATIENT CARE THE (2WXO)" : {
+    "coordinates": [ -71.069484, 42.362059 ],
+    "properties": {
+      "DPHid": "2WXO",
+      "type": "hospital_satellite",
+      "name": "YAWKEY CTR FOR OUTPATIENT CARE THE",
+      "address": "32 FRUIT STREET",
+  	  "city": "Boston",
+      "city_zip": "02114",
+      "state": "MA",
+      "country": "US",
+      "services_provided": "ambulatory",
+      "bed_count": "0"
+    }
+  }
+}

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -5,6 +5,7 @@ exporter.use_uuid_filenames = false
 exporter.subfolders_by_id_substring = false
 
 exporter.fhir.export = true
+exporter.hospital.fhir.export = true
 
 generate.timestep = 604800000
 # time is in ms


### PR DESCRIPTION
## Overview
Adds providers to Java implementation of Synthea.  Currently supported services and their respective facility types include:
 - ambulatory (outpatient) service - acute hospital, non acute hospital, hospital inpatient satellite, hospital satellite
 - inpatient service - acute hospital, non acute hospital, hospital inpatient satellite 
 - emergency service - acute hospital, satellite emergency facility 

Hospitals provide different services based on the type of facility.  The services above were already built into Synthea.

Healthcare facility information is found in `healthcare_facilities.json`.  It includes all acute hospitals, non-acute hospitals, hospital inpatient satellites, satellite emergency facilities and hospital satellites registered in the state of Massachusettes.  Synthea will grab hospital information from this file by default.  (Found in src/main/resources/geography.)

## Implementation
Implementation in Java is similar to that in Ruby.  Patients are assigned to their closest service providers for each type of service upon creation, which is stored in `person`'s attributes as the preferred provider.  Distance is determined using the Haversine formula and accounts for the curvature of the Earth.  `currentProvider` is a list of the providers for active encounters so that procedures and medication prescriptions occurring during encounters would know which provider that encounter occurred at.

Provider keeps a count of the utilization of each provider, including encounters, procedures, labs, and prescriptions.  Encounters and procedures occur at the closest hospitals that provide that service.  Prescriptions associated with an encounter are counted as a prescription administered by the encounter's provider.  Otherwise, standalone prescriptions are counted as given by the patient's default hospital.  The counts of utilization mirror those reported by `textSummary()` in HealthRecord.java.  Encounters recorded by provider is one less than those recorded by `textSummary()` because the initial wellness encounter is not counted.  Labs have also not been implemented in this version.  In regards to prescriptions, all prescriptions that have started are counted.

Hospital information is currently output in fhir format.  Export can be toggled on/off in synthea.properties.