### PR TITLE
Community Health Workers

### DIFF
--- a/src/main/java/org/mitre/synthea/modules/CommunityHealthWorker.java
+++ b/src/main/java/org/mitre/synthea/modules/CommunityHealthWorker.java
@@ -1,0 +1,74 @@
+package org.mitre.synthea.modules;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.mitre.synthea.helpers.Config;
+
+
+public class CommunityHealthWorker {
+
+	public static final String LUNG_CANCER_SCREENING = "Lung cancer screening";	
+	public static final String TOBACCO_SCREENING = "Tobacco screening";	
+	public static final String ALCOHOL_SCREENING = "Alcohol screening";	
+	public static final String OBESITY_SCREENING = "Obesity screening";	
+	public static final String BLOOD_PRESSURE_SCREENING = "Blood pressure screening";
+	public static final String DIABETES_SCREENING = "Diabetes screening";
+	public static final String COLORECTAL_CANCER_SCREENING = "Colorectal cancer screening"; 
+	public static final String PREECLAMPSIA_SCREENING = "Preeclampsia screening";	
+	public static final String OSTEOPOROSIS_SCREENING = "Osteoporosis screening";	
+	
+	public static final String ASPIRIN_MEDICATION = "Aspirin Medication";	
+	public static final String PREECLAMPSIA_ASPIRIN = "Preeclampsia aspirin";	
+	public static final String EXERCISE_PT_INJURY_SCREENING = "Fall prevention in older adults: Exercise or physical therapy";
+	public static final String VITAMIN_D_INJURY_SCREENING = "Fall prevention in older adults: Vitamin D";
+	public static final String DIET_PHYSICAL_ACTIVITY = "Diet and physical activity counseling";
+	public static final String STATIN_Medication = "Statin preventive medication";	
+	
+	// TODO social support variable, to be measured/implemented later on
+	public static final String ORGANIZE = "Organize"; 
+
+	public static final String CITY = "city";
+	
+	public static final int cost = Integer.parseInt(Config.get("generate.cost"));
+
+	// TODO Should be global variables, not necessarily specific to CHWs
+	// Will determine the scenarios in which CHWs are assigned
+	//public static boolean enabledforER;
+	//public static boolean discharged;
+	
+	public static Map<String,Object> services;
+	
+	//TODO possible arguments, randomization/computation of services later on
+	public CommunityHealthWorker(){ 
+		services = new ConcurrentHashMap<String,Object>();
+	}
+
+	public static void generateCHW(CommunityHealthWorker chw){
+					
+		services.put(CommunityHealthWorker.ALCOHOL_SCREENING, chw);
+		services.put(CommunityHealthWorker.ASPIRIN_MEDICATION, chw);
+		services.put(CommunityHealthWorker.BLOOD_PRESSURE_SCREENING, chw);
+		services.put(CommunityHealthWorker.COLORECTAL_CANCER_SCREENING, chw);
+		services.put(CommunityHealthWorker.DIABETES_SCREENING, chw);
+		services.put(CommunityHealthWorker.DIET_PHYSICAL_ACTIVITY, chw);
+		services.put(CommunityHealthWorker.EXERCISE_PT_INJURY_SCREENING, chw);
+		services.put(CommunityHealthWorker.LUNG_CANCER_SCREENING, chw);
+		services.put(CommunityHealthWorker.OBESITY_SCREENING, chw);
+		services.put(CommunityHealthWorker.ORGANIZE, chw);
+		services.put(CommunityHealthWorker.OSTEOPOROSIS_SCREENING, chw);
+		services.put(CommunityHealthWorker.PREECLAMPSIA_ASPIRIN, chw);
+		services.put(CommunityHealthWorker.PREECLAMPSIA_SCREENING, chw);
+			
+		services.put(CommunityHealthWorker.STATIN_Medication, chw);
+		services.put(CommunityHealthWorker.TOBACCO_SCREENING, chw);
+		services.put(CommunityHealthWorker.VITAMIN_D_INJURY_SCREENING, chw);
+
+	}
+
+	public static int getCost() {
+		return CommunityHealthWorker.cost;
+	}		
+}
+	

--- a/src/main/java/org/mitre/synthea/modules/CommunityHealthWorker.java
+++ b/src/main/java/org/mitre/synthea/modules/CommunityHealthWorker.java
@@ -1,10 +1,10 @@
 package org.mitre.synthea.modules;
 
-import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.mitre.synthea.helpers.Config;
+import org.mitre.synthea.world.Location;
 
 
 public class CommunityHealthWorker {
@@ -31,7 +31,8 @@ public class CommunityHealthWorker {
 
 	public static final String CITY = "city";
 	
-	public static final int cost = Integer.parseInt(Config.get("generate.cost"));
+	public static int cost = Integer.parseInt(Config.get("generate.chwCost"));
+	public static int budget = Integer.parseInt(Config.get("generate.chwBudget"));
 
 	// TODO Should be global variables, not necessarily specific to CHWs
 	// Will determine the scenarios in which CHWs are assigned
@@ -64,11 +65,52 @@ public class CommunityHealthWorker {
 		services.put(CommunityHealthWorker.STATIN_Medication, chw);
 		services.put(CommunityHealthWorker.TOBACCO_SCREENING, chw);
 		services.put(CommunityHealthWorker.VITAMIN_D_INJURY_SCREENING, chw);
+		Location.assignCity(chw);
 
 	}
+	
+	public static CommunityHealthWorker generateCHW(){
+		
+		CommunityHealthWorker chw = new CommunityHealthWorker();
+		
+		services.put(CommunityHealthWorker.ALCOHOL_SCREENING, chw);
+		services.put(CommunityHealthWorker.ASPIRIN_MEDICATION, chw);
+		services.put(CommunityHealthWorker.BLOOD_PRESSURE_SCREENING, chw);
+		services.put(CommunityHealthWorker.COLORECTAL_CANCER_SCREENING, chw);
+		services.put(CommunityHealthWorker.DIABETES_SCREENING, chw);
+		services.put(CommunityHealthWorker.DIET_PHYSICAL_ACTIVITY, chw);
+		services.put(CommunityHealthWorker.EXERCISE_PT_INJURY_SCREENING, chw);
+		services.put(CommunityHealthWorker.LUNG_CANCER_SCREENING, chw);
+		services.put(CommunityHealthWorker.OBESITY_SCREENING, chw);
+		services.put(CommunityHealthWorker.ORGANIZE, chw);
+		services.put(CommunityHealthWorker.OSTEOPOROSIS_SCREENING, chw);
+		services.put(CommunityHealthWorker.PREECLAMPSIA_ASPIRIN, chw);
+		services.put(CommunityHealthWorker.PREECLAMPSIA_SCREENING, chw);
+			
+		services.put(CommunityHealthWorker.STATIN_Medication, chw);
+		services.put(CommunityHealthWorker.TOBACCO_SCREENING, chw);
+		services.put(CommunityHealthWorker.VITAMIN_D_INJURY_SCREENING, chw);
+		Location.assignCity(chw);
+		
+		return chw;
 
+	}
+	
 	public static int getCost() {
 		return CommunityHealthWorker.cost;
-	}		
+	}	
+	
+	public static void setCost(int cost){
+		CommunityHealthWorker.cost = cost;
+	}
+	
+	public static int getBudget(){
+		return CommunityHealthWorker.budget;
+	}
+	
+	public static void setBudget(int budget){
+		CommunityHealthWorker.budget = budget;
+	}
+		
 }
 	

--- a/src/main/java/org/mitre/synthea/modules/Generator.java
+++ b/src/main/java/org/mitre/synthea/modules/Generator.java
@@ -110,11 +110,11 @@ public class Generator {
 			CommunityHealthWorker chw = new CommunityHealthWorker();
 			
 			String cityName = Location.randomCityName(random);
-			chw.services.put(CommunityHealthWorker.CITY, Location.assignCity(chw, cityName));	
-			
+			chw.services.put(CommunityHealthWorker.CITY, cityName);			
 			CommunityHealthWorker.generateCHW(chw);
 			
 			chws.add(chw);
+			
 		}
 	}
 	
@@ -172,6 +172,12 @@ public class Generator {
 					// if true
 					// then add chw encounter to record
 					// and set chw variable(s) on person.attributes.put(KEY, VALUE)
+					
+					if(chws.size() > 0){
+						System.out.println("sizey" + chws.size());
+						//person.attributes.put("CommunityHealthWorker", chws.get(1));
+					}
+					
 					time += timestep;
 				}
 				

--- a/src/main/java/org/mitre/synthea/modules/Generator.java
+++ b/src/main/java/org/mitre/synthea/modules/Generator.java
@@ -29,6 +29,8 @@ public class Generator {
 
 	public final long ONE_HUNDRED_YEARS = 100l * TimeUnit.DAYS.toMillis(365);
 	public List<Person> people;
+	public List<CommunityHealthWorker> chws;
+	public int budget;
 	public long numberOfPeople;
 	public final int MAX_TRIES = 10;
 	public long seed;
@@ -53,9 +55,11 @@ public class Generator {
 	{
 		this.people = Collections.synchronizedList(new ArrayList<Person>());
 		this.numberOfPeople = people;
+		this.chws = Collections.synchronizedList(new ArrayList<CommunityHealthWorker>());
 		this.seed = seed;
 		this.random = new Random(seed);
 		this.timestep = Long.parseLong( Config.get("generate.timestep") );
+		this.budget = Integer.parseInt(Config.get("generate.budget"));
 		this.stop = System.currentTimeMillis();
 		this.demographics = Demographics.loadByName( Config.get("generate.demographics.default_file") );
 		
@@ -101,7 +105,19 @@ public class Generator {
 		}
 		
 		System.out.println(stats);
+		
+		for(int i=0;i<= budget / CommunityHealthWorker.getCost();i++){
+			CommunityHealthWorker chw = new CommunityHealthWorker();
+			
+			String cityName = Location.randomCityName(random);
+			chw.services.put(CommunityHealthWorker.CITY, Location.assignCity(chw, cityName));	
+			
+			CommunityHealthWorker.generateCHW(chw);
+			
+			chws.add(chw);
+		}
 	}
+	
 	
 	private void generatePerson(int index)
 	{

--- a/src/main/java/org/mitre/synthea/modules/Generator.java
+++ b/src/main/java/org/mitre/synthea/modules/Generator.java
@@ -30,7 +30,6 @@ public class Generator {
 	public final long ONE_HUNDRED_YEARS = 100l * TimeUnit.DAYS.toMillis(365);
 	public List<Person> people;
 	public List<CommunityHealthWorker> chws;
-	public int budget;
 	public long numberOfPeople;
 	public final int MAX_TRIES = 10;
 	public long seed;
@@ -59,7 +58,6 @@ public class Generator {
 		this.seed = seed;
 		this.random = new Random(seed);
 		this.timestep = Long.parseLong( Config.get("generate.timestep") );
-		this.budget = Integer.parseInt(Config.get("generate.budget"));
 		this.stop = System.currentTimeMillis();
 		this.demographics = Demographics.loadByName( Config.get("generate.demographics.default_file") );
 		
@@ -105,17 +103,7 @@ public class Generator {
 		}
 		
 		System.out.println(stats);
-		
-		for(int i=0;i<= budget / CommunityHealthWorker.getCost();i++){
-			CommunityHealthWorker chw = new CommunityHealthWorker();
-			
-			String cityName = Location.randomCityName(random);
-			chw.services.put(CommunityHealthWorker.CITY, cityName);			
-			CommunityHealthWorker.generateCHW(chw);
-			
-			chws.add(chw);
-			
-		}
+	
 	}
 	
 	
@@ -172,11 +160,7 @@ public class Generator {
 					// if true
 					// then add chw encounter to record
 					// and set chw variable(s) on person.attributes.put(KEY, VALUE)
-					
-					if(chws.size() > 0){
-						System.out.println("sizey" + chws.size());
-						//person.attributes.put("CommunityHealthWorker", chws.get(1));
-					}
+			
 					
 					time += timestep;
 				}

--- a/src/main/java/org/mitre/synthea/modules/HealthRecord.java
+++ b/src/main/java/org/mitre/synthea/modules/HealthRecord.java
@@ -146,6 +146,7 @@ public class HealthRecord {
 		public String reason;
 		public Code discharge;
 		public Provider provider;
+		public CommunityHealthWorker chw;
 		
 		public Encounter(long time, String type) {
 			super(time, type);

--- a/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
+++ b/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
@@ -27,6 +27,7 @@ public final class LifecycleModule extends Module
 		// birth(person, time); intentionally left out - call it only once from Generator
 		age(person, time);
 		grow(person, time);
+		person.chwEncounter(person, time);
 		diabeticVitalSigns(person, time);
 		death(person, time);
 		
@@ -145,6 +146,7 @@ public final class LifecycleModule extends Module
 			person.recordDeath(time, NATURAL_CAUSES, "death");
 		}
 	}
+	
 	
 	private static double likelihoodOfDeath(int age)
 	{

--- a/src/main/java/org/mitre/synthea/modules/Person.java
+++ b/src/main/java/org/mitre/synthea/modules/Person.java
@@ -1,7 +1,6 @@
 package org.mitre.synthea.modules;
 
-import java.util.ArrayList;
-import java.util.concurrent.ThreadLocalRandom;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/org/mitre/synthea/modules/Person.java
+++ b/src/main/java/org/mitre/synthea/modules/Person.java
@@ -159,6 +159,50 @@ public class Person {
 		return false;
 	}
 	
+	// Community Health Workers API -----------------------------------------------------------
+	public static final String CHW = "communityHealthWorker";
+	
+	public void setCHW(CommunityHealthWorker chw){
+		attributes.put(CHW, chw);
+	}
+	
+	
+	public CommunityHealthWorker getCHW(){
+		return (CommunityHealthWorker) attributes.get(CHW);
+	}
+	
+	//TODO incorporate this method 
+	public boolean chwEncounterChance(Person person, CommunityHealthWorker chw){
+		if(person.CITY.equals(chw.CITY)){
+			return true;
+		} else{
+			return false;
+		}
+	}
+	
+	public static void chwEncounter(Person person, long time){
+		int age = person.ageInYears(time);
+		CommunityHealthWorker chw = CommunityHealthWorker.generateCHW();
+		
+		//TODO additional rules/percentages to define these encounters more probabilistically 
+		
+		//note: add a "CHW intervention" count to the health record (i.e. encounters, observations, etc)
+
+		if(age >= 20 && age % 2 == 0 && age < 65){
+				if((person.attributes.containsKey(CHW))){
+					Map<Integer, CommunityHealthWorker> chws = (Map) person.attributes.get(CHW);
+					chws.put(age, chw);
+					person.attributes.put(CHW, chws);
+					
+				}
+				else{
+					Map<Integer, CommunityHealthWorker> chws = new HashMap<Integer, CommunityHealthWorker>();
+					chws.put(age, chw);
+					person.attributes.put(CHW, chws);	
+				}
+			}
+		}
+	
 	// Providers API -----------------------------------------------------------
 	public static final String CURRENTPROVIDER = "currentProvider";
 	public static final String PREFERREDAMBULATORYPROVIDER = "preferredAmbulatoryProvider";

--- a/src/main/java/org/mitre/synthea/modules/Person.java
+++ b/src/main/java/org/mitre/synthea/modules/Person.java
@@ -1,5 +1,7 @@
 package org.mitre.synthea.modules;
 
+import java.util.ArrayList;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -188,16 +190,28 @@ public class Person {
 		
 		//note: add a "CHW intervention" count to the health record (i.e. encounters, observations, etc)
 
-		if(age >= 20 && age % 2 == 0 && age < 65){
+		if(age >= 20 && age <= 65){
+
 				if((person.attributes.containsKey(CHW))){
 					Map<Integer, CommunityHealthWorker> chws = (Map) person.attributes.get(CHW);
-					chws.put(age, chw);
-					person.attributes.put(CHW, chws);
-					
+					int randomChance = (int) (Math.random() * (100 - 1)) + 1;
+						if(randomChance >= 99){
+							Random rand = new Random();
+							int randomAge = rand.nextInt(age);
+							if(randomAge >= 20 && randomAge <= 65){
+								chws.put(randomAge, chw);}
+							}
+						person.attributes.put(CHW, chws);
 				}
 				else{
 					Map<Integer, CommunityHealthWorker> chws = new HashMap<Integer, CommunityHealthWorker>();
-					chws.put(age, chw);
+					int randomChance = (int) (Math.random() * (100 - 1)) + 1;
+					if(randomChance >= 99){
+						Random rand = new Random();
+						int randomAge = rand.nextInt(age);
+						if(randomAge >= 20 && randomAge <= 65){
+							chws.put(randomAge, chw);}
+						}
 					person.attributes.put(CHW, chws);	
 				}
 			}

--- a/src/main/java/org/mitre/synthea/modules/State.java
+++ b/src/main/java/org/mitre/synthea/modules/State.java
@@ -1,6 +1,7 @@
 package org.mitre.synthea.modules;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.mitre.synthea.modules.HealthRecord.CarePlan;
@@ -202,7 +203,7 @@ public class State {
 					person.addCurrentProvider(module, provider);
 					provider.incrementEncounters();
 					encounter.provider = provider;
-					
+			
 					this.exited = time;
 					return true;
 				} else {

--- a/src/main/java/org/mitre/synthea/world/Location.java
+++ b/src/main/java/org/mitre/synthea/world/Location.java
@@ -155,10 +155,4 @@ public class Location {
 		person.attributes.put(Person.COORDINATE, selectedPoint);
 	}
 	
-	public static String assignCity(CommunityHealthWorker chw, String cityName){
-
-		chw.services.put(CommunityHealthWorker.CITY, cityName);
-		return cityName;
-		
-	}
 }

--- a/src/main/java/org/mitre/synthea/world/Location.java
+++ b/src/main/java/org/mitre/synthea/world/Location.java
@@ -155,4 +155,11 @@ public class Location {
 		person.attributes.put(Person.COORDINATE, selectedPoint);
 	}
 	
+	public static void assignCity(CommunityHealthWorker chw){
+
+		Random random = new Random();
+		String city = Location.randomCityName(random);
+		chw.services.put(CommunityHealthWorker.CITY, city);
+		
+	}
 }

--- a/src/main/java/org/mitre/synthea/world/Location.java
+++ b/src/main/java/org/mitre/synthea/world/Location.java
@@ -1,12 +1,14 @@
 package org.mitre.synthea.world;
 
 import java.io.BufferedReader;
+
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Random;
 import java.util.stream.Collectors;
 
 import org.mitre.synthea.modules.Person;
+import org.mitre.synthea.modules.CommunityHealthWorker;
 import org.wololo.geojson.Feature;
 import org.wololo.geojson.FeatureCollection;
 import org.wololo.geojson.GeoJSONFactory;
@@ -151,5 +153,12 @@ public class Location {
 		person.attributes.put(Person.STATE, "MA");
 		person.attributes.put(Person.ZIP, getZipCode(cityName));
 		person.attributes.put(Person.COORDINATE, selectedPoint);
+	}
+	
+	public static String assignCity(CommunityHealthWorker chw, String cityName){
+
+		chw.services.put(CommunityHealthWorker.CITY, cityName);
+		return cityName;
+		
 	}
 }

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -17,3 +17,7 @@ generate.demographics.default_file = /geography/towns.json
 
 generate.demographics.real_world_population = 6794422
 #sum of the jsons in the config folder
+
+#budget & cost information
+generate.budget = 100000
+generate.cost = 20000

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -19,5 +19,5 @@ generate.demographics.real_world_population = 6794422
 #sum of the jsons in the config folder
 
 #budget & cost information
-generate.budget = 100000
-generate.cost = 20000
+generate.chwBudget = 100000
+generate.chwCost = 20000


### PR DESCRIPTION
## Overview 

* Initial implementation of community health workers (minimum viable product) into the Synthea java implementation 
* Community health workers provide 15 preventive services defined by the USPSTF 
* Community health workers have a location, cost, and accompanying budget information

## Implementation

Each community health worker is mapped to a service and city. For now, all community health workers provide all 15 preventive services. An additional service named "organize" was also discussed as being a measure of social support in the community provided by the community health worker, and can be implemented/defined later on. Community health workers are assigned a city at random, and the cost per community health worker is set in the Synthea properties file. Budget inputs, also in the Synthea properties file, will determine how many community health workers are generated. These are fixed for now, but can be updated to reflect real world/state estimates of cost per community health worker. Currently, patients between the ages of 20 and 65 have a random chance (defined by random number bounds that can be altered) of encountering a community health worker. The patient's age at the time of the intervention is mapped to a community health worker. The goal is to define these interventions more probabilistically, with additional conditions based on location. 
