### PR TITLE
Quality of life

### DIFF
--- a/src/main/java/org/mitre/synthea/export/FhirStu3.java
+++ b/src/main/java/org/mitre/synthea/export/FhirStu3.java
@@ -13,9 +13,11 @@ import org.hl7.fhir.dstu3.model.Condition.ConditionClinicalStatus;
 import org.hl7.fhir.dstu3.model.Condition.ConditionVerificationStatus;
 import org.hl7.fhir.dstu3.model.DateTimeType;
 import org.hl7.fhir.dstu3.model.DateType;
+import org.hl7.fhir.dstu3.model.DecimalType;
 import org.hl7.fhir.dstu3.model.DiagnosticReport;
 import org.hl7.fhir.dstu3.model.Encounter.EncounterStatus;
 import org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender;
+import org.hl7.fhir.dstu3.model.Extension;
 import org.hl7.fhir.dstu3.model.Immunization;
 import org.hl7.fhir.dstu3.model.MedicationRequest;
 import org.hl7.fhir.dstu3.model.Patient;
@@ -114,6 +116,17 @@ public class FhirStu3
 		{
 			patientResource.setGender(AdministrativeGender.FEMALE);
 		}
+		
+		// DALY and QALY values
+		Extension dalyExtension = new Extension(SNOMED_URI + "/disability-adjusted-life-years");
+		DecimalType daly = new DecimalType((double) person.attributes.get("DALY"));
+		dalyExtension.setValue(daly);
+		patientResource.addExtension(dalyExtension);
+		
+		Extension qalyExtension = new Extension(SNOMED_URI + "/quality-adjusted-life-years");
+		DecimalType qaly = new DecimalType((double) person.attributes.get("QALY"));
+		qalyExtension.setValue(qaly);
+		patientResource.addExtension(qalyExtension);
 		
 		return newEntry(bundle, patientResource);
 	}

--- a/src/main/java/org/mitre/synthea/helpers/QualityOfLife.java
+++ b/src/main/java/org/mitre/synthea/helpers/QualityOfLife.java
@@ -45,7 +45,7 @@ public class QualityOfLife{
         // from http://www.who.int/healthinfo/global_burden_disease/metrics_daly/en/
 		double yll = 0.0;
 		double yld = 0.0;
-		
+
 		int age = person.ageInYears(stop);
 		long birthdate = (long) person.attributes.get("birthdate");
 		
@@ -65,9 +65,9 @@ public class QualityOfLife{
 		}
 		
 		// calculate yld with yearly timestep
-		for(int i = 0; i < age; i++){
-			long yearStart = birthdate + i * TimeUnit.DAYS.toMillis(365);
-			long yearEnd = birthdate + (i+1) * TimeUnit.DAYS.toMillis(365);
+		for(int i = 0; i < age + 1; i++){
+			long yearStart = birthdate + TimeUnit.DAYS.toMillis((long) (365.25 * i));
+			long yearEnd = birthdate + (TimeUnit.DAYS.toMillis((long) (365.25 * (i+1) - 1)));
 			List<Entry> conditionsInYear = conditionsInYear(allConditions, yearStart, yearEnd);
 			
 			for(Entry condition : conditionsInYear){
@@ -88,7 +88,8 @@ public class QualityOfLife{
 		List<Entry> conditionsInYear = new ArrayList<Entry>();
 		for(Entry condition : conditions){
 			if(disabilityWeights.containsKey(condition.codes.get(0).display)){
-				if(yearStart >= condition.start && condition.start < yearEnd){
+				// condition.stop == 0 for conditions that have not yet ended
+				if(yearStart >= condition.start && condition.start <= yearEnd && (condition.stop > yearStart || condition.stop == 0)){
 					conditionsInYear.add(condition);
 				}
 			}

--- a/src/main/java/org/mitre/synthea/helpers/QualityOfLife.java
+++ b/src/main/java/org/mitre/synthea/helpers/QualityOfLife.java
@@ -1,0 +1,107 @@
+package org.mitre.synthea.helpers;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.io.BufferedReader;
+
+import org.mitre.synthea.modules.HealthRecord.Encounter;
+import org.mitre.synthea.modules.HealthRecord.Entry;
+import org.mitre.synthea.modules.Person;
+
+import com.google.gson.Gson;
+import com.google.gson.internal.LinkedTreeMap;
+
+public class QualityOfLife{
+	
+	public static HashMap<String, LinkedTreeMap> disabilityWeights;
+	
+	public QualityOfLife(){
+		String filename = "/gbd_disability_weights.json";
+		try {
+			InputStream stream = QualityOfLife.class.getResourceAsStream(filename);
+			String json = new BufferedReader(new InputStreamReader(stream)).lines()
+					.parallel().collect(Collectors.joining("\n"));
+			Gson g = new Gson();
+			disabilityWeights = g.fromJson(json, HashMap.class);
+		}
+		catch (Exception e) {
+			System.err.println("ERROR: unable to load json: " + filename);
+			e.printStackTrace();
+			throw new ExceptionInInitializerError(e);
+		}
+	}
+	
+	public static void calculate(Person person, long stop){
+        // Disability-Adjusted Life Year = DALY = YLL + YLD
+        // Years of Life Lost = YLL = (1) * (standard life expectancy at age of death in years)
+        // Years Lost due to Disability = YLD = (disability weight) * (average duration of case)
+        // from http://www.who.int/healthinfo/global_burden_disease/metrics_daly/en/
+		double yll = 0.0;
+		double yld = 0.0;
+		
+		int age = person.ageInYears(stop);
+		long birthdate = (long) person.attributes.get("birthdate");
+		
+		if(!person.alive(stop)){
+	          // life expectancy equation derived from IHME GBD 2015 Reference Life Table
+	          // 6E-5x^3 - 0.0054x^2 - 0.8502x + 86.16
+	          // R^2 = 0.99978
+	          double l = ((0.00006 * Math.pow(age, 3)) - (0.0054 * Math.pow(age, 2)) - (0.8502 * age) + 86.16);
+	          yll = l;
+		}
+		// get list of conditions 
+		List<Entry> allConditions = new ArrayList<Entry>();
+		for(Encounter encounter : person.record.encounters){
+			for(Entry condition : encounter.conditions){
+				allConditions.add(condition);
+			}
+		}
+		
+		// calculate yld with yearly timestep
+		for(int i = 0; i < age; i++){
+			long yearStart = birthdate + i * TimeUnit.DAYS.toMillis(365);
+			long yearEnd = birthdate + (i+1) * TimeUnit.DAYS.toMillis(365);
+			List<Entry> conditionsInYear = conditionsInYear(allConditions, yearStart, yearEnd);
+			
+			for(Entry condition : conditionsInYear){
+				double disabilityWeight = (double) disabilityWeights.get(condition.codes.get(0).display).get("disability_weight");
+				double weight = weight(disabilityWeight, i+1);
+				yld += weight;
+			}
+		}
+		
+		double daly = yll + yld;
+		double qaly = age - yld;
+		
+		person.attributes.put("DALY", daly);
+		person.attributes.put("QALY", qaly);
+	}
+	
+	public static List<Entry> conditionsInYear(List<Entry> conditions, long yearStart, long yearEnd){
+		List<Entry> conditionsInYear = new ArrayList<Entry>();
+		for(Entry condition : conditions){
+			if(disabilityWeights.containsKey(condition.codes.get(0).display)){
+				if(yearStart >= condition.start && condition.start < yearEnd){
+					conditionsInYear.add(condition);
+				}
+			}
+		}
+		return conditionsInYear;
+	}
+	
+	public static double weight(double disabilityWeight, int age){
+        // age_weight = 0.1658 * age * e^(-0.04 * age)
+        // from http://www.who.int/quantifying_ehimpacts/publications/9241546204/en/
+        // weight = age_weight * disability_weight
+		double ageWeight = 0.1658 * age * Math.exp(-0.04 * age);
+		double weight = ageWeight * disabilityWeight;
+		return weight;
+	}
+}

--- a/src/main/java/org/mitre/synthea/modules/State.java
+++ b/src/main/java/org/mitre/synthea/modules/State.java
@@ -150,6 +150,7 @@ public class State {
 				// intentionally clear out the variable
 				person.attributes.remove(attribute);
 			}
+			
 			this.exited = time;
 			return true;
 		case COUNTER:

--- a/src/main/resources/gbd_disability_weights.json
+++ b/src/main/resources/gbd_disability_weights.json
@@ -20,13 +20,13 @@
 
   "Microalbuminuria due to type 2 diabetes mellitus (disorder)" : {
     "system": "SNOMED-CT",
-    "code": "9.08E+13",
+    "code": "90800000000000",
     "disability_weight": 0.049
     },
 
   "Proteinuria due to type 2 diabetes mellitus (disorder)" : {
     "system": "SNOMED-CT",
-    "code": "1.57E+14",
+    "code": "157000000000000",
     "disability_weight": 0.049
     },
 
@@ -44,31 +44,31 @@
 
   "Nonproliferative diabetic retinopathy due to type 2 diabetes mellitus (disorder)" : {
     "system": "SNOMED-CT",
-    "code": "1.55E+12",
+    "code": "1550000000000",
     "disability_weight": 0.003
     },
 
   "Proliferative diabetic retinopathy due to type II diabetes mellitus (disorder)" : {
     "system": "SNOMED-CT",
-    "code": "1.50E+12",
+    "code": "1500000000000",
     "disability_weight": 0.031
     },
 
   "Macular edema and retinopathy due to type 2 diabetes mellitus (disorder)" : {
     "system": "SNOMED-CT",
-    "code": "9.73E+13",
+    "code": "97300000000000",
     "disability_weight": 0.031
     },
 
   "Blindness due to type 2 diabetes mellitus (disorder)" : {
     "system": "SNOMED-CT",
-    "code": "6.10E+13",
+    "code": "61000000000000",
     "disability_weight": 0.187
     },
 
   "Neuropathy due to type 2 diabetes mellitus (disorder)" : {
     "system": "SNOMED-CT",
-    "code": "3.69E+14",
+    "code": "369000000000000",
     "disability_weight": 0.133
     },
 
@@ -458,25 +458,25 @@
 
   "Primary small cell malignant neoplasm of lung  TNM stage 1 (disorder)" : {
     "system": "SNOMED-CT",
-    "code": "6.78E+13",
+    "code": "67800000000000",
     "disability_weight": 0.049
     },
 
   "Primary small cell malignant neoplasm of lung  TNM stage 2 (disorder)" : {
     "system": "SNOMED-CT",
-    "code": "6.78E+13",
+    "code": "67800000000000",
     "disability_weight": 0.049
     },
 
   "Primary small cell malignant neoplasm of lung  TNM stage 3 (disorder)" : {
     "system": "SNOMED-CT",
-    "code": "6.78E+13",
+    "code": "67800000000000",
     "disability_weight": 0.451
     },
 
   "Primary small cell malignant neoplasm of lung  TNM stage 4 (disorder)" : {
     "system": "SNOMED-CT",
-    "code": "6.78E+13",
+    "code": "67800000000000",
     "disability_weight": 0.54
     },
 
@@ -488,7 +488,7 @@
 
   "Chronic intractable migraine without aura" : {
     "system": "SNOMED-CT",
-    "code": "1.24E+14",
+    "code": "124000000000000",
     "disability_weight": 0.441
     },
 

--- a/src/main/resources/gbd_disability_weights.json
+++ b/src/main/resources/gbd_disability_weights.json
@@ -1,0 +1,542 @@
+{
+
+  "Prediabetes" : {
+    "system": "SNOMED-CT",
+    "code": "15777000",
+    "disability_weight": 0.049
+    },
+
+  "Diabetes" : {
+    "system": "SNOMED-CT",
+    "code": "44054006",
+    "disability_weight": 0.049
+    },
+
+  "Diabetic renal disease (disorder)" : {
+    "system": "SNOMED-CT",
+    "code": "127013003",
+    "disability_weight": 0.024
+    },
+
+  "Microalbuminuria due to type 2 diabetes mellitus (disorder)" : {
+    "system": "SNOMED-CT",
+    "code": "9.08E+13",
+    "disability_weight": 0.049
+    },
+
+  "Proteinuria due to type 2 diabetes mellitus (disorder)" : {
+    "system": "SNOMED-CT",
+    "code": "1.57E+14",
+    "disability_weight": 0.049
+    },
+
+  "End stage renal disease (disorder)" : {
+    "system": "SNOMED-CT",
+    "code": "46177005",
+    "disability_weight": 0.571
+    },
+
+  "Diabetic retinopathy associated with type II diabetes mellitus (disorder)" : {
+    "system": "SNOMED-CT",
+    "code": "422034002",
+    "disability_weight": 0.184
+    },
+
+  "Nonproliferative diabetic retinopathy due to type 2 diabetes mellitus (disorder)" : {
+    "system": "SNOMED-CT",
+    "code": "1.55E+12",
+    "disability_weight": 0.003
+    },
+
+  "Proliferative diabetic retinopathy due to type II diabetes mellitus (disorder)" : {
+    "system": "SNOMED-CT",
+    "code": "1.50E+12",
+    "disability_weight": 0.031
+    },
+
+  "Macular edema and retinopathy due to type 2 diabetes mellitus (disorder)" : {
+    "system": "SNOMED-CT",
+    "code": "9.73E+13",
+    "disability_weight": 0.031
+    },
+
+  "Blindness due to type 2 diabetes mellitus (disorder)" : {
+    "system": "SNOMED-CT",
+    "code": "6.10E+13",
+    "disability_weight": 0.187
+    },
+
+  "Neuropathy due to type 2 diabetes mellitus (disorder)" : {
+    "system": "SNOMED-CT",
+    "code": "3.69E+14",
+    "disability_weight": 0.133
+    },
+
+  "Stroke" : {
+    "system": "SNOMED-CT",
+    "code": "230690007",
+    "disability_weight": 0.07
+    },
+
+  "Coronary Heart Disease" : {
+    "system": "SNOMED-CT",
+    "code": "53741008",
+    "disability_weight": 0.049
+    },
+
+  "Atrial Fibrillation" : {
+    "system": "SNOMED-CT",
+    "code": "49436004",
+    "disability_weight": 0.224
+    },
+
+  "Disorder of cardiovascular system" : {
+    "system": "SNOMED-CT",
+    "code": "49601007",
+    "disability_weight": 0.049
+    },
+
+  "Type II Diabetes Mellitus Well Controlled" : {
+    "system": "SNOMED-CT",
+    "code": "444110003",
+    "disability_weight": 0.049
+    },
+
+  "Amputation of left arm" : {
+    "system": "SNOMED-CT",
+    "code": "13995008",
+    "disability_weight": 0.039
+    },
+
+  "Amputation of right hand" : {
+    "system": "SNOMED-CT",
+    "code": "46028000",
+    "disability_weight": 0.039
+    },
+
+  "Amputation of right foot" : {
+    "system": "SNOMED-CT",
+    "code": "180030006",
+    "disability_weight": 0.039
+    },
+
+  "Amputation of right leg" : {
+    "system": "SNOMED-CT",
+    "code": "79733001",
+    "disability_weight": 0.039
+    },
+
+  "Appendicitis" : {
+    "system": "SNOMED-CT",
+    "code": "74400008",
+    "disability_weight": 0.324
+    },
+
+  "Childhood asthma" : {
+    "system": "SNOMED-CT",
+    "code": "233678006",
+    "disability_weight": 0.015
+    },
+
+  "Asthma" : {
+    "system": "SNOMED-CT",
+    "code": "195967001",
+    "disability_weight": 0.015
+    },
+
+  "Child attention deficit disorder" : {
+    "system": "SNOMED-CT",
+    "code": "192127007",
+    "disability_weight": 0.045
+    },
+
+  "Overactivity/inattention behavior management" : {
+    "system": "SNOMED-CT",
+    "code": "386522008",
+    "disability_weight": 0.045
+    },
+
+  "Protracted diarrhea" : {
+    "system": "SNOMED-CT",
+    "code": "236077008",
+    "disability_weight": 0.247
+    },
+
+  "Bleeding from anus" : {
+    "system": "SNOMED-CT",
+    "code": "6072007",
+    "disability_weight": 0.325
+    },
+
+  "Primary malignant neoplasm of colon" : {
+    "system": "SNOMED-CT",
+    "code": "93761005",
+    "disability_weight": 0.049
+    },
+
+  "Overlapping malignant neoplasm of colon" : {
+    "system": "SNOMED-CT",
+    "code": "109838007",
+    "disability_weight": 0.049
+    },
+
+  "Malignant tumor of colon" : {
+    "system": "SNOMED-CT",
+    "code": "363406005",
+    "disability_weight": 0.451
+    },
+
+  "Secondary malignant neoplasm of colon" : {
+    "system": "SNOMED-CT",
+    "code": "94260004",
+    "disability_weight": 0.049
+    },
+
+  "Pulmonary emphysema (disorder)" : {
+    "system": "SNOMED-CT",
+    "code": "87433001",
+    "disability_weight": 0.019
+    },
+
+  "Chronic obstructive bronchitis (disorder)" : {
+    "system": "SNOMED-CT",
+    "code": "185086009",
+    "disability_weight": 0.019
+    },
+
+  "Alzheimer's disease (disorder)" : {
+    "system": "SNOMED-CT",
+    "code": "26929004",
+    "disability_weight": 0.377
+    },
+
+  "Familial Alzheimer's disease of early onset (disorder)" : {
+    "system": "SNOMED-CT",
+    "code": "230265002",
+    "disability_weight": 0.377
+    },
+
+  "Atopic dermatitis" : {
+    "system": "SNOMED-CT",
+    "code": "24079001",
+    "disability_weight": 0.027
+    },
+
+  "Contact dermatitis" : {
+    "system": "SNOMED-CT",
+    "code": "40275004",
+    "disability_weight": 0.027
+    },
+
+  "Otitis media" : {
+    "system": "SNOMED-CT",
+    "code": "65363002",
+    "disability_weight": 0.013
+    },
+
+  "Gout" : {
+    "system": "SNOMED-CT",
+    "code": "90560007",
+    "disability_weight": 0.295
+    },
+
+  "Fracture of the vertebral column with spinal cord injury" : {
+    "system": "SNOMED-CT",
+    "code": "1734006",
+    "disability_weight": 0.111
+    },
+
+  "Chronic paralysis due to lesion of spinal cord" : {
+    "system": "SNOMED-CT",
+    "code": "698754002",
+    "disability_weight": 0.296
+    },
+
+  "Fracture of vertebral column without spinal cord injury" : {
+    "system": "SNOMED-CT",
+    "code": "15724005",
+    "disability_weight": 0.111
+    },
+
+  "Concussion with no loss of consciousness" : {
+    "system": "SNOMED-CT",
+    "code": "62106007",
+    "disability_weight": 0.214
+    },
+
+  "Concussion with loss of consciousness" : {
+    "system": "SNOMED-CT",
+    "code": "62564004",
+    "disability_weight": 0.214
+    },
+
+  "Concussion injury of brain" : {
+    "system": "SNOMED-CT",
+    "code": "110030002",
+    "disability_weight": 0.214
+    },
+
+  "Brain damage - traumatic" : {
+    "system": "SNOMED-CT",
+    "code": "275272006",
+    "disability_weight": 0.231
+    },
+
+  "Whiplash injury to neck" : {
+    "system": "SNOMED-CT",
+    "code": "39848009",
+    "disability_weight": 0.114
+    },
+
+  "Fracture of clavicle" : {
+    "system": "SNOMED-CT",
+    "code": "58150001",
+    "disability_weight": 0.035
+    },
+
+  "Fracture of forearm" : {
+    "system": "SNOMED-CT",
+    "code": "65966004",
+    "disability_weight": 0.028
+    },
+
+  "Fracture subluxation of wrist" : {
+    "system": "SNOMED-CT",
+    "code": "263102004",
+    "disability_weight": 0.01
+    },
+
+  "Fracture of ankle" : {
+    "system": "SNOMED-CT",
+    "code": "16114001",
+    "disability_weight": 0.026
+    },
+
+  "Fracture of rib" : {
+    "system": "SNOMED-CT",
+    "code": "33737001",
+    "disability_weight": 0.103
+    },
+
+  "Closed fracture of hip" : {
+    "system": "SNOMED-CT",
+    "code": "359817006",
+    "disability_weight": 0.103
+    },
+
+  "First degree burn" : {
+    "system": "SNOMED-CT",
+    "code": "403190006",
+    "disability_weight": 0.141
+    },
+
+  "Second degree burn" : {
+    "system": "SNOMED-CT",
+    "code": "403191005",
+    "disability_weight": 0.314
+    },
+
+  "Third degree burn" : {
+    "system": "SNOMED-CT",
+    "code": "403192003",
+    "disability_weight": 0.455
+    },
+
+  "Laceration of hand" : {
+    "system": "SNOMED-CT",
+    "code": "284549007",
+    "disability_weight": 0.006
+    },
+
+  "Laceration of forearm" : {
+    "system": "SNOMED-CT",
+    "code": "283371005",
+    "disability_weight": 0.006
+    },
+
+  "Laceration of thigh" : {
+    "system": "SNOMED-CT",
+    "code": "283385000",
+    "disability_weight": 0.006
+    },
+
+  "Facial laceration" : {
+    "system": "SNOMED-CT",
+    "code": "370247008",
+    "disability_weight": 0.006
+    },
+
+  "Laceration of foot" : {
+    "system": "SNOMED-CT",
+    "code": "284551006",
+    "disability_weight": 0.006
+    },
+
+  "Sprain of ankle" : {
+    "system": "SNOMED-CT",
+    "code": "44465007",
+    "disability_weight": 0.008
+    },
+
+  "Sprain of wrist" : {
+    "system": "SNOMED-CT",
+    "code": "70704007",
+    "disability_weight": 0.008
+    },
+
+  "Injury of anterior cruciate ligament" : {
+    "system": "SNOMED-CT",
+    "code": "444470001",
+    "disability_weight": 0.008
+    },
+
+  "Injury of medial collateral ligament of knee" : {
+    "system": "SNOMED-CT",
+    "code": "444448004",
+    "disability_weight": 0.008
+    },
+
+  "Tear of meniscus of knee" : {
+    "system": "SNOMED-CT",
+    "code": "239720000",
+    "disability_weight": 0.008
+    },
+
+  "Rupture of patellar tendon" : {
+    "system": "SNOMED-CT",
+    "code": "30832001",
+    "disability_weight": 0.008
+    },
+
+  "Injury of tendon of the rotator cuff of shoulder" : {
+    "system": "SNOMED-CT",
+    "code": "307731004",
+    "disability_weight": 0.062
+    },
+
+  "Burn injury(morphologic abnormality)" : {
+    "system": "SNOMED-CT",
+    "code": "48333001",
+    "disability_weight": 0.141
+    },
+
+  "Non-small cell lung cancer (disorder)" : {
+    "system": "SNOMED-CT",
+    "code": "254637007",
+    "disability_weight": 0.288
+    },
+
+  "Small cell carcinoma of lung (disorder)" : {
+    "system": "SNOMED-CT",
+    "code": "254632001",
+    "disability_weight": 0.288
+    },
+
+  "Non-small cell carcinoma of lung  TNM stage 1 (disorder)" : {
+    "system": "SNOMED-CT",
+    "code": "424132000",
+    "disability_weight": 0.049
+    },
+
+  "Non-small cell carcinoma of lung  TNM stage 2 (disorder)" : {
+    "system": "SNOMED-CT",
+    "code": "425048006",
+    "disability_weight": 0.049
+    },
+
+  "Non-small cell carcinoma of lung  TNM stage 3 (disorder)" : {
+    "system": "SNOMED-CT",
+    "code": "422968005",
+    "disability_weight": 0.451
+    },
+
+  "Non-small cell carcinoma of lung  TNM stage 4 (disorder)" : {
+    "system": "SNOMED-CT",
+    "code": "423121009",
+    "disability_weight": 0.54
+    },
+
+  "Primary small cell malignant neoplasm of lung  TNM stage 1 (disorder)" : {
+    "system": "SNOMED-CT",
+    "code": "6.78E+13",
+    "disability_weight": 0.049
+    },
+
+  "Primary small cell malignant neoplasm of lung  TNM stage 2 (disorder)" : {
+    "system": "SNOMED-CT",
+    "code": "6.78E+13",
+    "disability_weight": 0.049
+    },
+
+  "Primary small cell malignant neoplasm of lung  TNM stage 3 (disorder)" : {
+    "system": "SNOMED-CT",
+    "code": "6.78E+13",
+    "disability_weight": 0.451
+    },
+
+  "Primary small cell malignant neoplasm of lung  TNM stage 4 (disorder)" : {
+    "system": "SNOMED-CT",
+    "code": "6.78E+13",
+    "disability_weight": 0.54
+    },
+
+  "Chronic pain" : {
+    "system": "SNOMED-CT",
+    "code": "82423001",
+    "disability_weight": 0.02
+    },
+
+  "Chronic intractable migraine without aura" : {
+    "system": "SNOMED-CT",
+    "code": "1.24E+14",
+    "disability_weight": 0.441
+    },
+
+  "Osteoarthritis of knee" : {
+    "system": "SNOMED-CT",
+    "code": "239873007",
+    "disability_weight": 0.079
+    },
+
+  "Osteoarthritis of hip" : {
+    "system": "SNOMED-CT",
+    "code": "239872002",
+    "disability_weight": 0.079
+    },
+
+  "Preeclampsia" : {
+    "system": "SNOMED-CT",
+    "code": "398254007",
+    "disability_weight": 0.049
+    },
+
+  "Antepartum eclampsia" : {
+    "system": "SNOMED-CT",
+    "code": "198992004",
+    "disability_weight": 0.049
+    },
+
+  "Rheumatoid arthritis" : {
+    "system": "SNOMED-CT",
+    "code": "69896004",
+    "disability_weight": 0.317
+    },
+
+  "Escherichia coli urinary tract infection" : {
+    "system": "SNOMED-CT",
+    "code": "301011002",
+    "disability_weight": 0.051
+    },
+
+  "Cystitis" : {
+    "system": "SNOMED-CT",
+    "code": "38822007",
+    "disability_weight": 0.051
+    },
+
+  "Recurrent urinary tract infection" : {
+    "system": "SNOMED-CT",
+    "code": "197927001",
+    "disability_weight": 0.051
+    }
+}

--- a/src/main/resources/gbd_disability_weights.json
+++ b/src/main/resources/gbd_disability_weights.json
@@ -20,13 +20,13 @@
 
   "Microalbuminuria due to type 2 diabetes mellitus (disorder)" : {
     "system": "SNOMED-CT",
-    "code": "90800000000000",
+    "code": "90781000119102",
     "disability_weight": 0.049
     },
 
   "Proteinuria due to type 2 diabetes mellitus (disorder)" : {
     "system": "SNOMED-CT",
-    "code": "157000000000000",
+    "code": "157141000119108",
     "disability_weight": 0.049
     },
 
@@ -44,31 +44,31 @@
 
   "Nonproliferative diabetic retinopathy due to type 2 diabetes mellitus (disorder)" : {
     "system": "SNOMED-CT",
-    "code": "1550000000000",
+    "code": "1551000119108",
     "disability_weight": 0.003
     },
 
   "Proliferative diabetic retinopathy due to type II diabetes mellitus (disorder)" : {
     "system": "SNOMED-CT",
-    "code": "1500000000000",
+    "code": "1501000119109",
     "disability_weight": 0.031
     },
 
   "Macular edema and retinopathy due to type 2 diabetes mellitus (disorder)" : {
     "system": "SNOMED-CT",
-    "code": "97300000000000",
+    "code": "97331000119101",
     "disability_weight": 0.031
     },
 
   "Blindness due to type 2 diabetes mellitus (disorder)" : {
     "system": "SNOMED-CT",
-    "code": "61000000000000",
+    "code": "60951000119105",
     "disability_weight": 0.187
     },
 
   "Neuropathy due to type 2 diabetes mellitus (disorder)" : {
     "system": "SNOMED-CT",
-    "code": "369000000000000",
+    "code": "368581000119106",
     "disability_weight": 0.133
     },
 
@@ -458,25 +458,25 @@
 
   "Primary small cell malignant neoplasm of lung  TNM stage 1 (disorder)" : {
     "system": "SNOMED-CT",
-    "code": "67800000000000",
+    "code": "67811000119102",
     "disability_weight": 0.049
     },
 
   "Primary small cell malignant neoplasm of lung  TNM stage 2 (disorder)" : {
     "system": "SNOMED-CT",
-    "code": "67800000000000",
+    "code": "67821000119109",
     "disability_weight": 0.049
     },
 
   "Primary small cell malignant neoplasm of lung  TNM stage 3 (disorder)" : {
     "system": "SNOMED-CT",
-    "code": "67800000000000",
+    "code": "67831000119107",
     "disability_weight": 0.451
     },
 
   "Primary small cell malignant neoplasm of lung  TNM stage 4 (disorder)" : {
     "system": "SNOMED-CT",
-    "code": "67800000000000",
+    "code": "67841000119103",
     "disability_weight": 0.54
     },
 
@@ -488,7 +488,7 @@
 
   "Chronic intractable migraine without aura" : {
     "system": "SNOMED-CT",
-    "code": "124000000000000",
+    "code": "124171000119105",
     "disability_weight": 0.441
     },
 

--- a/src/test/java/org/mitre/synthea/modules/QualityOfLifeTest.java
+++ b/src/test/java/org/mitre/synthea/modules/QualityOfLifeTest.java
@@ -1,0 +1,121 @@
+package org.mitre.synthea.modules;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mitre.synthea.helpers.QualityOfLife;
+import org.mitre.synthea.modules.HealthRecord.Code;
+import org.mitre.synthea.modules.HealthRecord.Encounter;
+import org.mitre.synthea.modules.HealthRecord.Entry;
+
+import static org.junit.Assert.*;
+
+//test calculate, conditionsInYear, weight
+
+public class QualityOfLifeTest {
+	
+	private Person person;
+	private QualityOfLife qolCalculator;
+	
+	public static final long stopTime = ((long) (365.25 * 35)) + 1;
+	
+	@Before
+	public void init(){
+		person = new Person(0);
+		person.events.create(0, "birth", "QualityOfLifeTest", true);
+		person.attributes.put("birthdate", 0L);
+		
+		// Diabetes - code = 44054006; dw = 0.049
+		// ADD - code = 192127007; dw = 0.045
+		// Asthma - code = 195967001; dw = 0.015
+		
+		//                   asthma
+		//             |-----------------|
+		//               ADD            diabetes
+		//             |-----|     |-----------------|
+		// |-----|-----|-----|-----|-----|-----|-----|
+		// 0     5     10    15    20    25    30    35  
+		
+		Entry ADDCondition = person.record.conditionStart(TimeUnit.DAYS.toMillis((long) (365.25 * 10)), "192127007");
+		ADDCondition.name = "Child attention deficit disorder";
+		Code ADDCode = new Code("SNOMED", "192127007", "Child attention deficit disorder");
+		ADDCondition.codes.add(ADDCode);
+		
+		Entry asthmaCondition = person.record.conditionStart(TimeUnit.DAYS.toMillis((long) (365.25 * 10)), "195967001");
+		asthmaCondition.name = "Asthma";
+		Code asthmaCode = new Code("SNOMED", "195967001", "Asthma");
+		asthmaCondition.codes.add(asthmaCode);
+		
+		person.record.conditionEnd((TimeUnit.DAYS.toMillis((long) (365.25 * 15) - 1)), "192127007"); // ADD ends
+		
+		Entry diabetesCondition = person.record.conditionStart(TimeUnit.DAYS.toMillis((long) (365.25 * 20)), "44054006");
+		diabetesCondition.name = "Diabetes";
+		Code diabetesCode = new Code("SNOMED", "4405400", "Diabetes");
+		diabetesCondition.codes.add(diabetesCode);
+		
+		person.record.conditionEnd((TimeUnit.DAYS.toMillis((long) (365.25 * 25) - 1)), "195967001"); // asthma ends
+		
+		qolCalculator = new QualityOfLife();
+	}
+	
+	@Test
+	public void testCalculateLiving(){
+		// living patient
+		// + 1 ms because (365.25 * 35) = 12783.75 as double and 12783 as long
+		qolCalculator.calculate(person, TimeUnit.DAYS.toMillis(stopTime));
+		
+		double daly_living = (double) person.attributes.get("DALY");
+		double qaly_living = (double) person.attributes.get("QALY");
+		assertEquals(true, (daly_living > 1.7 && daly_living < 1.8));
+		assertEquals(true, (qaly_living > 33 && qaly_living < 34));
+	}
+	
+	@Test
+	public void testCalculateDeceased(){
+		// deceased patient
+		person.events.create(TimeUnit.DAYS.toMillis((long) (365.25 * 35)), "death", "QualityOfLifeTest", true);
+		qolCalculator.calculate(person, TimeUnit.DAYS.toMillis(stopTime));
+		
+		double daly_deceased = (double) person.attributes.get("DALY");
+		double qaly_deceased = (double) person.attributes.get("QALY");
+		assertEquals(true, (daly_deceased > 54 && daly_deceased < 55));
+		assertEquals(true, (qaly_deceased > 33 && qaly_deceased < 34));
+	}
+	
+	@Test
+	public void testConditionsInYear(){
+		List<Entry> allConditions = new ArrayList<Entry>();
+		for(Encounter e : person.record.encounters){
+			for(Entry condition : e.conditions){
+				allConditions.add(condition);
+			}
+		}
+		
+		// conditions in year 5
+		List<Entry> conditionsYear5 = qolCalculator.conditionsInYear(allConditions, TimeUnit.DAYS.toMillis((long) (365.25 * 5)), TimeUnit.DAYS.toMillis((long) (365.25 * 6)));
+		List<Entry> empty = new ArrayList<Entry>();	
+		assertEquals(empty, conditionsYear5);
+		
+		// conditions in year 10
+		List<Entry> conditionsYear10 = qolCalculator.conditionsInYear(allConditions, TimeUnit.DAYS.toMillis((long) (365.25 * 10)), TimeUnit.DAYS.toMillis((long) (365.25 * 11)));
+		assertEquals(2, conditionsYear10.size());
+		assertEquals("Child attention deficit disorder", conditionsYear10.get(0).name);
+		assertEquals("Asthma", conditionsYear10.get(1).name);
+		
+		// conditions in year 30
+		List<Entry> conditionsYear30 = qolCalculator.conditionsInYear(allConditions, TimeUnit.DAYS.toMillis((long) (365.25 * 30)), TimeUnit.DAYS.toMillis((long) (365.25 * 31)));
+		assertEquals(1, conditionsYear30.size());
+		assertEquals("Diabetes", conditionsYear30.get(0).name);
+	}
+	
+	@Test
+	public void testWeight(){
+		// age 15 with disability weight of 0.45
+		double weight = qolCalculator.weight(0.45,  15);
+		assertEquals(true, (weight > 0.614 && weight < 0.615));
+	}
+	
+}


### PR DESCRIPTION
This PR introduces calculations for DALYs (disability adjusted life years) and QALYs (quality adjusted life years) for patients.  Disability weights are taken from the Global Burden of Disease Study 2015 (http://ghdx.healthdata.org/gbd-2015) and are used to calculate DALY.  These disability weights are mapped to conditions using SNOMED codes and stored in `resources/gbd_disability_weights.json`. 

DALY is calculated on a yearly timestep, after the patient has been generate, by `QualityOfLife.java`.  The calculate method takes `stop` as an argument, which is the time during a patient’s life that the quality of life values should be calculated.  This value is currently set to the end of the simulation.  

> Disability-Adjusted Life Year = DALY = YLL + YLD
>  Years of Life Lost = YLL = (1) * (standard life expectancy at age of death in years)
> Years Lost due to Disability = YLD = (disability weight) * (average duration of case)
> 
> Quality-Adjusted Life Year = QALY = age - YLD

The resulting values are stored in the person’s `attributes`.  They are exported by the `FhirStu3` exporter as extensions.  ‘Quality adjusted life year’ SNOMED code is used for QALY and ‘Disability rating scale’ SNOMED code is used for DALY since specific codes do not exist. 

### TODO
- Modify `QualityOfLife.java` to use the Java Time library instead of `TimeUnit`.
- Change storage of DALY/QALY information from `person.attributes` to observations.