### PR TITLE
Replace 2 instances of String.format with implicit stringbuilder for performance

### DIFF
--- a/src/main/java/org/mitre/synthea/modules/Module.java
+++ b/src/main/java/org/mitre/synthea/modules/Module.java
@@ -155,7 +155,7 @@ public class Module {
 			person.attributes.put(this.name, person.history);
 		}
 		person.history = (ArrayList<State>) person.attributes.get(this.name);
-		String activeKey = String.format("%s %s", EncounterModule.ACTIVE_WELLNESS_ENCOUNTER, this.name);
+		String activeKey = EncounterModule.ACTIVE_WELLNESS_ENCOUNTER + " " + this.name;
 		if(person.attributes.containsKey(EncounterModule.ACTIVE_WELLNESS_ENCOUNTER)) {
 			person.attributes.put(activeKey, true);
 		}

--- a/src/main/java/org/mitre/synthea/modules/State.java
+++ b/src/main/java/org/mitre/synthea/modules/State.java
@@ -194,7 +194,7 @@ public class State {
 		case ENCOUNTER:
 			if(definition.has("wellness") && definition.get("wellness").getAsBoolean()) {
 				Encounter encounter = person.record.currentEncounter(time);
-				String activeKey = String.format("%s %s", EncounterModule.ACTIVE_WELLNESS_ENCOUNTER, this.module);
+				String activeKey = EncounterModule.ACTIVE_WELLNESS_ENCOUNTER + " " + this.module;
 				if(person.attributes.containsKey(activeKey)) {
 					person.attributes.remove(activeKey);
 					


### PR DESCRIPTION
String.format is slower than using StringBuilder to concatenate strings (some sources say 100x slower). Not a big deal on things we don't call often, but I profiled the code and the String.format call in Module.process accounted for nearly 20% of app runtime. There are probably a lot of additional performance improvements, but this one is basically free.