### PR TITLE
Set CHW preventive services

### DIFF
--- a/src/main/java/App.java
+++ b/src/main/java/App.java
@@ -25,7 +25,6 @@ public class App {
 			}
 			System.out.format("Number of CHW Interventions: %d\n", person.attributes.get(Person.CHW_INTERVENTION));
 		}
-
 		System.out.format("Number of Towns: %d\n", CommunityHealthWorker.workers.size());
 		System.out.format("Number of CHWs: %d\n", CommunityHealthWorker.budget / CommunityHealthWorker.cost);
 //		for(String city : CommunityHealthWorker.workers.keySet()) {

--- a/src/main/java/App.java
+++ b/src/main/java/App.java
@@ -27,8 +27,5 @@ public class App {
 		}
 		System.out.format("Number of Towns: %d\n", CommunityHealthWorker.workers.size());
 		System.out.format("Number of CHWs: %d\n", CommunityHealthWorker.budget / CommunityHealthWorker.cost);
-//		for(String city : CommunityHealthWorker.workers.keySet()) {
-//			System.out.format("Number of CHWs in %s: %d\n", city, CommunityHealthWorker.workers.get(city).size());
-//		}
 	}
 }

--- a/src/main/java/org/mitre/synthea/modules/CommunityHealthWorker.java
+++ b/src/main/java/org/mitre/synthea/modules/CommunityHealthWorker.java
@@ -29,9 +29,6 @@ public class CommunityHealthWorker {
 	public static final String VITAMIN_D_INJURY_SCREENING = "Fall prevention in older adults: Vitamin D";
 	public static final String DIET_PHYSICAL_ACTIVITY = "Diet and physical activity counseling";
 	public static final String STATIN_Medication = "Statin preventive medication";	
-	
-	// TODO social support variable, to be measured/implemented later on
-	//public static final String ORGANIZE = "Organize"; 
 
 	public static final String CITY = "city";
 	public static final String DEPLOYMENT = "deployment";
@@ -104,7 +101,6 @@ public class CommunityHealthWorker {
 		chw.services.put(CommunityHealthWorker.EXERCISE_PT_INJURY_SCREENING, Boolean.parseBoolean(Config.get("chw.exercise_pt_injury_screening")));
 		chw.services.put(CommunityHealthWorker.LUNG_CANCER_SCREENING, Boolean.parseBoolean(Config.get("chw.lung_cancer_screening")));
 		chw.services.put(CommunityHealthWorker.OBESITY_SCREENING, Boolean.parseBoolean(Config.get("chw.obesity_screening")));
-		//chw.services.put(CommunityHealthWorker.ORGANIZE, true);
 		chw.services.put(CommunityHealthWorker.OSTEOPOROSIS_SCREENING, Boolean.parseBoolean(Config.get("chw.osteoporosis_screening")));
 		chw.services.put(CommunityHealthWorker.PREECLAMPSIA_ASPIRIN, Boolean.parseBoolean(Config.get("chw.preeclampsia_aspirin")));
 		chw.services.put(CommunityHealthWorker.PREECLAMPSIA_SCREENING, Boolean.parseBoolean(Config.get("chw.preeclampsia_screening")));

--- a/src/main/java/org/mitre/synthea/modules/CommunityHealthWorker.java
+++ b/src/main/java/org/mitre/synthea/modules/CommunityHealthWorker.java
@@ -31,7 +31,7 @@ public class CommunityHealthWorker {
 	public static final String STATIN_Medication = "Statin preventive medication";	
 	
 	// TODO social support variable, to be measured/implemented later on
-	public static final String ORGANIZE = "Organize"; 
+	//public static final String ORGANIZE = "Organize"; 
 
 	public static final String CITY = "city";
 	public static final String DEPLOYMENT = "deployment";
@@ -49,7 +49,6 @@ public class CommunityHealthWorker {
 	
 	public Map<String,Object> services;
 	
-	//TODO possible arguments, randomization/computation of services later on
 	public CommunityHealthWorker(){ 
 		services = new ConcurrentHashMap<String,Object>();
 	}
@@ -96,27 +95,26 @@ public class CommunityHealthWorker {
 		
 		CommunityHealthWorker chw = new CommunityHealthWorker();
 		
-		chw.services.put(CommunityHealthWorker.ALCOHOL_SCREENING, true);
-		chw.services.put(CommunityHealthWorker.ASPIRIN_MEDICATION, true);
-		chw.services.put(CommunityHealthWorker.BLOOD_PRESSURE_SCREENING, true);
-		chw.services.put(CommunityHealthWorker.COLORECTAL_CANCER_SCREENING, true);
-		chw.services.put(CommunityHealthWorker.DIABETES_SCREENING, true);
-		chw.services.put(CommunityHealthWorker.DIET_PHYSICAL_ACTIVITY, true);
-		chw.services.put(CommunityHealthWorker.EXERCISE_PT_INJURY_SCREENING, true);
-		chw.services.put(CommunityHealthWorker.LUNG_CANCER_SCREENING, true);
-		chw.services.put(CommunityHealthWorker.OBESITY_SCREENING, true);
-		chw.services.put(CommunityHealthWorker.ORGANIZE, true);
-		chw.services.put(CommunityHealthWorker.OSTEOPOROSIS_SCREENING, true);
-		chw.services.put(CommunityHealthWorker.PREECLAMPSIA_ASPIRIN, true);
-		chw.services.put(CommunityHealthWorker.PREECLAMPSIA_SCREENING, true);
+		chw.services.put(CommunityHealthWorker.ALCOHOL_SCREENING, Boolean.parseBoolean(Config.get("chw.alcohol_screening")));
+		chw.services.put(CommunityHealthWorker.ASPIRIN_MEDICATION, Boolean.parseBoolean(Config.get("chw.aspirin_medication")));
+		chw.services.put(CommunityHealthWorker.BLOOD_PRESSURE_SCREENING, Boolean.parseBoolean(Config.get("chw.blood_pressure_screening")));
+		chw.services.put(CommunityHealthWorker.COLORECTAL_CANCER_SCREENING, Boolean.parseBoolean(Config.get("chw.colorectal_cancer_screening")));
+		chw.services.put(CommunityHealthWorker.DIABETES_SCREENING, Boolean.parseBoolean(Config.get("chw.diabetes_screening")));
+		chw.services.put(CommunityHealthWorker.DIET_PHYSICAL_ACTIVITY, Boolean.parseBoolean(Config.get("chw.diet_physical_activity")));
+		chw.services.put(CommunityHealthWorker.EXERCISE_PT_INJURY_SCREENING, Boolean.parseBoolean(Config.get("chw.exercise_pt_injury_screening")));
+		chw.services.put(CommunityHealthWorker.LUNG_CANCER_SCREENING, Boolean.parseBoolean(Config.get("chw.lung_cancer_screening")));
+		chw.services.put(CommunityHealthWorker.OBESITY_SCREENING, Boolean.parseBoolean(Config.get("chw.obesity_screening")));
+		//chw.services.put(CommunityHealthWorker.ORGANIZE, true);
+		chw.services.put(CommunityHealthWorker.OSTEOPOROSIS_SCREENING, Boolean.parseBoolean(Config.get("chw.osteoporosis_screening")));
+		chw.services.put(CommunityHealthWorker.PREECLAMPSIA_ASPIRIN, Boolean.parseBoolean(Config.get("chw.preeclampsia_aspirin")));
+		chw.services.put(CommunityHealthWorker.PREECLAMPSIA_SCREENING, Boolean.parseBoolean(Config.get("chw.preeclampsia_screening")));
 			
-		chw.services.put(CommunityHealthWorker.STATIN_Medication, true);
-		chw.services.put(CommunityHealthWorker.TOBACCO_SCREENING, true);
-		chw.services.put(CommunityHealthWorker.VITAMIN_D_INJURY_SCREENING, true);
+		chw.services.put(CommunityHealthWorker.STATIN_Medication, Boolean.parseBoolean(Config.get("chw.statin_medication")));
+		chw.services.put(CommunityHealthWorker.TOBACCO_SCREENING, Boolean.parseBoolean(Config.get("chw.tobacco_screening")));
+		chw.services.put(CommunityHealthWorker.VITAMIN_D_INJURY_SCREENING, Boolean.parseBoolean(Config.get("chw.vitamin_d_injury_screening")));
 		Location.assignCity(chw);
 		
 		chw.services.put(DEPLOYMENT, deploymentType);
-
 		return chw;
 	}
 

--- a/src/main/java/org/mitre/synthea/modules/Immunizations.java
+++ b/src/main/java/org/mitre/synthea/modules/Immunizations.java
@@ -115,6 +115,9 @@ public class Immunizations
 			double recommendedAge = (double) at_months.get(0);
 			if(ageAtDate >= recommendedAge && ((ageAtDate - recommendedAge) < 48)) {
 				at_months.remove(0);
+				if(at_months.isEmpty()) {
+					return false;
+				}
 			}
 		}
 

--- a/src/main/java/org/mitre/synthea/modules/Person.java
+++ b/src/main/java/org/mitre/synthea/modules/Person.java
@@ -196,7 +196,7 @@ public class Person {
 			int chw_interventions = (int) person.attributes.getOrDefault(Person.CHW_INTERVENTION, 0);
 			chw_interventions++;
 			person.attributes.put(Person.CHW_INTERVENTION, chw_interventions);
-			if((boolean) person.attributes.getOrDefault(Person.SMOKER, false)) {
+			if((boolean) person.attributes.getOrDefault(Person.SMOKER, false) && (boolean) chw.services.getOrDefault(CommunityHealthWorker.TOBACCO_SCREENING, false)) {
 				double quit_smoking_chw_delta = Double.parseDouble( Config.get("lifecycle.quit_smoking.chw_delta", "0.3"));
 				double smoking_duration_factor_per_year = Double.parseDouble( Config.get("lifecycle.quit_smoking.smoking_duration_factor_per_year", "1.0"));
 				double probability = (double) person.attributes.get(LifecycleModule.QUIT_SMOKING_PROBABILITY);
@@ -205,7 +205,7 @@ public class Person {
 				person.attributes.put(LifecycleModule.QUIT_SMOKING_PROBABILITY, probability);
 			}
 			
-			if((boolean) person.attributes.getOrDefault(Person.ALCOHOLIC, false)) {
+			if((boolean) person.attributes.getOrDefault(Person.ALCOHOLIC, false) && (boolean) chw.services.getOrDefault(CommunityHealthWorker.ALCOHOL_SCREENING, false)) {
 				double quit_alcoholism_chw_delta = Double.parseDouble( Config.get("lifecycle.quit_alcoholism.chw_delta", "0.3"));
 				double alcoholism_duration_factor_per_year = Double.parseDouble( Config.get("lifecycle.quit_alcoholism.alcoholism_duration_factor_per_year", "1.0"));
 				double probability = (double) person.attributes.get(LifecycleModule.QUIT_ALCOHOLISM_PROBABILITY);

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -99,4 +99,3 @@ chw.preeclampsia_screening = true
 chw.statin_medication = true
 chw.tobacco_screening = true
 chw.vitamin_d_injury_screening = true
-

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -82,3 +82,21 @@ lifecycle.quit_alcoholism.alcoholism_duration_factor_per_year = 1.0
 lifecycle.aherence.baseline = 0.05
 lifecycle.aherence.chw_delta = 0.025
 
+# Services on/off
+
+chw.alcohol_screening = true
+chw.aspirin_medication = true
+chw.blood_pressure_screening = true
+chw.colorectal_cancer_screening = true
+chw.diabetes_screening = true
+chw.diet_physical_activity = true
+chw.exercise_pt_injury_screening = true
+chw.lung_cancer_screening = true
+chw.obesity_screening = true
+chw.osteoporosis_screening = true
+chw.preeclampsia_aspirin = true
+chw.preeclampsia_screening = true
+chw.statin_medication = true
+chw.tobacco_screening = true
+chw.vitamin_d_injury_screening = true
+


### PR DESCRIPTION
The 15 preventive services, as outlined by the USPSTF, can each be provided by community health workers. The goal is for the user to determine which of the services are provided by community health workers. Additionally, conditions for the "quit smoking" and quit alcoholism" methods are added to determine if tobacco screening or alcohol counseling services are provided by the community health worker. 