### PR TITLE
Add demographics, using city + town json config

### DIFF
--- a/src/main/java/App.java
+++ b/src/main/java/App.java
@@ -7,7 +7,7 @@ import org.mitre.synthea.modules.Person;
  */
 public class App {
  
-	public static void main(String[] args) {
+	public static void main(String[] args) throws Exception {
 		Generator generator = new Generator(1);
 		generator.run();
 		for(Person person : generator.people) {

--- a/src/main/java/org/mitre/synthea/helpers/RandomCollection.java
+++ b/src/main/java/org/mitre/synthea/helpers/RandomCollection.java
@@ -1,0 +1,25 @@
+package org.mitre.synthea.helpers;
+
+import java.util.NavigableMap;
+import java.util.Random;
+import java.util.TreeMap;
+
+/**
+ * Random collection of objects, with weightings.
+ * Intended to be an equivalent to the ruby Pickup gem.
+ * Adapted from https://stackoverflow.com/a/6409791/630384 
+ */
+public class RandomCollection<E> {
+    private final NavigableMap<Double, E> map = new TreeMap<Double, E>();
+    private double total = 0;
+
+    public void add(double weight, E result) {
+        total += weight;
+        map.put(total, result);
+    }
+
+    public E next(Random random) {
+        double value = random.nextDouble() * total;
+        return map.higherEntry(value).getValue();
+    }
+}

--- a/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
+++ b/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
@@ -38,11 +38,17 @@ public final class LifecycleModule extends Module
 		attributes.put(Person.BIRTHDATE, time);
 		person.events.create(time, Event.BIRTH, "Generator.run", true);
 		attributes.put(Person.NAME, faker.name().name());
-		attributes.put(Person.SOCIOECONOMIC_CATEGORY, "Middle"); // High Middle Low
-		attributes.put(Person.RACE, "White"); // "White", "Native" (Native American), "Hispanic", "Black", "Asian", and "Other"
-		attributes.put(Person.GENDER, person.rand() < 0.5 ? "M" : "F");
+		attributes.put(Person.SOCIOECONOMIC_CATEGORY, "Middle"); // TODO High Middle Low
+		if (!attributes.containsKey(Person.RACE))
+		{
+			attributes.put(Person.RACE, "White"); // TODO "White", "Native" (Native American), "Hispanic", "Black", "Asian", and "Other"
+		}
+		if (!attributes.containsKey(Person.GENDER))
+		{
+			attributes.put(Person.GENDER, person.rand() < 0.5 ? "M" : "F");
+		}
 
-		Location.assignPoint(person, null);
+		Location.assignPoint(person, (String)attributes.get(Person.CITY));
 		boolean hasStreetAddress2 = person.rand() < 0.5;
 		attributes.put(Person.ADDRESS, faker.address().streetAddress(hasStreetAddress2));
 

--- a/src/main/java/org/mitre/synthea/modules/Person.java
+++ b/src/main/java/org/mitre/synthea/modules/Person.java
@@ -18,7 +18,6 @@ public class Person {
 	
 	public static final String BIRTHDATE = "birthdate";
 	public static final String NAME = "name";
-	public static final String SOCIOECONOMIC_CATEGORY = "socioeconomic_category";
 	public static final String RACE = "race";
 	public static final String GENDER = "gender";
 	public static final String ID = "id";
@@ -29,8 +28,12 @@ public class Person {
 	public static final String COORDINATE = "coordinate";
 	public static final String HEIGHT = "height";
 	public static final String WEIGHT = "weight";
+	public static final String SOCIOECONOMIC_CATEGORY = "socioeconomic_category";
+	public static final String INCOME = "income";
+	public static final String EDUCATION = "education";
 	
-	private Random random;
+	public final Random random;
+	public final long seed;
 	public Map<String,Object> attributes;
 	private Map<String,Map<String,Integer>> symptoms;
 	public EventList events;
@@ -39,6 +42,7 @@ public class Person {
 	public List<State> history;
 	
 	public Person(long seed) {
+		this.seed = seed; // keep track of seed so it can be exported later
 		random = new Random(seed);
 		attributes = new ConcurrentHashMap<String,Object>();
 		symptoms = new ConcurrentHashMap<String,Map<String,Integer>>();

--- a/src/main/java/org/mitre/synthea/world/Demographics.java
+++ b/src/main/java/org/mitre/synthea/world/Demographics.java
@@ -1,0 +1,217 @@
+package org.mitre.synthea.world;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+import org.mitre.synthea.helpers.RandomCollection;
+
+import com.google.gson.Gson;
+
+/**
+ * Demographics class holds the information from the towns.json and associated county config files.
+ * This data is used to build up a synthetic population matching these real-world statistics.
+ * A single instance of Demographics represents a single city or town.
+ * The Ages, Gender, Race, Income, and Education properties are maps of frequency information.
+ * TODO: add ways to better wrap these maps so they are more accessible and useful.
+ * TODO: merge this with Location somehow. they probably don't need to be separate classes
+ */
+public class Demographics 
+{
+	public long population;
+	public String state;
+	public String county;
+	public Map<String,Double> ages;
+	private RandomCollection<String> ageDistribution;
+	public Map<String,Double> gender;
+	private RandomCollection<String> genderDistribution;
+	public Map<String,Double> race;
+	private RandomCollection<String> raceDistribution;
+	public Map<String,Double> income;
+	private RandomCollection<String> incomeDistribution;
+	public Map<String,Double> education;
+	private RandomCollection<String> educationDistribution;
+
+	public int pickAge(Random random)
+	{
+		// lazy-load in case this randomcollection isn't necessary
+		if (ageDistribution == null)
+		{
+			ageDistribution = buildRandomCollectionFromMap(ages);
+		}
+		/*
+		 Sample Age frequency:
+		 "ages": {
+		      "0..4": 0.03810425832699584,
+		      "5..9": 0.04199539968180355,
+			  [truncated]
+		      "75..79": 0.04838265689371212,
+		      "80..84": 0.037026496153182195,
+		      "85..110": 0.040978290790498896
+      		}
+		 */
+		
+		String pickedRange = ageDistribution.next(random);
+		
+		String[] range = pickedRange.split("\\.\\.");
+		// TODO this seems like it would benefit from better caching
+		int low = Integer.parseInt(range[0]);
+		int high = Integer.parseInt(range[1]);
+		
+		// nextInt is normally exclusive of the top value,
+	    // so add 1 to make it inclusive
+		return random.nextInt((high - low) + 1) + low; 
+	}
+	
+	public String pickGender(Random random)
+	{
+		// lazy-load in case this randomcollection isn't necessary
+		if (genderDistribution == null)
+		{
+			genderDistribution = buildRandomCollectionFromMap(gender);
+		}
+		
+		/*
+		 Sample Gender frequency:
+		   "gender": {
+		      "male": 0.47638487773697935,
+		      "female": 0.5236151222630206
+		    },
+		 */
+		return genderDistribution.next(random);
+	}
+	
+	public String pickRace(Random random)
+	{
+		// lazy-load in case this randomcollection isn't necessary
+		if (raceDistribution == null)
+		{
+			raceDistribution = buildRandomCollectionFromMap(race);
+		}
+		
+		/*
+		 * Sample Race frequency:
+		     "race": {
+			      "white": 0.932754172245991,
+			      "hispanic": 0.028409064399789113,
+			      "black": 0.026762094497814148,
+			      "asian": 0.014094889727666761,
+			      "native": 0.008015564565419232,
+			      "other": 0.001
+			    }, 
+		 */
+		
+		return raceDistribution.next(random);
+	}
+	
+	public int pickIncome(Random random)
+	{
+		// lazy-load in case this randomcollection isn't necessary
+		if (incomeDistribution == null)
+		{
+			Map<String,Double> tempIncome = new HashMap<>(income);
+			tempIncome.remove("mean");
+			tempIncome.remove("median");
+			incomeDistribution = buildRandomCollectionFromMap(tempIncome);
+		}
+		
+		/*
+		 * Sample Income frequency:
+		   "income": {
+		      "mean": 81908,
+		      "median": 58933,
+		      "00..10": 0.07200000000000001,
+		      "10..15": 0.055,
+		      "15..25": 0.099,
+		      "25..35": 0.079,
+		      "35..50": 0.115,
+		      "50..75": 0.205,
+		      "75..100": 0.115,
+		      "100..150": 0.155,
+		      "150..200": 0.052000000000000005,
+		      "200..999": 0.054000000000000006
+		    },
+		 */
+		
+		String pickedRange = incomeDistribution.next(random);
+		
+		String[] range = pickedRange.split("\\.\\.");
+		// TODO this seems like it would benefit from better caching
+		int low = Integer.parseInt(range[0]) * 1000;
+		int high = Integer.parseInt(range[1]) * 1000;
+		
+		// nextInt is normally exclusive of the top value,
+	    // so add 1 to make it inclusive
+		return random.nextInt((high - low) + 1) + low; 
+	}
+	
+	public String pickEducation(Random random)
+	{
+		// lazy-load in case this randomcollection isn't necessary
+		if (educationDistribution == null)
+		{
+			educationDistribution = buildRandomCollectionFromMap(education);
+		}
+		
+		return educationDistribution.next(random);
+	}
+	
+	/**
+	 * Load a map of Demographics from the JSON file at the given location.
+	 * 
+	 * @param filename location of a file containing demographic info.
+	 * @return Map of City Name -> Demographics
+	 * @throws IOException if the file could not be found or read
+	 */
+	public static Map<String,Demographics> loadByName(String filename) throws IOException
+	{	
+		InputStream stream = Location.class.getResourceAsStream(filename);
+		// read all text into a string
+		String json = new BufferedReader(new InputStreamReader(stream)).lines()
+				   .collect(Collectors.joining("\n"));
+		return loadByContent(json);
+	}
+	
+	/**
+	 * Load a map of Demographics from the given JSON string.
+	 * @param json String containing JSON content.
+	 * @return Map of City Name -> Demographics
+	 */
+	public static Map<String,Demographics> loadByContent(String json)
+	{
+		// wrap the json in a "demographicsFile" property so gson can parse it
+		json = "{ \"demographicsFile\" : " + json + " }";
+		Gson gson = new Gson();
+		
+		DemographicsFile parsed = gson.fromJson(json, DemographicsFile.class);
+
+		return parsed.demographicsFile;
+	}
+	
+	/**
+	 * Helper function to convert a map of frequencies into a RandomCollection.
+	 */
+	private static RandomCollection<String> buildRandomCollectionFromMap(Map<String,Double> map)
+	{
+		RandomCollection<String> distribution = new RandomCollection<>();
+		for (Map.Entry<String,Double> e : map.entrySet())
+		{
+			distribution.add(e.getValue(), e.getKey());
+		}
+		return distribution;
+	}
+	
+	/**
+	 * Helper class only used to make it easier to parse the towns.json
+	 * and county .json files via Gson.
+	 */
+	private static class DemographicsFile
+	{
+		private Map<String,Demographics> demographicsFile;
+	}
+}

--- a/src/main/java/org/mitre/synthea/world/Location.java
+++ b/src/main/java/org/mitre/synthea/world/Location.java
@@ -3,6 +3,7 @@ package org.mitre.synthea.world;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.Random;
 import java.util.stream.Collectors;
 
 import org.mitre.synthea.modules.Person;
@@ -56,6 +57,25 @@ public class Location {
 	public static String getZipCode(String cityName)
 	{
 		return "00000"; // TODO
+	}
+	
+	public static String randomCityName(Random random)
+	{
+		long targetPop = (long) (random.nextDouble() * totalPopulation);
+		
+		for (Feature f : cities.getFeatures())
+		{
+			Double pop = (Double) f.getProperties().get("pop");
+			targetPop -= pop.longValue();
+			
+			if (targetPop < 0)
+			{
+				return (String)f.getProperties().get("cs_name");
+
+			}
+		}
+		// should never happen
+		throw new RuntimeException("Unable to select a random city name.");
 	}
 	
 	/**

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -10,3 +10,10 @@ exporter.hospital.fhir.export = true
 generate.timestep = 604800000
 # time is in ms
 # 1000 * 60 * 60 * 24 * 7 = 604800000
+
+# default demographics is all of Massachusetts
+# can be changed to any county, ex "/geography/Middlesex_County.json"
+generate.demographics.default_file = /geography/towns.json
+
+generate.demographics.real_world_population = 6794422
+#sum of the jsons in the config folder

--- a/src/test/java/org/mitre/synthea/modules/GeneratorTest.java
+++ b/src/test/java/org/mitre/synthea/modules/GeneratorTest.java
@@ -4,10 +4,12 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 public class GeneratorTest {
-    @Test public void testGeneratorCreatesPeople() {
+    @Test public void testGeneratorCreatesPeople() throws Exception {
     	int numberOfPeople = 1;
         Generator generator = new Generator(numberOfPeople);
         generator.run();
-        assertEquals(numberOfPeople, generator.people.size());
+        assertEquals(numberOfPeople, generator.stats.get("alive").longValue());
+        // there may be more than the requested number of people, because we re-generate on death
+        assertTrue(numberOfPeople <= generator.people.size());
     }
 }


### PR DESCRIPTION
Synthetic population now roughly aligns to real-world demographics, based on selected config json.
By default the generated population is based on the full state of MA, using towns.json, but this is configurable.
This is not quite as robust as the ruby version yet, because I think there are still some wrinkles to iron out w.r.t person seeds. I.e., in the ruby version we select target demographics to ensure that the right number of people fall into each bucket, and if a person dies we start over. Here we need to ensure that a person seed always generates the same person, so we need to figure out how to combine those 2 ideas.