### PR TITLE
Fix wellness encounters and skeleton vital signs.

### DIFF
--- a/src/main/java/org/mitre/synthea/modules/CardiovascularDiseaseModule.java
+++ b/src/main/java/org/mitre/synthea/modules/CardiovascularDiseaseModule.java
@@ -5,6 +5,10 @@ import java.util.Calendar;
 
 public final class CardiovascularDiseaseModule extends Module 
 {
+	public CardiovascularDiseaseModule() {
+		this.name = "Cardiovascular Disease";
+	}
+
 	@Override
 	public boolean process(Person person, long time) 
 	{

--- a/src/main/java/org/mitre/synthea/modules/EncounterModule.java
+++ b/src/main/java/org/mitre/synthea/modules/EncounterModule.java
@@ -1,0 +1,64 @@
+package org.mitre.synthea.modules;
+
+import org.mitre.synthea.modules.HealthRecord.Encounter;
+import org.mitre.synthea.modules.HealthRecord.EncounterType;
+
+public final class EncounterModule extends Module {
+	
+	public final static String ACTIVE_WELLNESS_ENCOUNTER = "active_wellness_encounter";
+	public final static int SYMPTOM_THRESHOLD = 200;
+	
+	public EncounterModule() {
+		this.name = "Encounter";
+	}
+	
+	@Override
+	public boolean process(Person person, long time) 
+	{
+		// add a wellness encounter if this is the right time
+		if(person.record.timeSinceLastWellnessEncounter(time) >= recommendedTimeBetweenWellnessVisits(person, time)) {
+			Encounter encounter = person.record.encounterStart(time, EncounterType.WELLNESS.toString());
+			encounter.name = "Encounter Module Scheduled Wellness";
+			person.attributes.put(ACTIVE_WELLNESS_ENCOUNTER, true);
+		} else if(person.symptomTotal() > SYMPTOM_THRESHOLD) {
+			// add a symptom driven encounter if symptoms are severe
+			person.resetSymptoms();
+			Encounter encounter = person.record.encounterStart(time, EncounterType.WELLNESS.toString());
+			encounter.name = "Encounter Module Symptom Driven";
+			person.attributes.put(ACTIVE_WELLNESS_ENCOUNTER, true);
+		}
+		
+		// java modules will never "finish"
+		return false;
+	}
+	
+	public long recommendedTimeBetweenWellnessVisits(Person person, long time) {
+		int ageInYears = person.ageInYears(time);
+		if(ageInYears <= 3) {
+			int ageInMonths = person.ageInMonths(time);
+			if(ageInMonths <= 1) {
+				return Utilities.convertTime("months", 1);
+			} else if(ageInMonths <= 5) {
+				return Utilities.convertTime("months", 2);
+			} else if(ageInMonths <= 17) {
+				return Utilities.convertTime("months", 3);
+			} else {
+				return Utilities.convertTime("months", 6);				
+			}
+		} else if(ageInYears <= 19) {
+			return Utilities.convertTime("years", 1);
+		} else if(ageInYears <= 39) {
+			return Utilities.convertTime("years", 3);
+		} else if(ageInYears <= 49) {
+			return Utilities.convertTime("years", 2);
+		} else {
+			return Utilities.convertTime("years", 1);
+		}
+	}
+	
+	public void endWellnessEncounter(Person person, long time) {
+		person.record.encounterEnd(time, EncounterType.WELLNESS.toString());
+		person.attributes.remove(ACTIVE_WELLNESS_ENCOUNTER);
+	}
+	
+}

--- a/src/main/java/org/mitre/synthea/modules/Generator.java
+++ b/src/main/java/org/mitre/synthea/modules/Generator.java
@@ -125,23 +125,27 @@ public class Generator {
 				long start = setDemographics(person, cityName, city);
 				
 				LifecycleModule.birth(person, start);
+				EncounterModule encounterModule = new EncounterModule();
 				
 				people.add(person);
 				
 				long time = start;
 				while(person.alive(time) && time < stop)
 				{
+					encounterModule.process(person, time);
 					Iterator<Module> iter = modules.iterator();
 					while(iter.hasNext())
 					{
 						Module module = iter.next();
-	//					System.out.format("Processing module %s\n", module.name);
+						//System.out.format("Processing module %s\n", module.name);
 						if(module.process(person, time))
 						{
-	//						System.out.format("Removing module %s\n", module.name);
+							//System.out.format("Removing module %s\n", module.name);
 							iter.remove(); // this module has completed/terminated.
 						}
 					}
+					encounterModule.endWellnessEncounter(person, time);
+
 					// TODO: if CHW policy is enabled for community, possibly add CHW interventions
 					// if true
 					// then add chw encounter to record

--- a/src/main/java/org/mitre/synthea/modules/HealthRecord.java
+++ b/src/main/java/org/mitre/synthea/modules/HealthRecord.java
@@ -84,10 +84,12 @@ public class HealthRecord {
 		public Object value;
 		public String category;
 		public String unit;
+		public List<Observation> observations;
 		
 		public Observation(long time, String type, Object value) {
 			super(time, type);
 			this.value = value;
+			this.observations = new ArrayList<Observation>();
 		}
 	}
 	
@@ -206,14 +208,39 @@ public class HealthRecord {
 			encounter = encounters.get(encounters.size() - 1);
 		} else {
 			encounter = new Encounter(time, EncounterType.WELLNESS.toString());
+			encounter.name = "First Wellness";
 			encounters.add(encounter);
 		}
 		return encounter;
 	}
 	
+	public long timeSinceLastWellnessEncounter(long time) {
+		for(int i=encounters.size()-1; i >= 0; i--) {
+			Encounter encounter = encounters.get(i);
+			if(encounter.type == EncounterType.WELLNESS.toString()) {
+				return (time - encounter.start);
+			}
+		}
+		return Long.MAX_VALUE;
+	}
+
 	public Observation observation(long time, String type, Object value) {
 		Observation observation = new Observation(time, type, value);
 		currentEncounter(time).observations.add(observation);
+		return observation;
+	}
+
+	public Observation multiObservation(long time, String type, int number_of_observations) {
+		Observation observation = new Observation(time, type, null);
+		Encounter encounter = currentEncounter(time);
+		int count = number_of_observations;
+		if(encounter.observations.size() >= number_of_observations) {
+			while(count > 0) {
+				observation.observations.add(encounter.observations.remove(encounter.observations.size()-1));
+				count--;
+			}
+		}
+		encounter.observations.add(observation);
 		return observation;
 	}
 

--- a/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
+++ b/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
@@ -13,6 +13,10 @@ public final class LifecycleModule extends Module
 {
 	private static final Faker faker = new Faker();
 	
+	public LifecycleModule() {
+		this.name = "Lifecycle";
+	}
+
 	@Override
 	public boolean process(Person person, long time) 
 	{

--- a/src/main/java/org/mitre/synthea/modules/Person.java
+++ b/src/main/java/org/mitre/synthea/modules/Person.java
@@ -1,6 +1,5 @@
 package org.mitre.synthea.modules;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -116,6 +115,10 @@ public class Person {
 			total += getSymptom(type);			
 		}
 		return total;
+	}
+
+	public void resetSymptoms() {
+		symptoms.clear();
 	}
 
 	public boolean hadPriorState(String name) {

--- a/src/main/java/org/mitre/synthea/modules/VitalSign.java
+++ b/src/main/java/org/mitre/synthea/modules/VitalSign.java
@@ -1,0 +1,44 @@
+package org.mitre.synthea.modules;
+
+public enum VitalSign {
+	
+	HEIGHT("Height"),
+	WEIGHT("Weight"),
+	BMI("BMI"),
+	SYSTOLIC_BLOOD_PRESSURE("Systolic Blood Pressure"),
+	DIASTOLIC_BLOOD_PRESSURE("Diastolic Blood Pressure"),
+	BLOOD_GLUCOSE("Blood Glucose"),
+	GLUCOSE("Glucose"),
+	UREA_NITROGEN("Urea Nitrogen"),
+	CREATININE("Creatinine"),
+	CALCIUM("Calcium"),
+	SODIUM("Sodium"),
+	POTASSIUM("Potassium"),
+	CHLORIDE("Chloride"),
+	CARBON_DIOXIDE("Carbon Dioxide"),
+	TOTAL_CHOLESTEROL("Total Cholesterol"),
+	TRIGLYCERIDES("Triglycerides"),
+	LDL("LDL"),
+	HDL("HDL"),
+	MICROALBUMIN_CREATININE_RATIO("Microalbumin Creatinine Ratio"),
+	EGFR("EGFR");
+	
+	private String text;
+	
+	VitalSign(String text) {
+		this.text = text;
+	}
+	
+	public static VitalSign fromString(String text) {
+		for(VitalSign type : VitalSign.values()) {
+			if(type.text.equalsIgnoreCase(text)) {
+				return type;
+			}
+		}
+		return VitalSign.valueOf(text);
+	}
+	
+	public String toString() {
+		return text;
+	}
+}


### PR DESCRIPTION
Reworks wellness encounters so they are properly scheduled and only fire once per module (so the wellness encounter and med_rec modules don't endlessly loop).

Vital sign skeleton is also here. Until this is fully implemented, the observations have null values.