### PR TITLE
Rework Utilization to be tracked by year

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
 	
     compile group: 'com.github.javafaker', name: 'javafaker', version: '0.13'
 
+    // google guava for some data structures
+    compile 'com.google.guava:guava:23.0'
+
     // Use JUnit test framework
     testCompile 'junit:junit:4.12'
 }

--- a/src/main/java/org/mitre/synthea/modules/CardiovascularDiseaseModule.java
+++ b/src/main/java/org/mitre/synthea/modules/CardiovascularDiseaseModule.java
@@ -748,6 +748,8 @@ public final class CardiovascularDiseaseModule extends Module
 	
 	public static void performEncounter(Person person, long time)
 	{
+		int year = Utilities.getYear(time);
+		
 		// step 1 - diagnosis
 		for (String diagnosis : new String[] {"coronary_heart_disease", "atrial_fibrillation"})
 		{
@@ -784,7 +786,7 @@ public final class CardiovascularDiseaseModule extends Module
 					{
 						provider = person.getAmbulatoryProvider();
 					}
-					provider.incrementPrescriptions();
+					provider.incrementPrescriptions(year);
 				}
 			}
 			
@@ -817,7 +819,7 @@ public final class CardiovascularDiseaseModule extends Module
         				{
         					provider = person.getAmbulatoryProvider();
         				}
-        				provider.incrementProcedures();
+        				provider.incrementProcedures(year);
         			}
         		}
         	}
@@ -833,6 +835,8 @@ public final class CardiovascularDiseaseModule extends Module
 			provider = person.getEmergencyProvider();
 		}
 		
+		int year = Utilities.getYear(time);
+		
 		Entry condition = person.record.conditionStart(time, diagnosis);
 		condition.codes.add(LOOKUP.get(diagnosis));
 
@@ -842,7 +846,7 @@ public final class CardiovascularDiseaseModule extends Module
           medication.codes.add(LOOKUP.get(med));
           // increment number of prescriptions prescribed by respective hospital
     
-          provider.incrementPrescriptions();
+          provider.incrementPrescriptions(year);
           person.record.medicationEnd(time + TimeUnit.MINUTES.toMillis(15), med, "stop_drug");
         }
 
@@ -852,7 +856,7 @@ public final class CardiovascularDiseaseModule extends Module
         	procedure.codes.add(LOOKUP.get(proc));
         	procedure.reasons.add(diagnosis);
           // increment number of procedures performed by respective hospital
-          provider.incrementProcedures();
+          provider.incrementProcedures(year);
         }
 
         for (String cond : HISTORY_CONDITIONS.get(diagnosis))

--- a/src/main/java/org/mitre/synthea/modules/EncounterModule.java
+++ b/src/main/java/org/mitre/synthea/modules/EncounterModule.java
@@ -79,9 +79,10 @@ public final class EncounterModule extends Module {
 	
 	public static void emergencyEncounter(Person person, long time)
 	{
+		
         // find closest service provider with emergency service
         Provider provider = Provider.findClosestService(person, "emergency");
-        provider.incrementEncounters();
+        provider.incrementEncounters("emergency", Utilities.getYear(time));
 
         Encounter encounter = person.record.encounterStart(time, "emergency");
         encounter.codes.add(new Code("SNOMED-CT", "50849002", "Emergency Encounter"));

--- a/src/main/java/org/mitre/synthea/modules/Generator.java
+++ b/src/main/java/org/mitre/synthea/modules/Generator.java
@@ -90,20 +90,7 @@ public class Generator {
 	}
 	
 	public void run()
-	{
-		// insert providers at startup, so just in case we crash midway through the records are consistent
-		// TODO - this looping here is inefficient, do an insert batch or something
-		// TODO - de-dup hospitals if using a file-based database?
-		if (database != null)
-		{
-			database.store( Hospital.getHospitalList() );
-			
-			List<CommunityHealthWorker> chws = CommunityHealthWorker.workers
-					.values().stream().flatMap(List::stream)
-					.collect(Collectors.toList());
-			database.storeCHWs(chws);
-		}
-		
+	{		
 		ExecutorService threadPool = Executors.newFixedThreadPool(8);
 		
 		for(int i=0; i < this.numberOfPeople; i++)
@@ -122,6 +109,18 @@ public class Generator {
 		} catch (InterruptedException e)
 		{
 			e.printStackTrace();
+		}
+		
+		// have to store providers at the end to correctly capture utilization #s
+		// TODO - de-dup hospitals if using a file-based database?
+		if (database != null)
+		{
+			database.store( Hospital.getHospitalList() );
+			
+			List<CommunityHealthWorker> chws = CommunityHealthWorker.workers
+					.values().stream().flatMap(List::stream)
+					.collect(Collectors.toList());
+			database.storeCHWs(chws);
 		}
 		
 		// export hospital information

--- a/src/main/java/org/mitre/synthea/modules/State.java
+++ b/src/main/java/org/mitre/synthea/modules/State.java
@@ -201,7 +201,8 @@ public class State {
 					// find closest provider and increment encounters count
 					Provider provider = Provider.findClosestService(person, "wellness");
 					person.addCurrentProvider(module, provider);
-					provider.incrementEncounters();
+					int year = Utilities.getYear(time);
+					provider.incrementEncounters("wellness", year);
 					encounter.provider = provider;
 			
 					this.exited = time;
@@ -222,7 +223,8 @@ public class State {
 				// find closest provider and increment encounters count
 				Provider provider = Provider.findClosestService(person, encounter_class);
 				person.addCurrentProvider(module, provider);
-				provider.incrementEncounters();
+				int year = Utilities.getYear(time);
+				provider.incrementEncounters(encounter_class, year);
 				encounter.provider = provider;
 				
 				encounter.name = this.name;
@@ -426,7 +428,8 @@ public class State {
 			} else { // no provider associated with encounter or medication order
 				medicationProvider = person.getAmbulatoryProvider();
 			}
-			medicationProvider.incrementPrescriptions();
+			int year = Utilities.getYear(time);
+			medicationProvider.incrementPrescriptions( year );
 			this.exited = time;
 			return true;
 		case MEDICATIONEND:
@@ -544,7 +547,8 @@ public class State {
 			} else { // no provider associated with encounter or procedure
 				provider = person.getAmbulatoryProvider();
 			}
-			provider.incrementProcedures();
+			year = Utilities.getYear(time);
+			provider.incrementProcedures( year );
 
 			this.exited = time;
 			return true;


### PR DESCRIPTION
Updates the Provider-based utilization numbers to be tracked on a yearly basis instead of all in 1 bucket.
Now instead of a Map of Type -> Count, it's a 2D map/Table of (Year,Type) -> Count. Uses the Google Guava library for Table:  https://github.com/google/guava/wiki/NewCollectionTypesExplained#table 

Also expands the keys to track all encounters, as well as encounters grouped by class.


Also reworked the FHIR hospital exporter a little bit - previously it was converting the bundle to a JSON string after every iteration of the loop, now it only converts after all hospitals have been added to the bundle.