### PR TITLE
Cardiovascular disease module

### DIFF
--- a/src/main/java/org/mitre/synthea/modules/CardiovascularDiseaseModule.java
+++ b/src/main/java/org/mitre/synthea/modules/CardiovascularDiseaseModule.java
@@ -1,6 +1,11 @@
 package org.mitre.synthea.modules;
 
 import java.util.Calendar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 
 public final class CardiovascularDiseaseModule extends Module 
@@ -33,6 +38,153 @@ public final class CardiovascularDiseaseModule extends Module
 		return false;
 	}
 
+	//////////////
+	// RESOURCES//
+	//////////////
+	
+    // estimate cardiovascular risk of developing coronary heart disease (CHD)
+    // http://www.nhlbi.nih.gov/health-pro/guidelines/current/cholesterol-guidelines/quick-desk-reference-html/10-year-risk-framingham-table
+
+    // Indices in the array correspond to these age ranges: 20-24, 25-29, 30-34 35-39, 40-44, 45-49,
+    // 50-54, 55-59, 60-64, 65-69, 70-74, 75-79
+    private static final int[] age_chd_m;
+    private static final int[] age_chd_f;
+    
+    private static final int[][] age_chol_chd_m;
+    private static final int[][] age_chol_chd_f;
+    
+    private static final int[] age_smoke_chd_m;
+    private static final int[] age_smoke_chd_f;
+    
+    private static final int[][] sys_bp_chd_m;
+    private static final int[][] sys_bp_chd_f;
+    
+    private static final Map<Integer, Double> risk_chd_m;
+    private static final Map<Integer, Double> risk_chd_f; 
+    
+    private static int[] hdl_lookup_chd;
+    
+    private static final Map<String, Integer> MEDICATION_AVAILABLE;
+    static {
+    	age_chd_m = new int[]{-9, -9, -9, -4, 0, 3, 6, 8, 10, 11, 12, 13};
+    	age_chd_f = new int[]{-7, -7, -7, -3, 0, 3, 6, 8, 10, 12, 14, 16};
+
+    	age_chol_chd_m = new int[][] 
+    			{
+    	            // <160, 160-199, 200-239, 240-279, >280
+    	            {0, 4, 7, 9, 11}, // 20-29 years
+    	            {0, 4, 7, 9, 11}, // 30-39 years
+    	            {0, 3, 5, 6, 8}, // 40-49 years
+    	            {0, 2, 3, 4, 5}, // 50-59 years
+    	            {0, 1, 1, 2, 3}, // 60-69 years
+    	            {0, 0, 0, 1, 1} // 70-79 years
+    	         };
+
+    	age_chol_chd_f = new int[][]
+        	{
+                 // <160, 160-199, 200-239, 240-279, >280
+                 {0, 4, 8, 11, 13}, // 20-29 years
+                 {0, 4, 8, 11, 13}, // 30-39 years
+                 {0, 3, 6, 8, 10}, // 40-49 years
+                 {0, 2, 4, 5, 7}, // 50-59 years
+                 {0, 1, 2, 3, 4}, // 60-69 years
+                 {0, 1, 1, 2, 2} // 70-79 years
+             };
+
+     	// 20-29, 30-39, 40-49, 50-59, 60-69, 70-79 age ranges
+        age_smoke_chd_m = new int[]{8, 8, 5, 3, 1, 1};
+        age_smoke_chd_f = new int[]{9, 9, 7, 4, 2, 1};
+
+
+        hdl_lookup_chd = new int[]{2, 1, 0, -1}; // <40, 40-49, 50-59, >60
+
+        // true/false refers to whether or not blood pressure is treated
+        sys_bp_chd_m = new int[][]{
+        // true, false
+            { 0, 0 }, // <120
+            { 1, 0 }, // 120-129
+            { 2, 1 }, // 130-139
+            { 2, 1 }, // 140-149
+            { 2, 1 }, // 150-159
+            { 3, 2 } // >=160
+        };
+        
+        sys_bp_chd_f = new int[][]{
+         // true, false
+            { 0, 0 }, // <120
+            { 3, 1 }, // 120-129
+            { 4, 2 }, // 130-139
+            { 5, 3 }, // 140-149
+            { 5, 3 }, // 150-159
+            { 6, 4 } // >=160
+        };
+
+        // framingham point scores gives a 10-year risk
+        risk_chd_m = new HashMap<>();
+        risk_chd_m.put(-1, 0.005); // '-1' represents all scores <0
+        risk_chd_m.put(0, 0.01);
+        risk_chd_m.put(1, 0.01);
+        risk_chd_m.put(2, 0.01);
+        risk_chd_m.put(3, 0.01);
+        risk_chd_m.put(4, 0.01);
+        risk_chd_m.put(5, 0.02);
+        risk_chd_m.put(6, 0.02);
+        risk_chd_m.put(7, 0.03);
+        risk_chd_m.put(8, 0.04);
+        risk_chd_m.put(9, 0.05);
+        risk_chd_m.put(10, 0.06);
+        risk_chd_m.put(11, 0.08);
+        risk_chd_m.put(12, 0.1);
+        risk_chd_m.put(13, 0.12);
+        risk_chd_m.put(14, 0.16);
+        risk_chd_m.put(15, 0.20);
+        risk_chd_m.put(16, 0.25);
+        risk_chd_m.put(17, 0.3); // '17' represents all scores >16
+            
+       risk_chd_f = new HashMap<>();
+       risk_chd_f.put(8, 0.005); // '8' represents all scores <9
+       risk_chd_f.put(9, 0.01);
+       risk_chd_f.put(10, 0.01);
+       risk_chd_f.put(11, 0.01);
+       risk_chd_f.put(12, 0.01);
+       risk_chd_f.put(13, 0.02);
+       risk_chd_f.put(14, 0.02);
+       risk_chd_f.put(15, 0.03);
+       risk_chd_f.put(16, 0.04);
+       risk_chd_f.put(17, 0.05);
+       risk_chd_f.put(18, 0.06);
+       risk_chd_f.put(19, 0.08);
+       risk_chd_f.put(20, 0.11);
+       risk_chd_f.put(21, 0.14);
+       risk_chd_f.put(22, 0.17);
+       risk_chd_f.put(23, 0.22);
+       risk_chd_f.put(24, 0.27);
+       risk_chd_f.put(25, 0.3); // '25' represents all scores >24
+
+        MEDICATION_AVAILABLE = new HashMap<>();
+        MEDICATION_AVAILABLE.put("clopidogrel", 1997);
+        MEDICATION_AVAILABLE.put("simvastatin", 1991);
+        MEDICATION_AVAILABLE.put("amlodipine", 1994);
+        MEDICATION_AVAILABLE.put("nitroglycerin", 1878);
+        MEDICATION_AVAILABLE.put("warfarin", 1954);
+        MEDICATION_AVAILABLE.put("verapamil", 1981);
+        MEDICATION_AVAILABLE.put("digoxin", 1954);
+        MEDICATION_AVAILABLE.put("atorvastatin", 1996);
+        MEDICATION_AVAILABLE.put("captopril", 1981);
+        MEDICATION_AVAILABLE.put("alteplase", 1987);
+        MEDICATION_AVAILABLE.put("epinephrine", 1906);
+        MEDICATION_AVAILABLE.put("amiodarone", 1962);
+        MEDICATION_AVAILABLE.put("atropine", 1903);
+    }
+
+    private static List<String> filter_meds_by_year(List<String> meds, long time)
+    {
+		Calendar calendar = Calendar.getInstance();
+		calendar.setTimeInMillis(time);
+		double year = calendar.get(Calendar.YEAR);
+    	return meds.stream().filter( med -> year >= MEDICATION_AVAILABLE.get(med)).collect(Collectors.toList());
+    }
+	
 	/////////////////////////
 	// MIGRATED JAVA RULES //
 	/////////////////////////
@@ -72,24 +224,107 @@ public final class CardiovascularDiseaseModule extends Module
 		return ((year * -0.4865) + 996.41) / 100.0;
 	}
 	
+	private static int bound(int value, int min, int max)
+	{
+		return Math.min(Math.max(value, min), max);
+	}
+	
 	private static void calculateCardioRisk(Person person, long time)
 	{
+		int age = person.ageInYears(time);
+		String gender = (String)person.attributes.get(Person.GENDER);
+		Double sysBP = person.getVitalSign(VitalSign.SYSTOLIC_BLOOD_PRESSURE);
+		Double chol = person.getVitalSign(VitalSign.TOTAL_CHOLESTEROL);
+		if (sysBP == null || chol == null)
+		{
+			return;
+		}
+
+		Boolean bpTreated = (Boolean)person.attributes.getOrDefault("bp_treated?", false);
+
+		Double hdl = person.getVitalSign(VitalSign.HDL);
 		
+       // calculate which index in a lookup array a number corresponds to based on ranges in scoring
+      int short_age_range = bound((age - 20) / 5, 0, 11);
+      int long_age_range = bound((age - 20) / 10, 0, 5);
+
+      // 0: <160, 1: 160-199, 2: 200-239, 3: 240-279, 4: >280
+      int chol_range = bound((chol.intValue() - 160) / 40 + 1, 0, 4);
+
+      // 0: <120, 1: 120-129, 2: 130-139, 3: 140-149, 4: 150-159, 5: >=160
+      int bp_range = bound((sysBP.intValue() - 120) / 10 + 1, 0, 5);
+      int framingham_points = 0;
+      
+      int[] age_chd;
+      int[][] age_chol_chd;
+      int[] age_smoke_chd;
+      int[][] sys_bp_chd;
+      
+      if (gender.equals("M"))
+      {
+    	  age_chd = age_chd_m;
+    	  age_chol_chd = age_chol_chd_m;
+    	  age_smoke_chd = age_smoke_chd_m;
+    	  sys_bp_chd = sys_bp_chd_m;
+      } else
+      {
+    	  age_chd = age_chd_f;
+    	  age_chol_chd = age_chol_chd_f;
+    	  age_smoke_chd = age_smoke_chd_f;
+    	  sys_bp_chd = sys_bp_chd_f;
+      }
+      
+      framingham_points += age_chd[short_age_range];
+      framingham_points += age_chol_chd[long_age_range][chol_range];
+
+      if ((Boolean)person.attributes.getOrDefault("SMOKER", false))
+      {
+        framingham_points += age_smoke_chd[long_age_range];
+      }
+      
+      // 0: <40, 1: 40-49, 2: 50-59, 3: >60
+      int hdl_range = bound((hdl.intValue() - 40) / 10 + 1, 0, 3);
+      framingham_points += hdl_lookup_chd[hdl_range];
+      
+      int bp_treated = bpTreated ? 0 : 1;
+      framingham_points += sys_bp_chd[bp_range][bp_treated];
+      double risk;
+      // restrict lower and upper bound of framingham score
+	  if (gender.equals("M"))
+      {
+		  framingham_points = bound(framingham_points, 0, 17);
+		  risk = risk_chd_m.get(framingham_points);
+      } else
+      {
+    	  framingham_points = bound(framingham_points, 8, 25);
+    	  risk = risk_chd_f.get(framingham_points);
+      }
+
+      person.attributes.put("cardio_risk", Utilities.convertRiskToTimestep(risk, TimeUnit.DAYS.toMillis(3650)));
 	}
 	
 	private static void onsetCoronaryHeartDisease(Person person, long time)
 	{
-		
+		double cardioRisk = (double)person.attributes.getOrDefault("cardio_risk", -1.0);
+		if (person.attributes.containsKey("coronary_heart_disease"))
+		{
+			return;
+		}
+        if (person.rand() < cardioRisk)
+        {
+        	person.attributes.put("coronary_heart_disease", true);
+        	person.events.create(time, "coronary_heart_disease", "onsetCoronaryHeartDisease", true);
+        }
 	}
 	
 	private static void coronaryHeartDiseaseProgression(Person person, long time)
 	{
-		
+		// numbers are from appendix: http://www.ncbi.nlm.nih.gov/pmc/articles/PMC1647098/pdf/amjph00262-0029.pdf	
 	}
 	
 	private static void noCoronaryHeartDisease(Person person, long time)
 	{
-		
+		// chance of getting a sudden cardiac arrest without heart disease. (Most probable cardiac event w/o cause or history)	
 	}
 	
 	private static void calculateAtrialFibrillationRisk(Person person, long time)

--- a/src/main/java/org/mitre/synthea/modules/EncounterModule.java
+++ b/src/main/java/org/mitre/synthea/modules/EncounterModule.java
@@ -1,7 +1,11 @@
 package org.mitre.synthea.modules;
 
+import java.util.concurrent.TimeUnit;
+
+import org.mitre.synthea.modules.HealthRecord.Code;
 import org.mitre.synthea.modules.HealthRecord.Encounter;
 import org.mitre.synthea.modules.HealthRecord.EncounterType;
+import org.mitre.synthea.world.Provider;
 
 public final class EncounterModule extends Module {
 	
@@ -15,21 +19,75 @@ public final class EncounterModule extends Module {
 	@Override
 	public boolean process(Person person, long time) 
 	{
+		boolean startedEncounter = false;
+		
 		// add a wellness encounter if this is the right time
 		if(person.record.timeSinceLastWellnessEncounter(time) >= recommendedTimeBetweenWellnessVisits(person, time)) {
 			Encounter encounter = person.record.encounterStart(time, EncounterType.WELLNESS.toString());
 			encounter.name = "Encounter Module Scheduled Wellness";
 			person.attributes.put(ACTIVE_WELLNESS_ENCOUNTER, true);
+			startedEncounter = true;
 		} else if(person.symptomTotal() > SYMPTOM_THRESHOLD) {
 			// add a symptom driven encounter if symptoms are severe
 			person.resetSymptoms();
 			Encounter encounter = person.record.encounterStart(time, EncounterType.WELLNESS.toString());
 			encounter.name = "Encounter Module Symptom Driven";
 			person.attributes.put(ACTIVE_WELLNESS_ENCOUNTER, true);
+			startedEncounter = true;
+		}
+		
+		if (startedEncounter)
+		{
+			CardiovascularDiseaseModule.performEncounter(person, time);
 		}
 		
 		// java modules will never "finish"
 		return false;
+	}
+	
+	public static void emergencyVisit(Person person, long time)
+	{
+	      // processes all emergency events. Implemented as a function instead of a rule because emergency events must be procesed
+	      // immediately rather than waiting til the next time period. Patient may die, resulting in rule not being called.
+
+		for (Event event : person.events.before(time, "emergency_encounter"))
+		{
+			if (event.processed)
+			{
+				continue;
+			}
+			
+			event.processed = true;
+			
+			emergencyEncounter(person, time);
+		}
+	
+		for (Event event : person.events.before(time))
+		{
+			if (event.processed || !(event.type.equals("myocardial_infarction") || event.type.equals("cardiac_arrest") || event.type.equals("stroke")))
+			{
+				continue;
+			}
+			
+			event.processed = true;
+			
+			CardiovascularDiseaseModule.performEmergency(person, time, event.type);
+			
+		}
+	}
+	
+	public static void emergencyEncounter(Person person, long time)
+	{
+        // find closest service provider with emergency service
+        Provider provider = Provider.findClosestService(person, "emergency");
+        provider.incrementEncounters();
+
+        Encounter encounter = person.record.encounterStart(time, "emergency");
+        encounter.codes.add(new Code("SNOMED-CT", "50849002", "Emergency Encounter"));
+        // TODO: emergency encounters need their duration to be defined by the activities performed
+        // based on the emergencies given here (heart attack, stroke)
+        // assume people will be in the hospital for observation for a few days
+        person.record.encounterEnd(time + TimeUnit.DAYS.toMillis(4), "emergency");
 	}
 	
 	public long recommendedTimeBetweenWellnessVisits(Person person, long time) {

--- a/src/main/java/org/mitre/synthea/modules/EventList.java
+++ b/src/main/java/org/mitre/synthea/modules/EventList.java
@@ -42,7 +42,7 @@ public class EventList {
 		List<Event> retVal = new ArrayList<Event>();
 		synchronized(LOCK) {
 			for(Event event : events) {
-				if (event.time < time) {
+				if (event.time <= time) {
 					retVal.add(event);
 				} else if (event.time > time) {
 					break;
@@ -62,7 +62,7 @@ public class EventList {
 		List<Event> retVal = new ArrayList<Event>();
 		synchronized(LOCK) {
 			for(Event event : events) {
-				if (event.type == type && event.time < time) {
+				if (event.type == type && event.time <= time) {
 					retVal.add(event);
 				} else if (event.time > time) {
 					break;
@@ -81,7 +81,7 @@ public class EventList {
 		List<Event> retVal = new ArrayList<Event>();
 		synchronized(LOCK) {
 			for(Event event : events) {
-				if (event.time > time) {
+				if (event.time >= time) {
 					retVal.add(event);
 				}
 			}
@@ -99,7 +99,7 @@ public class EventList {
 		List<Event> retVal = new ArrayList<Event>();
 		synchronized(LOCK) {
 			for(Event event : events) {
-				if (event.time > time && event.type == type) {
+				if (event.time >= time && event.type == type) {
 					retVal.add(event);
 				}
 			}

--- a/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
+++ b/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
@@ -132,7 +132,27 @@ public final class LifecycleModule extends Module
 	
 	private static void diabeticVitalSigns(Person person, long time)
 	{
-		
+		// TODO - most of the rest of the vital signs
+		boolean hypertension = (Boolean)person.attributes.getOrDefault("hypertension", false);
+		/*
+		    blood_pressure:
+		      normal:
+		        systolic: [100,139] # mmHg
+		        diastolic: [70,89]  # mmHg
+		      hypertensive:
+		        systolic: [140,200] # mmHg
+		        diastolic: [90,120] # mmHg
+		 */
+        if (hypertension)
+        {
+        	person.setVitalSign(VitalSign.SYSTOLIC_BLOOD_PRESSURE, person.rand(140, 200));
+        	person.setVitalSign(VitalSign.DIASTOLIC_BLOOD_PRESSURE, person.rand(90, 120));
+        }
+        else
+        {
+        	person.setVitalSign(VitalSign.SYSTOLIC_BLOOD_PRESSURE, person.rand(100, 139));
+        	person.setVitalSign(VitalSign.DIASTOLIC_BLOOD_PRESSURE, person.rand(70, 89));
+        }
 	}
 	
 	private static final Code NATURAL_CAUSES = new Code("SNOMED-CT", "9855000", "Natural death with unknown cause");

--- a/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
+++ b/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
@@ -130,6 +130,12 @@ public final class LifecycleModule extends Module
 		return (weightKG / ((heightCM / 100.0) * (heightCM / 100.0)));
 	}
 	
+	// LIPID PANEL  https://www.nlm.nih.gov/medlineplus/magazine/issues/summer12/articles/summer12pg6-7.html
+    private static final int[] CHOLESTEROL = new int[] {160,200,239,259,279,300}; // # mg/dL
+    private static final int[] TRIGLYCERIDES = new int[] {100,150,199,499,550,600}; // mg/dL
+    private static final int[] HDL = new int[] { 80, 59, 40, 20, 10,  0}; // mg/dL
+
+	
 	private static void diabeticVitalSigns(Person person, long time)
 	{
 		// TODO - most of the rest of the vital signs
@@ -153,6 +159,22 @@ public final class LifecycleModule extends Module
         	person.setVitalSign(VitalSign.SYSTOLIC_BLOOD_PRESSURE, person.rand(100, 139));
         	person.setVitalSign(VitalSign.DIASTOLIC_BLOOD_PRESSURE, person.rand(70, 89));
         }
+        
+        int index = 0;
+        if (person.attributes.containsKey("diabetes_severity"))
+        {
+        	index = (Integer) person.attributes.getOrDefault("diabetes_severity", 1);
+        }
+        
+        double total_cholesterol = person.rand(CHOLESTEROL[index], CHOLESTEROL[index+1]);
+        double triglycerides = person.rand(TRIGLYCERIDES[index], TRIGLYCERIDES[index+1]);
+        double hdl = person.rand(HDL[index], HDL[index+1]);
+        double ldl = total_cholesterol - hdl - (0.2 * triglycerides);
+        
+        person.setVitalSign(VitalSign.TOTAL_CHOLESTEROL, total_cholesterol);
+        person.setVitalSign(VitalSign.TRIGLYCERIDES, triglycerides);
+        person.setVitalSign(VitalSign.HDL, hdl);
+        person.setVitalSign(VitalSign.LDL, ldl);
 	}
 	
 	private static final Code NATURAL_CAUSES = new Code("SNOMED-CT", "9855000", "Natural death with unknown cause");

--- a/src/main/java/org/mitre/synthea/modules/Person.java
+++ b/src/main/java/org/mitre/synthea/modules/Person.java
@@ -34,6 +34,7 @@ public class Person {
 	public final Random random;
 	public final long seed;
 	public Map<String,Object> attributes;
+	public Map<VitalSign, Double> vitalSigns;
 	private Map<String,Map<String,Integer>> symptoms;
 	public EventList events;
 	public HealthRecord record;
@@ -44,6 +45,7 @@ public class Person {
 		this.seed = seed; // keep track of seed so it can be exported later
 		random = new Random(seed);
 		attributes = new ConcurrentHashMap<String,Object>();
+		vitalSigns = new ConcurrentHashMap<VitalSign,Double>();
 		symptoms = new ConcurrentHashMap<String,Map<String,Integer>>();
 		events = new EventList();
 		record = new HealthRecord();
@@ -99,6 +101,16 @@ public class Person {
 			}
 		}
 		return max;
+	}
+	
+	public Double getVitalSign(VitalSign vitalSign)
+	{
+		return vitalSigns.get(vitalSign);
+	}
+	
+	public void setVitalSign(VitalSign vitalSign, double value)
+	{
+		vitalSigns.put(vitalSign, value);
 	}
 	
 	public void recordDeath(long time, Code cause, String ruleName)

--- a/src/main/java/org/mitre/synthea/modules/State.java
+++ b/src/main/java/org/mitre/synthea/modules/State.java
@@ -332,7 +332,7 @@ public class State {
 				value = person.attributes.get(attribute);
 			} else if(definition.has("vital_sign")) {
 				attribute = definition.get("vital_sign").getAsString();
-				value = person.attributes.get(attribute);
+				value = person.getVitalSign(VitalSign.fromString(attribute));
 			}
 			Observation observation = person.record.observation(time, primary_code, value);
 			observation.name = this.name;


### PR DESCRIPTION
Ports the cardiovascular disease module from Ruby to Java. This is intended to only be a stop-gap measure until we have time to convert the CVD module to GMF, which would be a much larger endeavor, so this is intentionally left kind of rough. Many of the names use ruby naming conventions instead of java naming conventions because they were copy & pasted from ruby code, and left that way so that it's easier to trace back to the ruby origins.