### PR TITLE
Migrate quality of life to a module so QALY/DALY are calculated every year

### DIFF
--- a/src/main/java/org/mitre/synthea/modules/Generator.java
+++ b/src/main/java/org/mitre/synthea/modules/Generator.java
@@ -20,7 +20,6 @@ import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.world.Hospital;
 import org.mitre.synthea.world.Demographics;
 import org.mitre.synthea.world.Location;
-import org.mitre.synthea.helpers.QualityOfLife;
 
 /**
  * Generator creates a population by running the generic modules each timestep per Person.
@@ -160,9 +159,6 @@ public class Generator {
 					
 					time += timestep;
 				}
-				
-				// calculate quality of life
-				QualityOfLife.calculate(person, stop);
 				
 				Exporter.export(person, stop);
 				

--- a/src/main/java/org/mitre/synthea/modules/Module.java
+++ b/src/main/java/org/mitre/synthea/modules/Module.java
@@ -37,6 +37,7 @@ public class Module {
 
 		retVal.put("Lifecycle", new LifecycleModule());
 		retVal.put("Cardiovascular Disease", new CardiovascularDiseaseModule());
+		retVal.put("Quality Of Life", new QualityOfLifeModule());
 
 		try {
 			URL modulesFolder = ClassLoader.getSystemClassLoader().getResource("modules");

--- a/src/test/java/org/mitre/synthea/modules/QualityOfLifeTest.java
+++ b/src/test/java/org/mitre/synthea/modules/QualityOfLifeTest.java
@@ -6,7 +6,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mitre.synthea.helpers.QualityOfLife;
 import org.mitre.synthea.modules.HealthRecord.Code;
 import org.mitre.synthea.modules.HealthRecord.Encounter;
 import org.mitre.synthea.modules.HealthRecord.Entry;
@@ -62,10 +61,10 @@ public class QualityOfLifeTest {
 	public void testCalculateLiving(){
 		// living patient
 		// + 1 ms because (365.25 * 35) = 12783.75 as double and 12783 as long
-		QualityOfLife.calculate(person, TimeUnit.DAYS.toMillis(stopTime));
+		double[] qol = QualityOfLifeModule.calculate(person, TimeUnit.DAYS.toMillis(stopTime));
 		
-		double daly_living = (double) person.attributes.get("DALY");
-		double qaly_living = (double) person.attributes.get("QALY");
+		double daly_living = qol[0];
+		double qaly_living = qol[1];
 		assertEquals(true, (daly_living > 1.7 && daly_living < 1.8));
 		assertEquals(true, (qaly_living > 33 && qaly_living < 34));
 	}
@@ -74,10 +73,10 @@ public class QualityOfLifeTest {
 	public void testCalculateDeceased(){
 		// deceased patient
 		person.events.create(TimeUnit.DAYS.toMillis((long) (365.25 * 35)), "death", "QualityOfLifeTest", true);
-		QualityOfLife.calculate(person, TimeUnit.DAYS.toMillis(stopTime));
+		double[] qol = QualityOfLifeModule.calculate(person, TimeUnit.DAYS.toMillis(stopTime));
 		
-		double daly_deceased = (double) person.attributes.get("DALY");
-		double qaly_deceased = (double) person.attributes.get("QALY");
+		double daly_deceased = qol[0];
+		double qaly_deceased = qol[1];
 		assertEquals(true, (daly_deceased > 54 && daly_deceased < 55));
 		assertEquals(true, (qaly_deceased > 33 && qaly_deceased < 34));
 	}
@@ -92,18 +91,18 @@ public class QualityOfLifeTest {
 		}
 		
 		// conditions in year 5
-		List<Entry> conditionsYear5 = QualityOfLife.conditionsInYear(allConditions, TimeUnit.DAYS.toMillis((long) (365.25 * 5)), TimeUnit.DAYS.toMillis((long) (365.25 * 6)));
+		List<Entry> conditionsYear5 = QualityOfLifeModule.conditionsInYear(allConditions, TimeUnit.DAYS.toMillis((long) (365.25 * 5)), TimeUnit.DAYS.toMillis((long) (365.25 * 6)));
 		List<Entry> empty = new ArrayList<Entry>();	
 		assertEquals(empty, conditionsYear5);
 		
 		// conditions in year 10
-		List<Entry> conditionsYear10 = QualityOfLife.conditionsInYear(allConditions, TimeUnit.DAYS.toMillis((long) (365.25 * 10)), TimeUnit.DAYS.toMillis((long) (365.25 * 11)));
+		List<Entry> conditionsYear10 = QualityOfLifeModule.conditionsInYear(allConditions, TimeUnit.DAYS.toMillis((long) (365.25 * 10)), TimeUnit.DAYS.toMillis((long) (365.25 * 11)));
 		assertEquals(2, conditionsYear10.size());
 		assertEquals("Child attention deficit disorder", conditionsYear10.get(0).name);
 		assertEquals("Asthma", conditionsYear10.get(1).name);
 		
 		// conditions in year 30
-		List<Entry> conditionsYear30 = QualityOfLife.conditionsInYear(allConditions, TimeUnit.DAYS.toMillis((long) (365.25 * 30)), TimeUnit.DAYS.toMillis((long) (365.25 * 31)));
+		List<Entry> conditionsYear30 = QualityOfLifeModule.conditionsInYear(allConditions, TimeUnit.DAYS.toMillis((long) (365.25 * 30)), TimeUnit.DAYS.toMillis((long) (365.25 * 31)));
 		assertEquals(1, conditionsYear30.size());
 		assertEquals("Diabetes", conditionsYear30.get(0).name);
 	}
@@ -111,7 +110,7 @@ public class QualityOfLifeTest {
 	@Test
 	public void testWeight(){
 		// age 15 with disability weight of 0.45
-		double weight = QualityOfLife.weight(0.45,  15);
+		double weight = QualityOfLifeModule.weight(0.45,  15);
 		assertEquals(true, (weight > 0.614 && weight < 0.615));
 	}
 	


### PR DESCRIPTION
Migrates the Quality of Life calculations (QALY/DALY) to a module so that a person's QALY and DALY are calculated every year. This works by storing the QALY/DALY history in an array, where the array index is their age. When the patient is exported, only the most recent QALY/DALY is written to the FHIR record. (Same as today)

This will be necessary to track QALY/DALY values of a population over time