### PR TITLE
Allow Transition Probabilities to be defined by attributes, aka "Named transitions"

### DIFF
--- a/src/main/java/org/mitre/synthea/modules/Module.java
+++ b/src/main/java/org/mitre/synthea/modules/Module.java
@@ -67,7 +67,7 @@ public class Module {
 		return filePath.toString().replaceFirst(folderString, "").replaceFirst(".json", "").replace("\\", "/");
 	}
 	
-	private static Module loadFile(Path path, Path modulesFolder) throws IOException {
+	public static Module loadFile(Path path, Path modulesFolder) throws IOException {
 		System.out.format("Loading %s\n", path.toString());
 		boolean submodule = !path.getParent().equals(modulesFolder);
 		JsonObject object = null;

--- a/src/test/java/org/mitre/synthea/TestHelper.java
+++ b/src/test/java/org/mitre/synthea/TestHelper.java
@@ -1,0 +1,17 @@
+package org.mitre.synthea;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.mitre.synthea.modules.Module;
+
+public abstract class TestHelper {
+
+	public static Module getFixture(String filename) throws IOException
+	{
+		Path modulesFolder = Paths.get("src/test/resources/generic");
+		Path module = modulesFolder.resolve(filename);
+		return Module.loadFile(module, modulesFolder);
+	}
+}

--- a/src/test/java/org/mitre/synthea/modules/GenericTransitionsTest.java
+++ b/src/test/java/org/mitre/synthea/modules/GenericTransitionsTest.java
@@ -1,0 +1,88 @@
+package org.mitre.synthea.modules;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mitre.synthea.TestHelper;
+
+public class GenericTransitionsTest {
+
+	private Person person;
+	
+	@Before public void setup()
+	{
+		person = new Person(56L); // seed chosen specifically for testDistributedTransition()
+	} 
+	
+	@Test public void testDistributedTransition() throws IOException {
+		Module distributedTransition = TestHelper.getFixture("distributed_transition.json");
+
+		Map<String, Integer> counts = new HashMap<>();
+		counts.put("Terminal1", 0);
+		counts.put("Terminal2", 0);
+		counts.put("Terminal3", 0);
+		
+		for (int i = 0 ; i < 100 ; i++)
+		{
+			distributedTransition.process(person, 0L);
+			@SuppressWarnings("unchecked")
+			List<State> history = (List<State>) person.attributes.remove("Distributed Module");
+			String finalStateName = history.get(0).name;
+			int count = counts.get(finalStateName);
+			counts.put(finalStateName, count + 1);
+		}
+	}
+	
+	@Test public void testDistributedTransitionWithAttributes() throws IOException {
+		person.attributes.put("probability1", 1.0);
+		
+		Module distributedTransitionWithAttrs = TestHelper.getFixture("distributed_transition_with_attrs.json");
+		
+		Map<String, Integer> counts = new HashMap<>();
+		counts.put("Terminal1", 0);
+		counts.put("Terminal2", 0);
+		counts.put("Terminal3", 0);
+		
+		for (int i = 0 ; i < 100 ; i++)
+		{
+			distributedTransitionWithAttrs.process(person, 0L);
+			@SuppressWarnings("unchecked")
+			List<State> history = (List<State>) person.attributes.remove("Distributed With Attributes Module");
+			String finalStateName = history.get(0).name;
+			int count = counts.get(finalStateName);
+			counts.put(finalStateName, count + 1);
+		}
+		
+		assertEquals(100, counts.get("Terminal1").intValue());
+		assertEquals(0, counts.get("Terminal2").intValue());
+		assertEquals(0, counts.get("Terminal3").intValue());
+		
+		person.attributes.put("probability1", 0.0);
+		person.attributes.put("probability2", 0.0);
+		person.attributes.put("probability3", 1.0);
+		
+		counts.put("Terminal1", 0);
+		counts.put("Terminal2", 0);
+		counts.put("Terminal3", 0);
+		
+		for (int i = 0 ; i < 100 ; i++)
+		{
+			distributedTransitionWithAttrs.process(person, 0L);
+			@SuppressWarnings("unchecked")
+			List<State> history = (List<State>) person.attributes.remove("Distributed With Attributes Module");
+			String finalStateName = history.get(0).name;
+			int count = counts.get(finalStateName);
+			counts.put(finalStateName, count + 1);
+		}
+
+		assertEquals(0, counts.get("Terminal1").intValue());
+		assertEquals(0, counts.get("Terminal2").intValue());
+		assertEquals(100, counts.get("Terminal3").intValue());
+	}
+}

--- a/src/test/resources/generic/allergies.json
+++ b/src/test/resources/generic/allergies.json
@@ -1,0 +1,40 @@
+{
+    "name": "Allergies",
+    "states": {
+        "Initial": {
+            "type": "Initial",
+            "direct_transition": "Allergy_to_Eggs"
+        },
+        "Allergy_to_Eggs": {
+            "type": "AllergyOnset",
+            "codes": [{
+                "system": "SNOMED-CT",
+                "code": "91930004",
+                "display": "Allergy to eggs"
+            }],
+            "target_encounter": "Dr_Visit",
+            "direct_transition": "Dr_Visit"
+        },
+        "Dr_Visit": {
+            "type": "Encounter",
+            "encounter_class": "ambulatory",
+            "codes": [
+              {
+                "system": "SNOMED-CT",
+                "code": "185345009",
+                "display": "Encounter for symptom"
+              }
+            ],
+            "direct_transition": "Allergy_Ends"
+        },
+        "Allergy_Ends" : {
+            "type" : "AllergyEnd",
+            "allergy_onset" : "Allergy_to_Eggs",
+            "direct_transition" : "Terminal"
+        },
+
+        "Terminal": {
+            "type": "Terminal"
+        }
+    }
+}

--- a/src/test/resources/generic/calls_submodule.json
+++ b/src/test/resources/generic/calls_submodule.json
@@ -1,0 +1,53 @@
+{
+  "name": "Calls Submodule",
+  "remarks": [
+    "This module calls a basic submodule that performs a MedicationOrder."
+  ],
+  "states": {
+
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "Encounter"
+    },
+
+    "Encounter": {
+      "type": "Encounter",
+      "encounter_class": "ambulatory",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": "12345678",
+          "display": "Encounter for problem"
+        }
+      ],
+      "direct_transition": "Examplitis"
+    },
+
+    "Examplitis": {
+      "type": "ConditionOnset",
+      "remarks": [
+        "target_encounter is optional in this case since this ConditionOnset ",
+        "state directly follows and is concurrent with an Encounter state."
+      ],
+      "assign_to_attribute": "examplitis",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": "87654321",
+          "display": "Acute examplitis"
+        }
+      ],
+      "direct_transition": "CallSubmodule"
+    },
+
+    "CallSubmodule": {
+      "type": "CallSubmodule",
+      "submodule": "submodules/basic_submodule",
+      "direct_transition": "Main_Terminal"
+    },
+
+    "Main_Terminal": {
+      "type": "Terminal"
+    }
+  }
+}

--- a/src/test/resources/generic/careplan_end.json
+++ b/src/test/resources/generic/careplan_end.json
@@ -1,0 +1,126 @@
+{
+    "name": "CarePlanEnd",
+    "states": {
+
+        "Initial": {
+            "type": "Initial",
+            "direct_transition": "The_Condition"
+        },
+
+        "The_Condition": {
+          "type": "ConditionOnset",
+          "target_encounter": "Wellness_Encounter",
+          "codes": [
+            {
+              "system": "SNOMED-CT",
+              "code": "228380004",
+              "display": "Chases the dragon"
+            }
+          ],
+          "direct_transition": "Wellness_Encounter"
+        },
+
+        "Wellness_Encounter" : {
+          "type" : "Encounter",
+          "wellness" : true,
+          "direct_transition" : "CarePlan1_Start"
+        },
+
+        "CarePlan1_Start": {
+          "type": "CarePlanStart",
+          "target_encounter": "Wellness_Encounter",
+          "codes": [
+            {
+              "system": "SNOMED-CT",
+              "code": "698360004",
+              "display": "Diabetes self management plan"
+            }
+          ],
+          "activities": [
+            {
+              "system": "SNOMED-CT",
+              "code": "160670007",
+              "display": "Diabetic diet"
+            }
+          ],
+          "assign_to_attribute": "Diabetes_CarePlan",
+          "direct_transition": "CarePlan2_Start"
+        },
+
+        "CarePlan2_Start": {
+          "type": "CarePlanStart",
+          "target_encounter": "Wellness_Encounter",
+          "codes": [
+            {
+              "system": "SNOMED-CT",
+              "code": "698358001",
+              "display": "Angina self management plan"
+            }
+          ],
+          "activities": [
+            {
+              "system": "SNOMED-CT",
+              "code": "229065009",
+              "display": "Exercise therapy"
+            },
+            {
+              "system": "SNOMED-CT",
+              "code": "226234005",
+              "display": "Healthy diet"
+            }
+          ],
+          "direct_transition": "CarePlan3_Start"
+        },
+
+        "CarePlan3_Start": {
+          "type": "CarePlanStart",
+          "target_encounter": "Wellness_Encounter",
+          "codes": [
+            {
+              "system": "SNOMED-CT",
+              "code": "408907000",
+              "display": "Immunological care management"
+            }
+          ],
+          "activities": [
+            {
+              "system": "SNOMED-CT",
+              "code": "764101000000108",
+              "display": "Allergen immunotherapy drugs band 1"
+            }
+          ],
+          "direct_transition": "CarePlan1_End"
+        },
+
+        "CarePlan1_End": {
+          "remarks": ["Ends a careplan by attribute"],
+          "type": "CarePlanEnd",
+          "referenced_by_attribute": "Diabetes_CarePlan",
+          "direct_transition": "CarePlan2_End"
+        },
+
+        "CarePlan2_End": {
+          "remarks": ["Ends a careplan by code"],
+          "type": "CarePlanEnd",
+          "codes": [
+            {
+              "system": "SNOMED-CT",
+              "code": "698358001",
+              "display": "Angina self management plan"
+            }
+          ],
+          "direct_transition": "CarePlan3_End"
+        },
+
+        "CarePlan3_End": {
+          "remarks": ["Ends a careplan by direct reference to that state"],
+          "type": "CarePlanEnd",
+          "careplan": "CarePlan3_Start",
+          "direct_transition": "Terminal"
+        },
+
+        "Terminal": {
+            "type": "Terminal"
+        }
+    }
+}

--- a/src/test/resources/generic/careplan_start.json
+++ b/src/test/resources/generic/careplan_start.json
@@ -1,0 +1,55 @@
+{
+    "name": "CarePlanStart",
+    "states": {
+
+        "Initial": {
+            "type": "Initial",
+            "direct_transition": "Diabetes"
+        },
+
+        "Diabetes": {
+            "type": "ConditionOnset",
+            "target_encounter": "Wellness_Encounter",
+            "codes": [
+              {
+                "system": "SNOMED-CT",
+                "code": "73211009",
+                "display": "Diabetes mellitus"
+              }
+            ],
+            "direct_transition": "Wellness_Encounter"
+        },
+
+        "Wellness_Encounter": {
+            "type": "Encounter",
+            "wellness": true,
+            "direct_transition": "Diabetes_Self_Management"
+        },
+
+        "Diabetes_Self_Management": {
+          "type": "CarePlanStart",
+          "target_encounter": "Wellness_Encounter",
+          "codes": [
+            {
+              "system": "SNOMED-CT",
+              "code": "698360004",
+              "display": "Diabetes self management plan"
+            }
+          ],
+          "activities": [
+            {
+              "system": "SNOMED-CT",
+              "code": "160670007",
+              "display": "Diabetic diet"
+            }
+          ],
+          "reason": "Diabetes",
+          "assign_to_attribute": "Diabetes_CarePlan",
+          "direct_transition": "Terminal"
+        },
+
+        "Terminal": {
+            "type": "Terminal"
+        }
+    }
+}

--- a/src/test/resources/generic/complex_transition.json
+++ b/src/test/resources/generic/complex_transition.json
@@ -1,0 +1,55 @@
+{
+    "name": "Complex",
+    "states": {
+        "Initial": {
+            "type": "Initial",
+            "complex_transition": [
+                {
+                    "condition": {
+                        "condition_type": "Gender",
+                        "gender": "M" 
+                    },
+                    "distributions" : [
+                        {
+                            "distribution": 0.15,
+                            "transition": "TerminalM1"
+                        },
+                        {
+                            "distribution": 0.85,
+                            "transition": "TerminalM2"
+                        }
+                    ]
+                },
+                {
+                    "condition": {
+                        "condition_type": "Gender",
+                        "gender": "F" 
+                    },
+                    "distributions" : [
+                        {
+                            "distribution": 0.75,
+                            "transition": "TerminalF1"
+                        },
+                        {
+                            "distribution": 0.25,
+                            "transition": "TerminalF2"
+                        }
+                    ]
+                }
+
+            ]
+        },
+        "TerminalM1": {
+            "type": "Terminal"
+        },
+        "TerminalM2": {
+            "type": "Terminal"
+        },
+        "TerminalF1": {
+            "type": "Terminal"
+        },
+        "TerminalF2": {
+            "type": "Terminal"
+        }
+    }
+}

--- a/src/test/resources/generic/condition_end.json
+++ b/src/test/resources/generic/condition_end.json
@@ -1,0 +1,75 @@
+{
+	"name" : "Condition End",
+  "states" : {
+    "Initial" : {
+      "type" : "Initial",
+      "direct_transition" : "Condition1_Start"
+    },
+
+    "Condition1_Start" : {
+      "type" : "ConditionOnset",
+      "target_encounter" : "DiagnosisEncounter",
+      "codes" : [{
+        "system" : "SNOMED-CT",
+        "code" : "228380004",
+        "display" : "Chases the dragon (finding)"
+      }],
+      "assign_to_attribute" : "Drug Use Behavior",
+      "direct_transition" : "Condition2_Start"
+    },
+
+    "Condition2_Start" : {
+      "type" : "ConditionOnset",
+      "target_encounter" : "DiagnosisEncounter",
+      "codes" : [{
+        "system" : "SNOMED-CT",
+        "code" : "6142004",
+        "display" : "Influenza"
+      }],
+      "direct_transition" : "Condition3_Start"
+    },
+
+    "Condition3_Start" : {
+      "type" : "ConditionOnset",
+      "target_encounter" : "DiagnosisEncounter",
+      "codes": [{
+          "system": "SNOMED-CT",
+          "code": "73211009",
+          "display": "Diabetes mellitus"
+      }],
+      "direct_transition" : "DiagnosisEncounter"
+    },
+
+    "DiagnosisEncounter" : {
+      "type" : "Encounter",
+      "wellness" : true,
+      "direct_transition" : "Condition1_End"
+    },
+
+    "Condition1_End" : {
+      "type" : "ConditionEnd",
+      "referenced_by_attribute" : "Drug Use Behavior",
+      "direct_transition" : "Condition2_End"
+    },
+
+    "Condition2_End" : {
+      "type" : "ConditionEnd",
+      "condition_onset" : "Condition2_Start",
+      "direct_transition" : "Condition3_End"
+    },
+
+    "Condition3_End" : {
+      "type" : "ConditionEnd",
+      "codes": [{
+          "system": "SNOMED-CT",
+          "code": "73211009",
+          "display": "Diabetes mellitus"
+      }],
+      "direct_transition" : "Terminal"
+		},
+
+    "Terminal" : {
+      "type" : "Terminal"
+    }
+  }
+}

--- a/src/test/resources/generic/condition_onset.json
+++ b/src/test/resources/generic/condition_onset.json
@@ -1,0 +1,51 @@
+{
+    "name": "ConditionOnset",
+    "states": {
+        "Initial": {
+            "type": "Initial",
+            "direct_transition": "Diabetes"
+        },
+        "Diabetes": {
+            "type": "ConditionOnset",
+            "codes": [{
+                "system": "SNOMED-CT",
+                "code": "73211009",
+                "display": "Diabetes mellitus"
+            }],
+            "target_encounter": "ED_Visit",
+            "direct_transition": "6_Month_Delay"
+        },
+        "6_Month_Delay": {
+            "type": "Delay",
+            "exact": {
+                "quantity": 6,
+                "unit": "months"
+            },
+            "direct_transition": "ED_Visit"
+        },
+        "ED_Visit": {
+            "type": "Encounter",
+            "encounter_class": "emergency",
+            "codes": [{
+                "system": "SNOMED-CT",
+                "code": "50849002",
+                "display": "Emergency Room Admission"
+            }],
+            "direct_transition": "Appendicitis"
+        },
+        "Appendicitis": {
+            "type": "ConditionOnset",
+            "target_encounter": "ED_Visit",
+            "codes": [{
+                "system": "SNOMED-CT",
+                "code": "47693006",
+                "display": "Rupture of appendix"
+            }],
+            "assign_to_attribute" : "Most Recent ED Visit",
+            "direct_transition": "Terminal"
+        },
+        "Terminal": {
+            "type": "Terminal"
+        }
+    }
+}

--- a/src/test/resources/generic/conditional_transition.json
+++ b/src/test/resources/generic/conditional_transition.json
@@ -1,0 +1,36 @@
+{
+    "name": "Conditional",
+    "states": {
+        "Initial": {
+            "type": "Initial",
+            "conditional_transition": [
+                {
+                    "condition": {
+                        "condition_type": "Gender",
+                        "gender": "M" 
+                    },
+                    "transition": "Terminal1"
+                },
+                {
+                    "condition": {
+                        "condition_type": "Gender",
+                        "gender": "F" 
+                    },
+                    "transition": "Terminal2"
+                },
+                {
+                    "transition": "Terminal3"
+                }
+            ]
+        },
+        "Terminal1": {
+            "type": "Terminal"
+        },
+        "Terminal2": {
+            "type": "Terminal"
+        },
+        "Terminal3": {
+            "type": "Terminal"
+        }
+    }
+}

--- a/src/test/resources/generic/counter.json
+++ b/src/test/resources/generic/counter.json
@@ -1,0 +1,46 @@
+{
+  "name": "Counter",
+  "states": {
+
+    "Initial" : {
+      "type" : "Initial",
+      "direct_transition" : "Counter"
+    },
+
+    "Counter" : {
+      "type" : "Counter",
+      "action" : "increment",
+      "attribute" : "loop_index",
+      "direct_transition" : "Check_Counter"
+    },
+
+    "Check_Counter" : {
+      "type" : "Simple",
+      "conditional_transition" : [
+        {
+          "condition" : {
+            "condition_type" : "Attribute",
+            "attribute" : "loop_index",
+            "operator" : ">",
+            "value" : 10
+          },
+          "transition" : "Counter_Decrement"
+        },
+        { "transition" : "Counter" }
+      ]
+    },
+
+    "Counter_Decrement" : {
+      "type" : "Counter",
+      "action" : "decrement",
+      "attribute" : "loop_index",
+      "direct_transition" : "Terminal"
+    },
+
+    "Terminal" : {
+      "type" : "Terminal"
+    }
+
+  }
+
+}

--- a/src/test/resources/generic/death.json
+++ b/src/test/resources/generic/death.json
@@ -1,0 +1,16 @@
+{
+    "name": "Death",
+    "states": {
+        "Initial": {
+            "type": "Initial",
+            "direct_transition": "Death"
+        },
+        "Death": {
+            "type": "Death",
+            "direct_transition": "Terminal"
+        },
+        "Terminal": {
+            "type": "Terminal"
+        }
+    }
+}

--- a/src/test/resources/generic/death_life_expectancy.json
+++ b/src/test/resources/generic/death_life_expectancy.json
@@ -1,0 +1,39 @@
+{
+    "name": "Death",
+    "states": {
+        "Initial": {
+            "type": "Initial",
+            "direct_transition": "Death"
+        },
+        "Death": {
+            "type": "Death",
+            "range": {
+                "low": 4,
+                "high": 5,
+                "unit": "months"
+            },
+            "direct_transition": "Continue"
+        },
+        "Continue": {
+            "type": "SetAttribute",
+            "attribute": "processing",
+            "value": true,
+            "direct_transition": "Delay"
+        },
+        "Delay": {
+            "type": "Delay",
+            "range": {
+                "low": 9,
+                "high": 10,
+                "unit": "days"
+            },
+            "direct_transition": "Continue II"
+        },
+        "Continue II": {
+            "type": "SetAttribute",
+            "attribute": "still_processing",
+            "value": true,
+            "direct_transition": "Continue"
+        }
+    }
+}

--- a/src/test/resources/generic/death_reason.json
+++ b/src/test/resources/generic/death_reason.json
@@ -1,0 +1,51 @@
+{
+    "name": "Death Reason",
+    "states": {
+        "Initial": {
+            "type": "Initial",
+            "direct_transition": "OnsetDiabetes"
+        },
+        "OnsetDiabetes": {
+            "type": "ConditionOnset",
+            "target_encounter" : "Diagnosis",
+            "codes": [{
+                "system": "SNOMED-CT",
+                "code": "73211009",
+                "display": "Diabetes mellitus"
+            }],
+            "assign_to_attribute" : "Cause of Death",
+            "direct_transition": "Diagnosis"
+        },
+        "Diagnosis" : {
+            "type" : "Encounter",
+            "wellness" : true,
+            "distributed_transition" : [
+                { "distribution" : 0.33 , "transition" : "Death_by_Code" },
+                { "distribution" : 0.33 , "transition" : "Death_by_Attribute" },
+                { "distribution" : 0.33 , "transition" : "Death_by_ConditionOnset" }
+            ]
+        },
+        "Death_by_Code": {
+            "type": "Death",
+            "codes": [{
+                "system": "SNOMED-CT",
+                "code": "987654321",
+                "display": "Some undiscovered condition"
+            }],
+            "direct_transition": "Terminal"
+        },
+        "Death_by_ConditionOnset" : {
+            "type": "Death",
+            "condition_onset" : "OnsetDiabetes",
+            "direct_transition": "Terminal"
+        },
+        "Death_by_Attribute" : {
+            "type": "Death",
+            "referenced_by_attribute" : "Cause of Death",
+            "direct_transition": "Terminal"
+        },
+        "Terminal": {
+            "type": "Terminal"
+        }
+    }
+}

--- a/src/test/resources/generic/delay.json
+++ b/src/test/resources/generic/delay.json
@@ -1,0 +1,131 @@
+{
+    "name": "Delay",
+    "states": {
+        "Initial": {
+            "type": "Initial",
+            "direct_transition": "2_Second_Delay"
+        },
+        "2_Second_Delay": {
+            "type": "Delay",
+            "exact": {
+                "quantity": 2,
+                "unit": "seconds"
+            },
+            "direct_transition": "2_Minute_Delay"
+        },
+        "2_Minute_Delay": {
+            "type": "Delay",
+            "exact": {
+                "quantity": 2,
+                "unit": "minutes"
+            },
+            "direct_transition": "2_Hour_Delay"
+        },
+        "2_Hour_Delay": {
+            "type": "Delay",
+            "exact": {
+                "quantity": 2,
+                "unit": "hours"
+            },
+            "direct_transition": "2_Day_Delay"
+        },
+        "2_Day_Delay": {
+            "type": "Delay",
+            "exact": {
+                "quantity": 2,
+                "unit": "days"
+            },
+            "direct_transition": "2_Week_Delay"
+        },
+        "2_Week_Delay": {
+            "type": "Delay",
+            "exact": {
+                "quantity": 2,
+                "unit": "weeks"
+            },
+            "direct_transition": "2_Month_Delay"
+        },
+        "2_Month_Delay": {
+            "type": "Delay",
+            "exact": {
+                "quantity": 2,
+                "unit": "months"
+            },
+            "direct_transition": "2_Year_Delay"
+        },
+        "2_Year_Delay": {
+            "type": "Delay",
+            "exact": {
+                "quantity": 2,
+                "unit": "years"
+            },
+            "direct_transition": "2_To_10_Second_Delay"
+        },
+        "2_To_10_Second_Delay": {
+            "type": "Delay",
+            "range": {
+                "low": 2,
+                "high": 10,
+                "unit": "seconds"
+            },
+            "direct_transition": "2_To_10_Minute_Delay"
+        },
+        "2_To_10_Minute_Delay": {
+            "type": "Delay",
+            "range": {
+                "low": 2,
+                "high": 10,
+                "unit": "minutes"
+            },
+            "direct_transition": "2_To_10_Hour_Delay"
+        },
+        "2_To_10_Hour_Delay": {
+            "type": "Delay",
+            "range": {
+                "low": 2,
+                "high": 10,
+                "unit": "hours"
+            },
+            "direct_transition": "2_To_10_Day_Delay"
+        },
+        "2_To_10_Day_Delay": {
+            "type": "Delay",
+            "range": {
+                "low": 2,
+                "high": 10,
+                "unit": "days"
+            },
+            "direct_transition": "2_To_10_Week_Delay"
+        },
+        "2_To_10_Week_Delay": {
+            "type": "Delay",
+            "range": {
+                "low": 2,
+                "high": 10,
+                "unit": "weeks"
+            },
+            "direct_transition": "2_To_10_Month_Delay"
+        },
+        "2_To_10_Month_Delay": {
+            "type": "Delay",
+            "range": {
+                "low": 2,
+                "high": 10,
+                "unit": "months"
+            },
+            "direct_transition": "2_To_10_Year_Delay"
+        },
+        "2_To_10_Year_Delay": {
+            "type": "Delay",
+            "range": {
+                "low": 2,
+                "high": 10,
+                "unit": "years"
+            },
+            "direct_transition": "Terminal"
+        },
+        "Terminal": {
+            "type": "Terminal"
+        }
+    }
+}

--- a/src/test/resources/generic/delay_time_travel.json
+++ b/src/test/resources/generic/delay_time_travel.json
@@ -1,0 +1,42 @@
+{
+    "name": "DelayTimeTravel",
+    "states": {
+        "Initial": {
+            "type": "Initial",
+            "direct_transition": "2_Day_Delay"
+        },
+        "2_Day_Delay": {
+            "type": "Delay",
+            "exact": {
+                "quantity": 2,
+                "unit": "days"
+            },
+            "direct_transition": "ED_Visit"
+        },
+        "ED_Visit": {
+            "type": "Encounter",
+            "encounter_class": "emergency",
+            "codes": [{
+                "system": "SNOMED-CT",
+                "code": "50849002",
+                "display": "Emergency Room Admission"
+            }],
+            "direct_transition": "3_Day_Delay"
+        },
+        "3_Day_Delay": {
+            "type": "Delay",
+            "exact": {
+                "quantity": 3,
+                "unit": "days"
+            },
+            "direct_transition": "Death"
+        },
+        "Death": {
+            "type": "Death",
+            "direct_transition": "Terminal"
+        },
+        "Terminal": {
+            "type": "Terminal"
+        }
+    }
+}

--- a/src/test/resources/generic/direct_transition.json
+++ b/src/test/resources/generic/direct_transition.json
@@ -1,0 +1,12 @@
+{
+    "name": "Direct",
+    "states": {
+        "Initial": {
+            "type": "Initial",
+            "direct_transition": "Terminal"
+        },
+        "Terminal": {
+            "type": "Terminal"
+        }
+    }
+}

--- a/src/test/resources/generic/distributed_transition.json
+++ b/src/test/resources/generic/distributed_transition.json
@@ -1,0 +1,31 @@
+{
+    "name": "Distributed",
+    "states": {
+        "Initial": {
+            "type": "Initial",
+            "distributed_transition": [
+                {
+                    "distribution": 0.15,
+                    "transition": "Terminal1"
+                },
+                {
+                    "distribution": 0.55,
+                    "transition": "Terminal2"
+                },
+                {
+                    "distribution": 0.30,
+                    "transition": "Terminal3"
+                }
+            ]
+        },
+        "Terminal1": {
+            "type": "Terminal"
+        },
+        "Terminal2": {
+            "type": "Terminal"
+        },
+        "Terminal3": {
+            "type": "Terminal"
+        }
+    }
+}

--- a/src/test/resources/generic/distributed_transition_with_attrs.json
+++ b/src/test/resources/generic/distributed_transition_with_attrs.json
@@ -1,0 +1,31 @@
+{
+    "name": "Distributed With Attributes",
+    "states": {
+        "Initial": {
+            "type": "Initial",
+            "distributed_transition": [
+                {
+                    "distribution": { "attribute" : "probability1", "default" : 0.15 },
+                    "transition": "Terminal1"
+                },
+                {
+                    "distribution": { "attribute" : "probability2", "default" : 0.55 },
+                    "transition": "Terminal2"
+                },
+                {
+                    "distribution": { "attribute" : "probability3", "default" : 0.30 },
+                    "transition": "Terminal3"
+                }
+            ]
+        },
+        "Terminal1": {
+            "type": "Terminal"
+        },
+        "Terminal2": {
+            "type": "Terminal"
+        },
+        "Terminal3": {
+            "type": "Terminal"
+        }
+    }
+}

--- a/src/test/resources/generic/encounter.json
+++ b/src/test/resources/generic/encounter.json
@@ -1,0 +1,73 @@
+{
+    "name": "Encounter",
+    "states": {
+        "Initial": {
+            "type": "Initial",
+            "direct_transition": "Annual_Physical"
+        },
+        "Annual_Physical": {
+            "type": "Encounter",
+            "wellness": true,
+            "direct_transition": "6_Month_Delay"
+        },
+        "6_Month_Delay": {
+            "type": "Delay",
+            "exact": {
+                "quantity": 6,
+                "unit": "months"
+            },
+            "direct_transition": "Diabetes"
+        },
+        "Diabetes": {
+            "type": "ConditionOnset",
+            "target_encounter": "Annual_Physical_2",
+            "codes": [{
+                "system": "SNOMED-CT",
+                "code": "73211009",
+                "display": "Diabetes Mellitus"
+            }],
+            "assign_to_attribute" : "some_active_condition",
+            "direct_transition": "Annual_Physical_2"
+        },
+        "Annual_Physical_2": {
+            "type": "Encounter",
+            "wellness": true,
+            "direct_transition": "2_Year_Delay"
+        },
+        "2_Year_Delay": {
+            "type": "Delay",
+            "exact": {
+                "quantity": 2,
+                "unit": "years"
+            },
+            "direct_transition": "ED_Visit"
+        },
+        "ED_Visit": {
+            "type": "Encounter",
+            "encounter_class": "emergency",
+            "codes": [{
+                "system": "SNOMED-CT",
+                "code": "50849002",
+                "display": "Emergency Room Admission"
+            }],
+            "reason" : "Diabetes",
+            "direct_transition": "ED_Visit_AttributeReason"
+        },
+
+        "ED_Visit_AttributeReason": {
+            "type": "Encounter",
+            "encounter_class": "emergency",
+            "codes": [{
+                "system": "SNOMED-CT",
+                "code": "50849002",
+                "display": "Emergency Room Admission"
+            }],
+            "reason" : "some_active_condition",
+            "direct_transition": "Terminal"
+        },
+
+        "Terminal": {
+            "type": "Terminal"
+        }
+    }
+}

--- a/src/test/resources/generic/example_module.json
+++ b/src/test/resources/generic/example_module.json
@@ -1,0 +1,174 @@
+{
+  "name": "Examplitis",
+  "remarks": [
+    "Examplitis is a painful condition that affects only males. Most patients ",
+    "can be cured with Examplitol or an Examplotomy but some never recover."
+  ],
+  "states": {
+
+    "Initial": {
+      "type": "Initial",
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "Gender",
+            "gender": "M"
+          },
+          "transition": "Age_Guard"
+        },
+        {
+          "transition": "Terminal"
+        }
+      ]
+    },
+
+    "Age_Guard": {
+      "type": "Guard",
+      "allow": {
+        "condition_type": "Age",
+        "operator": ">",
+        "quantity": 40,
+        "unit": "years"
+      },
+      "distributed_transition": [
+        {
+          "distribution": 0.10,
+          "transition": "Pre_Examplitis"
+        },
+        {
+          "distribution": 0.90,
+          "transition": "Terminal"
+        }
+      ]
+    },
+
+    "Pre_Examplitis": {
+      "type": "Delay",
+      "range": {
+        "low": 0,
+        "high": 10,
+        "unit": "years"
+      },
+      "direct_transition": "Examplitis"
+    },
+
+    "Examplitis": {
+      "type": "ConditionOnset",
+      "target_encounter": "Wellness_Encounter",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": "123",
+          "display": "Examplitis"
+        }
+      ],
+      "direct_transition": "Wellness_Encounter"
+    },
+
+    "Wellness_Encounter": {
+      "type": "Encounter",
+      "wellness": true,
+      "direct_transition": "Examplitol"
+    },
+
+    "Examplitol": {
+      "type": "MedicationOrder",
+      "reason": "Examplitis",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "456",
+          "display": "Examplitol"
+        }
+      ],
+      "distributed_transition": [
+        {
+          "distribution": 0.2,
+          "transition": "Pre_Examplotomy"
+        },
+        {
+          "distribution": 0.1,
+          "transition": "Last_Days"
+        },
+        {
+          "distribution": 0.7,
+          "transition": "Terminal"
+        }
+      ]
+    },
+
+    "Pre_Examplotomy": {
+      "type": "Delay",
+      "range": {
+        "low": 18,
+        "high": 36,
+        "unit": "months"
+      },
+      "direct_transition": "Examplotomy_Encounter"
+    },
+
+    "Examplotomy_Encounter": {
+      "type": "Encounter",
+      "encounter_class": "ambulatory",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": "ABC",
+          "display": "Examplotomy Encounter"
+        }
+      ],
+      "direct_transition": "Examplotomy"
+    },
+
+    "Examplotomy": {
+      "type": "Procedure",
+      "duration": {
+        "low": 2,
+        "high": 3,
+        "unit": "hours"
+      },
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": "789",
+          "display": "Examplotomy"
+        }
+      ],
+      "reason": "Examplitis",
+      "direct_transition": "End_Examplotomy_Encounter"
+    },
+
+    "End_Examplotomy_Encounter": {
+    	"type": "EncounterEnd",
+    	"distributed_transition": [
+        {
+          "distribution": 0.1,
+          "transition": "Death"
+        },
+        {
+          "distribution": 0.9,
+          "transition": "Terminal"
+        }
+      ]
+    },
+
+    "Last_Days": {
+      "type": "Delay",
+      "range": {
+          "low": 8,
+          "high": 20,
+          "unit": "years"
+      },
+      "direct_transition": "Death"
+    },
+
+    "Death": {
+      "type": "Death",
+      "direct_transition": "Terminal"
+    },
+
+    "Terminal": {
+      "type": "Terminal"
+    }
+  }
+}

--- a/src/test/resources/generic/guard.json
+++ b/src/test/resources/generic/guard.json
@@ -1,0 +1,20 @@
+{
+    "name": "Guard",
+    "states": {
+        "Initial": {
+            "type": "Initial",
+            "direct_transition": "Gender_Guard"
+        },
+        "Gender_Guard": {
+            "type": "Guard",
+            "allow": {
+                "condition_type": "Gender",
+                "gender": "F" 
+            },
+            "direct_transition": "Terminal"
+        },
+        "Terminal": {
+            "type": "Terminal"
+        }
+    }
+}

--- a/src/test/resources/generic/history.json
+++ b/src/test/resources/generic/history.json
@@ -1,0 +1,52 @@
+{
+    "name": "History",
+    "states": {
+        "Initial": {
+            "type": "Initial",
+            "direct_transition": "Guard1"
+        },
+        "Guard1": {
+            "type": "Guard",
+            "allow": {
+                "condition_type": "True"
+            },
+            "distributed_transition": [
+                {
+                    "distribution": 0.40,
+                    "transition": "Guard1"
+                },
+                {
+                    "distribution": 0.45,
+                    "transition": "Guard2"
+                },
+                {
+                    "distribution": 0.15,
+                    "transition": "Terminal"
+                }
+            ]
+        },
+        "Guard2": {
+            "type": "Guard",
+            "allow": {
+                "condition_type": "True"
+            },
+            "distributed_transition": [
+                {
+                    "distribution": 0.45,
+                    "transition": "Guard1"
+                },
+                {
+                    "distribution": 0.40,
+                    "transition": "Guard2"
+                },
+                {
+                    "distribution": 0.15,
+                    "transition": "Terminal"
+                }
+            ]
+        },
+        "Terminal": {
+            "type": "Terminal"
+        }
+    }
+}

--- a/src/test/resources/generic/incomplete_conditional_transition.json
+++ b/src/test/resources/generic/incomplete_conditional_transition.json
@@ -1,0 +1,20 @@
+{
+    "name": "IncompleteConditional",
+    "states": {
+        "Initial": {
+            "type": "Initial",
+            "conditional_transition": [
+                {
+                    "condition": {
+                        "condition_type": "Gender",
+                        "gender": "M" 
+                    },
+                    "transition": "Terminal1"
+                }
+            ]
+        },
+        "Terminal1": {
+            "type": "Terminal"
+        }
+    }
+}

--- a/src/test/resources/generic/initial_to_terminal.json
+++ b/src/test/resources/generic/initial_to_terminal.json
@@ -1,0 +1,12 @@
+{
+    "name": "Initial",
+    "states": {
+        "Initial": {
+            "type": "Initial",
+            "direct_transition": "Terminal"
+        },
+        "Terminal": {
+            "type": "Terminal"
+        }
+    }
+}

--- a/src/test/resources/generic/logic.json
+++ b/src/test/resources/generic/logic.json
@@ -1,0 +1,315 @@
+{
+  "trueTest": {
+      "condition_type": "True"
+  },
+  "falseTest": {
+      "condition_type": "False"
+  },
+  "genderIsMaleTest": {
+      "condition_type": "Gender",
+      "gender": "M"
+  },
+  "ageLt40Test": {
+      "condition_type": "Age",
+      "operator": "<",
+      "quantity": 40,
+      "unit": "years"
+  },
+  "ageLte40Test": {
+      "condition_type": "Age",
+      "operator": "<=",
+      "quantity": 40,
+      "unit": "years"
+  },
+  "ageEq40Test": {
+      "condition_type": "Age",
+      "operator": "==",
+      "quantity": 40,
+      "unit": "years"
+  },
+  "ageGte40Test": {
+      "condition_type": "Age",
+      "operator": ">=",
+      "quantity": 40,
+      "unit": "years"
+  },
+  "ageGt40Test": {
+      "condition_type": "Age",
+      "operator": ">",
+      "quantity": 40,
+      "unit": "years"
+  },
+  "ageNe40Test": {
+      "condition_type": "Age",
+      "operator": "!=",
+      "quantity": 40,
+      "unit": "years"
+  },
+  "sesHighTest" : {
+    "condition_type" : "Socioeconomic Status",
+    "category" : "High"
+  },
+  "sesMiddleTest" : {
+    "condition_type" : "Socioeconomic Status",
+    "category" : "Middle"
+  },
+  "sesLowTest" : {
+    "condition_type" : "Socioeconomic Status",
+    "category" : "Low"
+  },
+  "raceExistsTest": {
+    "condition_type" : "Race",
+    "race" : "White"
+  },
+  "raceDoesNotExistTest": {
+    "condition_type" : "Race",
+    "race" : "foo"
+  },
+  "before2016Test" : {
+    "condition_type" : "Date",
+    "operator" : "<",
+    "year" : 2016
+  },
+  "after2000Test" : {
+    "condition_type" : "Date",
+    "operator" : ">=",
+    "year" : 2000
+  },
+  "attributeEqualTo_TestValue_Test" : {
+    "condition_type" : "Attribute",
+    "attribute" : "Test_Attribute_Key",
+    "operator" : "==",
+    "value" : "TestValue"
+  },
+  "attributeGt100Test" : {
+    "condition_type" : "Attribute",
+    "attribute" : "Test_Attribute_Key",
+    "operator" : ">",
+    "value" : 100
+  },
+  "symptomPainLevelGt50" : {
+    "condition_type": "Symptom",
+    "symptom" : "PainLevel",
+    "operator" : ">",
+    "value" : 50
+  },
+  "symptomPainLevelLte80" : {
+    "condition_type": "Symptom",
+    "symptom" : "PainLevel",
+    "operator" : "<=",
+    "value" : 80
+  },
+  "mmseObservationGt22" : {
+    "condition_type" : "Observation",
+    "codes" : [{
+      "system" : "LOINC",
+      "code" : "72107-6",
+      "display" : "Mini Mental State Examination"
+    }],
+    "operator" : ">",
+    "value" : 22
+  },
+  "hasDiabetesObservation" : {
+    "condition_type" : "Observation",
+    "referenced_by_attribute" : "Diabetes Test Performed",
+    "operator" : "is not nil"
+  },
+  "SystolicBloodPressureGt120" : {
+    "condition_type" : "Vital Sign",
+    "vital_sign" : "Systolic Blood Pressure",
+    "operator" : ">",
+    "value" : 120
+  },
+  "diabetesConditionTest" : {
+    "condition_type" : "Active Condition",
+    "codes": [{
+        "system": "SNOMED-CT",
+        "code": "73211009",
+        "display": "Diabetes mellitus"
+    }]
+  },
+  "alzheimersConditionTest" : {
+    "condition_type" : "Active Condition",
+    "referenced_by_attribute" : "Alzheimer's Variant"
+  },
+  "diabetesCarePlanTest": {
+    "condition_type": "Active CarePlan",
+    "codes": [{
+      "system": "SNOMED-CT",
+      "code": "698360004",
+      "display": "Diabetes self management plan"
+    }]
+  },
+  "anginaCarePlanTest": {
+    "condition_type": "Active CarePlan",
+    "referenced_by_attribute": "Angina_CarePlan"
+  },
+  "attributeNilTest" : {
+    "condition_type" : "Attribute",
+    "attribute" : "Test_Attribute_Key",
+    "operator" : "is nil"
+  },
+  "attributeNotNilTest" : {
+    "condition_type" : "Attribute",
+    "attribute" : "Test_Attribute_Key",
+    "operator" : "is not nil"
+  },
+  "priorStateDoctorVisitTest" : {
+    "condition_type": "PriorState",
+    "name" : "DoctorVisit"
+  },
+  "priorStateCarePlanSinceDoctorVisitTest" : {
+    "condition_type": "PriorState",
+    "name" : "CarePlan",
+    "since" : "DoctorVisit"
+  },
+  "priorStateDoctorVisitWithin3YearsTest" : {
+    "condition_type": "PriorState",
+    "name" : "DoctorVisit",
+    "within" : { "quantity" : 3, "unit" : "years" }
+  },
+  "priorStateCarePlanSinceDoctorVisitWithin3YearsTest" : {
+    "condition_type": "PriorState",
+    "name" : "CarePlan",
+    "since" : "DoctorVisit",
+    "within" : { "quantity" : 3, "unit" : "years" }
+  },
+  "andAllTrueTest": {
+    "condition_type": "And",
+    "conditions": [
+      { "condition_type": "True" },
+      { "condition_type": "True" },
+      { "condition_type": "True" }
+    ]
+  },
+  "andOneFalseTest": {
+    "condition_type": "And",
+    "conditions": [
+      { "condition_type": "True" },
+      { "condition_type": "False" },
+      { "condition_type": "True" }
+    ]
+  },
+  "andAllFalseTest": {
+    "condition_type": "And",
+    "conditions": [
+      { "condition_type": "False" },
+      { "condition_type": "False" },
+      { "condition_type": "False" }
+    ]
+  },
+  "orAllTrueTest": {
+    "condition_type": "Or",
+    "conditions": [
+      { "condition_type": "True" },
+      { "condition_type": "True" },
+      { "condition_type": "True" }
+    ]
+  },
+  "orOneTrueTest": {
+    "condition_type": "Or",
+    "conditions": [
+      { "condition_type": "False" },
+      { "condition_type": "True" },
+      { "condition_type": "False" }
+    ]
+  },
+  "orAllFalseTest": {
+    "condition_type": "Or",
+    "conditions": [
+      { "condition_type": "False" },
+      { "condition_type": "False" },
+      { "condition_type": "False" }
+    ]
+  },
+  "atLeast3_AllTrueTest" : {
+    "condition_type": "At Least",
+    "minimum" : 3,
+    "conditions": [
+      { "condition_type": "True" },
+      { "condition_type": "True" },
+      { "condition_type": "True" },
+      { "condition_type": "True" }
+    ]
+  },
+  "atLeast3_3TrueTest" : {
+    "condition_type": "At Least",
+    "minimum" : 3,
+    "conditions": [
+      { "condition_type": "True" },
+      { "condition_type": "True" },
+      { "condition_type": "False" },
+      { "condition_type": "True" }
+    ]
+  },
+  "atLeast3_2TrueTest" : {
+    "condition_type": "At Least",
+    "minimum" : 3,
+    "conditions": [
+      { "condition_type": "True" },
+      { "condition_type": "False" },
+      { "condition_type": "False" },
+      { "condition_type": "True" }
+    ]
+  },
+  "atLeast3_NoneTrueTest" : {
+    "condition_type": "At Least",
+    "minimum" : 3,
+    "conditions": [
+      { "condition_type": "False" },
+      { "condition_type": "False" },
+      { "condition_type": "False" },
+      { "condition_type": "False" }
+    ]
+  },
+
+  "atMost2_AllTrueTest" : {
+    "condition_type": "At Most",
+    "maximum" : 2,
+    "conditions": [
+      { "condition_type": "True" },
+      { "condition_type": "True" },
+      { "condition_type": "True" },
+      { "condition_type": "True" }
+    ]
+  },
+  "atMost2_3TrueTest" : {
+    "condition_type": "At Most",
+    "maximum" : 2,
+    "conditions": [
+      { "condition_type": "True" },
+      { "condition_type": "True" },
+      { "condition_type": "False" },
+      { "condition_type": "True" }
+    ]
+  },
+  "atMost2_2TrueTest" : {
+    "condition_type": "At Most",
+    "maximum" : 2,
+    "conditions": [
+      { "condition_type": "True" },
+      { "condition_type": "False" },
+      { "condition_type": "False" },
+      { "condition_type": "True" }
+    ]
+  },
+  "atMost2_NoneTrueTest" : {
+    "condition_type": "At Most",
+    "maximum" : 2,
+    "conditions": [
+      { "condition_type": "False" },
+      { "condition_type": "False" },
+      { "condition_type": "False" },
+      { "condition_type": "False" }
+    ]
+  },
+
+  "notTrueTest": {
+    "condition_type": "Not",
+    "condition": { "condition_type": "True" }
+  },
+  "notFalseTest": {
+    "condition_type": "Not",
+    "condition": { "condition_type": "False" }
+  }
+}

--- a/src/test/resources/generic/medication_end.json
+++ b/src/test/resources/generic/medication_end.json
@@ -1,0 +1,86 @@
+{
+    "name": "MedicationEnd",
+    "states": {
+        "Initial": {
+            "type": "Initial",
+            "direct_transition": "Diabetes"
+        },
+        "Diabetes": {
+            "type": "ConditionOnset",
+            "target_encounter": "Wellness_Encounter",
+            "codes": [{
+                "system": "SNOMED-CT",
+                "code": "73211009",
+                "display": "Diabetes mellitus"
+            }],
+            "direct_transition": "Wellness_Encounter"
+        },
+        "Wellness_Encounter": {
+            "type": "Encounter",
+            "wellness": true,
+            "direct_transition": "Metformin_Start"
+        },
+        "Metformin_Start": {
+            "type": "MedicationOrder",
+            "target_encounter": "Wellness_Encounter",
+            "codes": [{
+                "system": "RxNorm",
+                "code": "860975",
+                "display": "24 HR Metformin hydrochloride 500 MG Extended Release Oral Tablet"
+            }],
+            "reason": "Diabetes",
+            "direct_transition": "Insulin_Start"
+        },
+
+        "Insulin_Start": {
+            "type": "MedicationOrder",
+            "target_encounter": "Wellness_Encounter",
+            "codes": [{
+                "system": "RxNorm",
+                "code": "575679",
+                "display": "Insulin, Aspart, Human 100 UNT/ML [NovoLOG]"
+            }],
+            "assign_to_attribute" : "DiabetesMed1",
+            "reason": "Diabetes",
+            "direct_transition": "Bromocriptine_Start"
+        },
+
+        "Bromocriptine_Start": {
+            "type": "MedicationOrder",
+            "target_encounter": "Wellness_Encounter",
+            "codes": [{
+                "system": "RxNorm",
+                "code": "563894",
+                "display": "Bromocriptine 5 MG [Parlodel]"
+            }],
+            "reason": "Diabetes",
+            "direct_transition": "Metformin_End"
+        },
+
+        "Metformin_End": {
+            "type": "MedicationEnd",
+            "codes": [{
+                "system": "RxNorm",
+                "code": "860975",
+                "display": "24 HR Metformin hydrochloride 500 MG Extended Release Oral Tablet"
+            }],
+            "direct_transition": "Insulin_End"
+        },
+
+        "Insulin_End": {
+            "type": "MedicationEnd",
+            "referenced_by_attribute" : "DiabetesMed1",
+            "direct_transition": "Bromocriptine_End"
+        },
+
+        "Bromocriptine_End": {
+            "type": "MedicationEnd",
+            "medication_order" : "Bromocriptine_Start",
+            "direct_transition": "Terminal"
+        },
+
+        "Terminal": {
+            "type": "Terminal"
+        }
+    }
+}

--- a/src/test/resources/generic/medication_order.json
+++ b/src/test/resources/generic/medication_order.json
@@ -1,0 +1,88 @@
+{
+    "name": "MedicationOrder",
+    "states": {
+        "Initial": {
+            "type": "Initial",
+            "direct_transition": "Diabetes"
+        },
+        "Diabetes": {
+            "type": "ConditionOnset",
+            "target_encounter": "Wellness_Encounter",
+            "codes": [{
+                "system": "SNOMED-CT",
+                "code": "73211009",
+                "display": "Diabetes mellitus"
+            }],
+            "direct_transition": "Wellness_Encounter"
+        },
+        "Wellness_Encounter": {
+            "type": "Encounter",
+            "wellness": true,
+            "direct_transition": "Metformin"
+        },
+        "Metformin": {
+            "type": "MedicationOrder",
+            "target_encounter": "Wellness_Encounter",
+            "codes": [{
+                "system": "RxNorm",
+                "code": "860975",
+                "display": "24 HR Metformin hydrochloride 500 MG Extended Release Oral Tablet"
+            }],
+            "assign_to_attribute" : "Diabetes Medication",
+            "reason": "Diabetes",
+            "direct_transition": "Metformin_With_Dosage"
+        },
+        "Metformin_With_Dosage": {
+            "type": "MedicationOrder",
+            "target_encounter": "Wellness_Encounter",
+            "reason": "Diabetes",
+            "codes": [
+              {
+                "system": "RxNorm",
+                "code": "860975",
+                "display": "24 HR Metformin hydrochloride 500 MG Extended Release Oral Tablet"
+              }
+            ],
+            "prescription": {
+              "refills": 1,
+              "dosage": {
+                "amount": 1,
+                "frequency": 1,
+                "period": 1,
+                "unit": "days"
+              },
+              "duration": {
+                "quantity": 1,
+                "unit": "months"
+              },
+              "instructions": [
+                {
+                  "system": "SNOMED-CT",
+                  "code": "311501008",
+                  "display": "Half to one hour before food"
+                }
+              ]
+            },
+            "direct_transition": "Tylenol_As_Needed"
+        },
+        "Tylenol_As_Needed": {
+          "type": "MedicationOrder",
+          "target_encounter": "Wellness_Encounter",
+          "reason": "Diabetes",
+          "codes": [
+            {
+              "system": "RxNorm",
+              "code": "123456",
+              "display": "Acetaminophen 325mg [Tylenol]"
+            }
+          ],
+          "prescription": {
+            "as_needed": true
+          },
+          "direct_transition": "Terminal"
+        },
+        "Terminal": {
+            "type": "Terminal"
+        }
+    }
+}

--- a/src/test/resources/generic/procedure.json
+++ b/src/test/resources/generic/procedure.json
@@ -1,0 +1,34 @@
+{
+    "name": "Procedure",
+    "states": {
+        "Initial": {
+            "type": "Initial",
+            "direct_transition": "Inpatient_Encounter"
+        },
+        "Inpatient_Encounter": {
+            "type": "Encounter",
+            "encounter_class": "inpatient",
+            "codes": [{
+                "system": "SNOMED-CT",
+                "code": "32485007",
+                "display": "Hospital admission"
+            }],
+            "direct_transition": "Appendectomy"
+        },
+        "Appendectomy": {
+            "type": "Procedure",
+            "target_encounter": "Inpatient_Encounter",
+            "codes": [{
+                "system": "SNOMED-CT",
+                "code": "6025007",
+                "display": "Laparoscopic appendectomy"
+            }],
+            "duration" : { "low": 45, "high" : 45, "unit": "minutes" },
+            "assign_to_attribute" : "Most Recent Surgery",
+            "direct_transition": "Terminal"
+        },
+        "Terminal": {
+            "type": "Terminal"
+        }
+    }
+}

--- a/src/test/resources/generic/recursively_calls_submodules.json
+++ b/src/test/resources/generic/recursively_calls_submodules.json
@@ -1,0 +1,43 @@
+{
+  "name": "Recursive Calls Submodules",
+  "remarks": [
+    "This module calls a submodule that then calls another submodule. ",
+    "main_module calls--> encounter_submodule calls--> medication_submodule "
+  ],
+  "states": {
+
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "Example_Condition"
+    },
+
+    "Example_Condition": {
+      "type": "ConditionOnset",
+      "target_encounter": "Encounter_In_Submodule",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": "12345678",
+          "display": "Examplitis"
+        }
+      ],
+      "direct_transition": "Call_Encounter_Submodule"
+    },
+
+    "Call_Encounter_Submodule": {
+      "type": "CallSubmodule",
+      "submodule": "submodules/encounter_submodule",
+      "direct_transition": "End_Condition"
+    },
+
+    "End_Condition": {
+      "type": "ConditionEnd",
+      "condition_onset": "Example_Condition",
+      "direct_transition": "Terminal"
+    },
+
+    "Terminal": {
+      "type": "Terminal"
+    }
+  }
+}

--- a/src/test/resources/generic/set_attribute.json
+++ b/src/test/resources/generic/set_attribute.json
@@ -1,0 +1,25 @@
+{
+    "name": "SetAttribute",
+    "states": {
+        "Initial": {
+            "type": "Initial",
+            "direct_transition": "Set_Attribute_1"
+        },
+        "Set_Attribute_1": {
+            "type": "SetAttribute",
+            "attribute" : "Current Opioid Prescription",
+            "value" : "Vicodin",
+            "direct_transition": "Set_Attribute_2"
+        },
+
+        "Set_Attribute_2": {
+            "type": "SetAttribute",
+            "attribute" : "Current Opioid Prescription",
+            "direct_transition": "Terminal"
+        },
+
+        "Terminal": {
+            "type": "Terminal"
+        }
+    }
+}

--- a/src/test/resources/generic/submodules/basic_submodule.json
+++ b/src/test/resources/generic/submodules/basic_submodule.json
@@ -1,0 +1,41 @@
+{
+  "name": "Basic Submodule",
+  "remarks": [
+    "The patient's record should include the medication ",
+    "order from this submodule."
+  ],
+  "states": {
+
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "MedicationOrder"
+    },
+
+    "MedicationOrder": {
+      "type": "MedicationOrder",
+      "reason": "Examplitis",
+      "assign_to_attribute": "examplitol",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "123456",
+          "display": "Examplitol"
+        }
+      ],
+      "direct_transition": "Gender_Guard"
+    },
+
+    "Gender_Guard": {
+      "type": "Guard",
+      "allow": {
+        "condition_type": "Gender",
+        "gender": "M"
+      },
+      "direct_transition": "Sub_Terminal"
+    },
+
+    "Sub_Terminal": {
+      "type": "Terminal"
+    }
+  }
+}

--- a/src/test/resources/generic/submodules/encounter_submodule.json
+++ b/src/test/resources/generic/submodules/encounter_submodule.json
@@ -1,0 +1,55 @@
+{
+  "name": "Encounter Submodule",
+  "remarks": [
+    "Called by the main 'recursively_calls_submodules' module"
+  ],
+  "states": {
+
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "Delay"
+    },
+
+    "Delay": {
+      "type": "Delay",
+      "exact": {
+        "quantity": 1,
+        "unit": "years"
+      },
+      "direct_transition": "Encounter_In_Submodule"
+    },
+
+    "Encounter_In_Submodule": {
+      "type": "Encounter",
+      "encounter_class": "ambulatory",
+      "reason": "Example_Condition",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": "503552143",
+          "display": "Encounter for symptom"
+        }
+      ],
+      "direct_transition": "Call_MedicationOrder_Submodule"
+    },
+
+    "Call_MedicationOrder_Submodule": {
+      "type": "CallSubmodule",
+      "submodule": "submodules/medication_submodule",
+      "direct_transition": "Delay_Some_More"
+    },
+
+    "Delay_Some_More": {
+      "type": "Delay",
+      "exact": {
+        "quantity": 4,
+        "unit": "weeks"
+      },
+      "direct_transition": "Encounter_Terminal"
+    },
+
+    "Encounter_Terminal": {
+      "type": "Terminal"
+    }
+  }
+}

--- a/src/test/resources/generic/submodules/medication_submodule.json
+++ b/src/test/resources/generic/submodules/medication_submodule.json
@@ -1,0 +1,45 @@
+{
+  "name": "Medication Submodule",
+  "remarks": [
+    "Called by the Encounter submodule."
+  ],
+  "states": {
+
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "Examplitis_Medication"
+    },
+
+    "Examplitis_Medication": {
+      "type": "MedicationOrder",
+      "reason": "Example_Condition",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "354522",
+          "display": "Examplitol 100mg"
+        }
+      ],
+      "direct_transition": "Delay_Yet_Again"
+    },
+
+    "Delay_Yet_Again": {
+      "type": "Delay",
+      "exact": {
+        "quantity": 2,
+        "unit": "weeks"
+      },
+      "direct_transition": "End_Medication"
+    },
+
+    "End_Medication": {
+      "type": "MedicationEnd",
+      "medication_order": "Examplitis_Medication",
+      "direct_transition": "Med_Terminal"
+    },
+
+    "Med_Terminal": {
+      "type": "Terminal"
+    }
+  }
+}

--- a/src/test/resources/generic/symptom.json
+++ b/src/test/resources/generic/symptom.json
@@ -1,0 +1,33 @@
+{
+  "name": "Symptom",
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "SymptomOnset"
+    },
+
+    "SymptomOnset" : {
+      "type" : "Symptom",
+      "symptom" : "Chest Pain",
+      "range" : {
+        "low" : 1,
+        "high" : 10
+      },
+      "direct_transition": "SymptomWorsen"
+    },
+
+    "SymptomWorsen" : {
+      "type" : "Symptom",
+      "symptom" : "Chest Pain",
+      "cause" : "Heart Attack",
+      "exact" : {
+        "quantity" : 96
+      },
+      "direct_transition": "Terminal"
+    },
+
+    "Terminal" : {
+      "type" : "Terminal"
+    }
+  }
+}

--- a/src/test/resources/generic/validation/field_errors.json
+++ b/src/test/resources/generic/validation/field_errors.json
@@ -1,0 +1,106 @@
+{
+  "name": "Field_Errors",
+  "states": {
+
+    "Initial" : {
+      "type" : "Initial",
+      "direct_transition" : "Terminal"
+    },
+
+    "Terminal" : {
+      "type" : "Terminal"
+    },
+
+    "Missing_Transition": {
+      "type": "Simple"
+    },
+
+    "Guard_Missing_Allow" : {
+      "type" : "Guard",
+      "direct_transition" : "Terminal"
+    },
+
+    "Delay_Missing_Amount" : {
+      "type" : "Delay",
+      "direct_transition" : "Terminal"
+    },
+
+    "Encounter_Empty" : {
+      "type" : "Encounter",
+      "direct_transition" : "Terminal"
+    },
+
+    "Encounter_With_Class_Missing_Codes" : {
+      "type" : "Encounter",
+      "encounter_class" : "emergency",
+      "direct_transition" : "Terminal"
+    },
+
+    "Encounter_With_Code_Missing_System" : {
+      "type" : "Encounter",
+      "encounter_class" : "emergency",
+      "codes" : [{
+        "code" : "123456",
+        "display" : "Emergency Room Admission"
+      }],
+      "direct_transition" : "Terminal"
+    },
+
+    "Procedure_Missing_Target_Encounter" : {
+      "type" : "Procedure",
+      "codes" : [{
+        "system" : "aaa",
+        "code" : "bbb",
+        "display" : "ccc"
+      }],
+      "direct_transition" : "Terminal"
+    },
+
+    "Conditional_Transition_Missing_Transition" : {
+      "type" : "Simple",
+      "conditional_transition" : [
+        {
+          "condition" : {
+            "condition_type" : "True"
+          }
+        },
+        {
+          "transition" : "Terminal"
+        }
+      ]
+    },
+
+    "Distributed_Transition_Missing_Pieces" : {
+      "type" : "Simple",
+      "distributed_transition" : [
+        { "distribution" : 0.5, "transition" : "Initial" },
+        { "transition" : "Terminal" },
+        { "distribution" : 0.5 }
+      ]
+    },
+
+    "Complex_Transition_Missing_Pieces" : {
+      "type" : "Simple",
+      "complex_transition" : [
+        {
+          "condition" : {
+            "condition_type" : "True"
+          }
+        },
+        {
+          "transition" : "Terminal"
+        }
+      ]
+    },
+
+    "Date_Condition_Missing_Operator" : {
+      "type" : "Guard",
+      "allow" : {
+        "condition_type" : "Date",
+        "year" : 2016
+      },
+      "direct_transition" : "Terminal"
+    }
+
+  }
+}

--- a/src/test/resources/generic/validation/reference_errors.json
+++ b/src/test/resources/generic/validation/reference_errors.json
@@ -1,0 +1,41 @@
+{
+  "name": "Reference_Errors",
+  "states": {
+    "Initial" : {
+      "type" : "Initial",
+      "direct_transition" : "ConditionOnset_references_Non_Encounter_State"
+    },
+
+    "Unreachable_State" : {
+      "type" : "Simple",
+      "direct_transition" : "Terminal"
+    },
+
+    "ConditionOnset_references_Non_Encounter_State" : {
+      "type" : "ConditionOnset",
+      "codes" : [{
+        "system" : "blah",
+        "code" : "blah",
+        "display" : "blah"
+      }],
+      "target_encounter" : "Nonexistent_State",
+      "direct_transition" : "Doctor_Visit"
+    },
+
+    "Doctor_Visit" : {
+      "type" : "Encounter",
+      "wellness" : true,
+      "direct_transition" : "ConditionEnd_references_Incorrect_State"
+    },
+
+    "ConditionEnd_references_Incorrect_State" : {
+      "type" : "ConditionEnd",
+      "condition_onset" : "Doctor_Visit",
+      "direct_transition" : "Terminal"
+    },
+
+    "Terminal" : {
+      "type" : "Terminal"
+    }
+  }
+}

--- a/src/test/resources/generic/vitalsign_observation.json
+++ b/src/test/resources/generic/vitalsign_observation.json
@@ -1,0 +1,45 @@
+{
+    "name": "VitalSign_Observation",
+    "states": {
+        "Initial": {
+            "type": "Initial",
+            "direct_transition": "VitalSign"
+        },
+
+        "VitalSign" : {
+            "type" : "VitalSign",
+            "vital_sign" : "Systolic Blood Pressure",
+            "exact" : { "quantity" : "120" },
+            "unit" : "mmHg",
+            "direct_transition" : "SomeEncounter"
+        },
+
+        "SomeEncounter" : {
+            "type" : "Encounter",
+            "encounter_class": "inpatient",
+            "codes": [{
+                "system": "SNOMED-CT",
+                "code": "32485007",
+                "display": "Hospital admission"
+            }],
+            "direct_transition" : "SomeObservation"
+        },
+
+        "SomeObservation" : {
+            "type" : "Observation",
+            "vital_sign" : "Systolic Blood Pressure",
+            "category" : "vital-signs",
+            "codes" : [{
+              "system" : "LOINC",
+              "code" : "8480-6",
+              "display" : "Systolic Blood Pressure"
+            }],
+            "unit" : "mmHg",
+            "direct_transition" : "Terminal"
+        },
+
+        "Terminal": {
+            "type": "Terminal"
+        }
+    }
+}


### PR DESCRIPTION
Adds the ability for transition probabilities on Distributed Transitions to be defined by attributes in addition to just regular static %s.

Also copies over the full suite of test fixtures from the ruby synthea, in anticipation of writing more unit tests eventually.

Example:
```
"distributed_transition": [
    {
        "distribution": { "attribute" : "probability1", "default" : 0.15 },
        "transition": "Terminal1"
    },
    {
        "distribution": { "attribute" : "probability2", "default" : 0.55 },
        "transition": "Terminal2"
    },
    {
        "distribution": { "attribute" : "probability3", "default" : 0.30 },
        "transition": "Terminal3"
    }
]
```