### PR TITLE
Fix NPE on SetAttribute states with no value

### DIFF
--- a/src/main/java/org/mitre/synthea/modules/State.java
+++ b/src/main/java/org/mitre/synthea/modules/State.java
@@ -140,8 +140,15 @@ public class State {
 			return exit;
 		case SETATTRIBUTE:
 			String attribute = definition.get("attribute").getAsString();
-			Object value = Utilities.primitive( definition.get("value").getAsJsonPrimitive() );
-			person.attributes.put(attribute, value);
+			if (definition.has("value"))
+			{
+				Object value = Utilities.primitive( definition.get("value").getAsJsonPrimitive() );
+				person.attributes.put(attribute, value);
+			} else if (person.attributes.containsKey(attribute))
+			{
+				// intentionally clear out the variable
+				person.attributes.remove(attribute);
+			}
 			this.exited = time;
 			return true;
 		case COUNTER:
@@ -292,7 +299,7 @@ public class State {
 			return true;
 		case OBSERVATION:
 			primary_code = definition.get("codes").getAsJsonArray().get(0).getAsJsonObject().get("code").getAsString();
-			value = null;
+			Object value = null;
 			if(definition.has("exact")) {
 				value = Utilities.primitive( definition.get("exact").getAsJsonObject().get("quantity").getAsJsonPrimitive() );
 			} else if(definition.has("range")) {


### PR DESCRIPTION
SetAttribute states are allowed to exclude the "value" field, in which case the corresponding attribute should be null. Currently if one of these states is hit it causes a NullPointerException at `definition.get("value")`.