### PR TITLE
Report exporter

### DIFF
--- a/src/main/java/org/mitre/synthea/datastore/DataStore.java
+++ b/src/main/java/org/mitre/synthea/datastore/DataStore.java
@@ -22,7 +22,6 @@ import org.mitre.synthea.modules.Person;
 import org.mitre.synthea.world.Provider;
 
 import com.google.common.collect.Table;
-import com.google.gson.internal.LinkedTreeMap;
 
 /**
  * In-memory database, intended to be the primary repository for Synthea data as it runs.

--- a/src/main/java/org/mitre/synthea/export/HospitalExporter.java
+++ b/src/main/java/org/mitre/synthea/export/HospitalExporter.java
@@ -9,6 +9,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.hl7.fhir.dstu3.model.Address;
@@ -25,7 +26,6 @@ import org.mitre.synthea.world.Provider;
 import ca.uhn.fhir.context.FhirContext;
 
 import com.google.common.collect.Table;
-import com.google.gson.internal.LinkedTreeMap;
 
 public abstract class HospitalExporter{
 	
@@ -74,7 +74,7 @@ public abstract class HospitalExporter{
 			.setSystem("https://github.com/synthetichealth/synthea")
 			.setValue((String) h.getResourceID());
 		
-		LinkedTreeMap hAttributes = h.getAttributes();
+		Map<String,Object> hAttributes = h.getAttributes();
 		
 		organizationResource.setName(hAttributes.get("name").toString());
 		

--- a/src/main/java/org/mitre/synthea/export/ReportExporter.java
+++ b/src/main/java/org/mitre/synthea/export/ReportExporter.java
@@ -10,7 +10,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 

--- a/src/main/java/org/mitre/synthea/export/ReportExporter.java
+++ b/src/main/java/org/mitre/synthea/export/ReportExporter.java
@@ -1,0 +1,133 @@
+package org.mitre.synthea.export;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.mitre.synthea.modules.Generator;
+
+import com.google.gson.stream.JsonWriter;
+
+/**
+ * The ReportExporter generates a "report" of the current run of Synthea,
+ * tracking information on heathcare Outcomes, Access, and Costs.
+ * The report is created in JSON so it can be easily parsed by other tools.
+ */
+public class ReportExporter 
+{
+	public static void export(Generator generator) 
+	{
+		if (generator == null || generator.database == null)
+		{
+			return;
+		}
+		
+		try (Connection connection = generator.database.getConnection()) 
+		{	
+			File outDirectory = Exporter.getOutputFolder("statistics", null);
+			String timeStamp = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss").format(new Date());
+			Path outFilePath = outDirectory.toPath().resolve("statistics-"+timeStamp+".json");
+			
+			JsonWriter writer = new JsonWriter(new FileWriter(outFilePath.toFile()));
+			writer.setIndent("  ");
+			writer.beginObject(); // top-level
+			
+			processOutcomes(connection, writer);
+			processAccess(connection, writer);
+			processCosts(connection, writer);
+			
+			writer.endObject(); // top-level	
+			writer.close();
+			
+		} catch (IOException | SQLException e) {
+			e.printStackTrace();
+			throw new RuntimeException("error exporting statistics");
+		}
+	}
+	
+	private static void processOutcomes(Connection connection, JsonWriter writer) throws IOException, SQLException
+	{
+		PreparedStatement stmt = connection.prepareStatement("select year, AVG(qol) average, STDDEV_POP(qol) stddev, COUNT(qol) num from quality_of_life group by year order by year asc");
+		// ASSUMPTION - there should never be a gap in years
+		ResultSet rs = stmt.executeQuery();
+
+		int firstYear = 0;
+		
+		// initial capacity is 80 - think 50 past 30 future?
+		List<Double> averages = new ArrayList<Double>(80); 
+		List<Double> stddevs = new ArrayList<Double>(80);
+		List<Integer> counts = new ArrayList<Integer>(80);
+		
+		while (rs.next())
+		{
+			int year = rs.getInt(1);
+			
+			if (firstYear == 0)
+			{
+				firstYear = year;
+			}
+			
+			double average = rs.getDouble(2);
+			double stddev = rs.getDouble(3);
+			int count = rs.getInt(4);
+			
+			averages.add(average);
+			stddevs.add(stddev);
+			counts.add(count);
+		}
+
+		writer.name("quality_of_life").beginObject();
+		
+		writer.name("first_year").value(firstYear);
+		
+		writer.name("averages").beginArray();
+		for(double avg : averages)
+		{
+			writer.value(avg);
+		}
+		writer.endArray();
+		
+		writer.name("stddevs").beginArray();
+		for(double stdev : stddevs)
+		{
+			writer.value(stdev);
+		}
+		writer.endArray();
+		
+		writer.name("counts").beginArray();
+		for (int c : counts)
+		{
+			writer.value(c);
+		}
+		writer.endArray();
+		
+		writer.endObject(); // quality_of_life
+	}
+	
+	private static void processAccess(Connection connection, JsonWriter writer) throws IOException, SQLException
+	{
+		writer.name("access").beginObject();
+		
+		writer.name("encounters").beginObject();
+				
+		writer.endObject(); // encounters
+		
+		writer.endObject(); // access
+	}
+	
+	private static void processCosts(Connection connection, JsonWriter writer) throws IOException, SQLException
+	{
+		writer.name("costs").beginObject();
+		
+		writer.endObject(); // access	
+	}
+}

--- a/src/main/java/org/mitre/synthea/helpers/Config.java
+++ b/src/main/java/org/mitre/synthea/helpers/Config.java
@@ -6,6 +6,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
+import java.util.Set;
 
 public abstract class Config
 {
@@ -78,5 +79,20 @@ public abstract class Config
   public static void set(String key, String value)
   {
     properties.setProperty(key, value);
+  }
+  
+  /**
+   * Get a set of the names for all properties in the config file.
+   * 
+   * Returns a set of keys in this property list where the key and its corresponding value are strings, 
+   *  including distinct keys in the default property list if a key of the same name has not already been found from the main properties list. 
+   *  Properties whose key or value is not of type String are omitted. 
+   * The returned set is not backed by the Properties object. Changes to this Properties are not reflected in the set, or vice versa.
+   *
+   * @return Set of property key names
+   */
+  public static Set<String> allPropertyNames()
+  {
+	  return properties.stringPropertyNames();
   }
 }

--- a/src/main/java/org/mitre/synthea/modules/CommunityHealthWorker.java
+++ b/src/main/java/org/mitre/synthea/modules/CommunityHealthWorker.java
@@ -5,14 +5,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.world.Location;
+import org.mitre.synthea.world.Provider;
 
 
-public class CommunityHealthWorker {
+public class CommunityHealthWorker extends Provider {
 
 	public static final String LUNG_CANCER_SCREENING = "Lung cancer screening";	
 	public static final String TOBACCO_SCREENING = "Tobacco screening";	
@@ -29,7 +29,7 @@ public class CommunityHealthWorker {
 	public static final String EXERCISE_PT_INJURY_SCREENING = "Fall prevention in older adults: Exercise or physical therapy";
 	public static final String VITAMIN_D_INJURY_SCREENING = "Fall prevention in older adults: Vitamin D";
 	public static final String DIET_PHYSICAL_ACTIVITY = "Diet and physical activity counseling";
-	public static final String STATIN_Medication = "Statin preventive medication";	
+	public static final String STATIN_MEDICATION = "Statin preventive medication";	
 
 	public static final String CITY = "city";
 	public static final String DEPLOYMENT = "deployment";
@@ -45,10 +45,9 @@ public class CommunityHealthWorker {
 
 	public static Map<String,List<CommunityHealthWorker>> workers = generateWorkers();
 	
-	public Map<String,Object> services;
-	
-	public CommunityHealthWorker(){ 
-		services = new ConcurrentHashMap<String,Object>();
+	private CommunityHealthWorker()
+	{
+		// don't allow anyone else to instantiate this
 	}
 	
 	private static Map<String,List<CommunityHealthWorker>> generateWorkers() {
@@ -59,7 +58,7 @@ public class CommunityHealthWorker {
 		for(int i=0; i < Math.round(numWorkers * community); i++)
 		{
 			worker = generateCHW(DEPLOYMENT_COMMUNITY);
-			String city = (String) worker.services.get(CITY);
+			String city = (String) worker.attributes.get(CITY);
 			if(!workers.containsKey(city)) {
 				workers.put(city, new ArrayList<CommunityHealthWorker>());
 			}
@@ -69,7 +68,7 @@ public class CommunityHealthWorker {
 		for(int i=0; i < Math.round(numWorkers * emergency); i++)
 		{
 			worker = generateCHW(DEPLOYMENT_EMERGENCY);
-			String city = (String) worker.services.get(CITY);
+			String city = (String) worker.attributes.get(CITY);
 			if(!workers.containsKey(city)) {
 				workers.put(city, new ArrayList<CommunityHealthWorker>());
 			}
@@ -79,7 +78,7 @@ public class CommunityHealthWorker {
 		for(int i=numWorkersGenerated; i < numWorkers; i++)
 		{
 			worker = generateCHW(DEPLOYMENT_POSTDISCHARGE);
-			String city = (String) worker.services.get(CITY);
+			String city = (String) worker.attributes.get(CITY);
 			if(!workers.containsKey(city)) {
 				workers.put(city, new ArrayList<CommunityHealthWorker>());
 			}
@@ -93,28 +92,30 @@ public class CommunityHealthWorker {
 		
 		CommunityHealthWorker chw = new CommunityHealthWorker();
 		
-		chw.services.put(CommunityHealthWorker.ALCOHOL_SCREENING, Boolean.parseBoolean(Config.get("chw.alcohol_screening")));
-		chw.services.put(CommunityHealthWorker.ASPIRIN_MEDICATION, Boolean.parseBoolean(Config.get("chw.aspirin_medication")));
-		chw.services.put(CommunityHealthWorker.BLOOD_PRESSURE_SCREENING, Boolean.parseBoolean(Config.get("chw.blood_pressure_screening")));
-		chw.services.put(CommunityHealthWorker.COLORECTAL_CANCER_SCREENING, Boolean.parseBoolean(Config.get("chw.colorectal_cancer_screening")));
-		chw.services.put(CommunityHealthWorker.DIABETES_SCREENING, Boolean.parseBoolean(Config.get("chw.diabetes_screening")));
-		chw.services.put(CommunityHealthWorker.DIET_PHYSICAL_ACTIVITY, Boolean.parseBoolean(Config.get("chw.diet_physical_activity")));
-		chw.services.put(CommunityHealthWorker.EXERCISE_PT_INJURY_SCREENING, Boolean.parseBoolean(Config.get("chw.exercise_pt_injury_screening")));
-		chw.services.put(CommunityHealthWorker.LUNG_CANCER_SCREENING, Boolean.parseBoolean(Config.get("chw.lung_cancer_screening")));
-		chw.services.put(CommunityHealthWorker.OBESITY_SCREENING, Boolean.parseBoolean(Config.get("chw.obesity_screening")));
-		chw.services.put(CommunityHealthWorker.OSTEOPOROSIS_SCREENING, Boolean.parseBoolean(Config.get("chw.osteoporosis_screening")));
-		chw.services.put(CommunityHealthWorker.PREECLAMPSIA_ASPIRIN, Boolean.parseBoolean(Config.get("chw.preeclampsia_aspirin")));
-		chw.services.put(CommunityHealthWorker.PREECLAMPSIA_SCREENING, Boolean.parseBoolean(Config.get("chw.preeclampsia_screening")));
+		chw.attributes.put(CommunityHealthWorker.ALCOHOL_SCREENING, Boolean.parseBoolean(Config.get("chw.alcohol_screening")));
+		chw.attributes.put(CommunityHealthWorker.ASPIRIN_MEDICATION, Boolean.parseBoolean(Config.get("chw.aspirin_medication")));
+		chw.attributes.put(CommunityHealthWorker.BLOOD_PRESSURE_SCREENING, Boolean.parseBoolean(Config.get("chw.blood_pressure_screening")));
+		chw.attributes.put(CommunityHealthWorker.COLORECTAL_CANCER_SCREENING, Boolean.parseBoolean(Config.get("chw.colorectal_cancer_screening")));
+		chw.attributes.put(CommunityHealthWorker.DIABETES_SCREENING, Boolean.parseBoolean(Config.get("chw.diabetes_screening")));
+		chw.attributes.put(CommunityHealthWorker.DIET_PHYSICAL_ACTIVITY, Boolean.parseBoolean(Config.get("chw.diet_physical_activity")));
+		chw.attributes.put(CommunityHealthWorker.EXERCISE_PT_INJURY_SCREENING, Boolean.parseBoolean(Config.get("chw.exercise_pt_injury_screening")));
+		chw.attributes.put(CommunityHealthWorker.LUNG_CANCER_SCREENING, Boolean.parseBoolean(Config.get("chw.lung_cancer_screening")));
+		chw.attributes.put(CommunityHealthWorker.OBESITY_SCREENING, Boolean.parseBoolean(Config.get("chw.obesity_screening")));
+		chw.attributes.put(CommunityHealthWorker.OSTEOPOROSIS_SCREENING, Boolean.parseBoolean(Config.get("chw.osteoporosis_screening")));
+		chw.attributes.put(CommunityHealthWorker.PREECLAMPSIA_ASPIRIN, Boolean.parseBoolean(Config.get("chw.preeclampsia_aspirin")));
+		chw.attributes.put(CommunityHealthWorker.PREECLAMPSIA_SCREENING, Boolean.parseBoolean(Config.get("chw.preeclampsia_screening")));
 			
-		chw.services.put(CommunityHealthWorker.STATIN_Medication, Boolean.parseBoolean(Config.get("chw.statin_medication")));
-		chw.services.put(CommunityHealthWorker.TOBACCO_SCREENING, Boolean.parseBoolean(Config.get("chw.tobacco_screening")));
-		chw.services.put(CommunityHealthWorker.VITAMIN_D_INJURY_SCREENING, Boolean.parseBoolean(Config.get("chw.vitamin_d_injury_screening")));
+		chw.attributes.put(CommunityHealthWorker.STATIN_MEDICATION, Boolean.parseBoolean(Config.get("chw.statin_medication")));
+		chw.attributes.put(CommunityHealthWorker.TOBACCO_SCREENING, Boolean.parseBoolean(Config.get("chw.tobacco_screening")));
+		chw.attributes.put(CommunityHealthWorker.VITAMIN_D_INJURY_SCREENING, Boolean.parseBoolean(Config.get("chw.vitamin_d_injury_screening")));
 		Location.assignCity(chw);
 
-		chw.services.put(DEPLOYMENT, deploymentType);
+		chw.attributes.put(DEPLOYMENT, deploymentType);
 
-		//resourceID so that it's the same as Provider. TODO make CHW a subclass of Providers
-		chw.services.put("resourceID", UUID.randomUUID().toString());
+		//resourceID so that it's the same as Provider.
+		chw.attributes.put("resourceID", UUID.randomUUID().toString());
+		
+		chw.attributes.put("name", "CHW providing " + deploymentType + " services in " + chw.attributes.get(CITY));
 
 		return chw;
 	}
@@ -140,30 +141,13 @@ public class CommunityHealthWorker {
 		}
 		if(person.rand() < probability && workers.containsKey(city)) {
 			List<CommunityHealthWorker> candidates = workers.get(city).stream()
-					.filter(p -> p.services.get(DEPLOYMENT).equals(deploymentType))
+					.filter(p -> p.attributes.get(DEPLOYMENT).equals(deploymentType))
 					.collect(Collectors.toList());
 			if(!candidates.isEmpty()) {
 				worker = candidates.get((int)person.rand(0, candidates.size()-1));
 			}
 		}
 		return worker;
-	}
-	
-	public static int getCost() {
-		return CommunityHealthWorker.cost;
-	}	
-	
-	public static void setCost(int cost){
-		CommunityHealthWorker.cost = cost;
-	}
-	
-	public static int getBudget(){
-		return CommunityHealthWorker.budget;
-	}
-	
-	public static void setBudget(int budget){
-		CommunityHealthWorker.budget = budget;
-	}
-		
+	}		
 }
 	

--- a/src/main/java/org/mitre/synthea/modules/Generator.java
+++ b/src/main/java/org/mitre/synthea/modules/Generator.java
@@ -123,12 +123,7 @@ public class Generator {
 			database.storeCHWs(chws);
 		}
 		
-		// export hospital information
-		try{
-			HospitalExporter.export(stop);			
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
+		Exporter.runPostCompletionExports(this);
 		
 		System.out.println(stats);
 	}

--- a/src/main/java/org/mitre/synthea/modules/Generator.java
+++ b/src/main/java/org/mitre/synthea/modules/Generator.java
@@ -17,7 +17,6 @@ import java.util.stream.Collectors;
 
 import org.mitre.synthea.datastore.DataStore;
 import org.mitre.synthea.export.Exporter;
-import org.mitre.synthea.export.HospitalExporter;
 import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.world.Demographics;
 import org.mitre.synthea.world.Hospital;
@@ -86,7 +85,7 @@ public class Generator {
 		// initialize hospitals
 		Hospital.loadHospitals();
 		Module.getModules(); // ensure modules load early
-		CommunityHealthWorker.getCost(); // ensure CHWs are set early
+		CommunityHealthWorker.workers.size(); // ensure CHWs are set early
 	}
 	
 	public void run()
@@ -120,7 +119,7 @@ public class Generator {
 			List<CommunityHealthWorker> chws = CommunityHealthWorker.workers
 					.values().stream().flatMap(List::stream)
 					.collect(Collectors.toList());
-			database.storeCHWs(chws);
+			database.store(chws);
 		}
 		
 		Exporter.runPostCompletionExports(this);

--- a/src/main/java/org/mitre/synthea/modules/Person.java
+++ b/src/main/java/org/mitre/synthea/modules/Person.java
@@ -195,11 +195,13 @@ public class Person implements Serializable
 			enc.codes.add( new Code("SNOMED-CT","389067005","Community health procedure") );
 
 			enc.stop = time + TimeUnit.MINUTES.toMillis(35); // encounter lasts 35 minutes on avg
+			
+			chw.incrementEncounters(deploymentType, Utilities.getYear(time));
 
 			int chw_interventions = (int) person.attributes.getOrDefault(Person.CHW_INTERVENTION, 0);
 			chw_interventions++;
 			person.attributes.put(Person.CHW_INTERVENTION, chw_interventions);
-			if((boolean) person.attributes.getOrDefault(Person.SMOKER, false) && (boolean) chw.services.getOrDefault(CommunityHealthWorker.TOBACCO_SCREENING, false)) {
+			if((boolean) person.attributes.getOrDefault(Person.SMOKER, false) && (boolean) chw.attributes.getOrDefault(CommunityHealthWorker.TOBACCO_SCREENING, false)) {
 				double quit_smoking_chw_delta = Double.parseDouble( Config.get("lifecycle.quit_smoking.chw_delta", "0.3"));
 				double smoking_duration_factor_per_year = Double.parseDouble( Config.get("lifecycle.quit_smoking.smoking_duration_factor_per_year", "1.0"));
 				double probability = (double) person.attributes.get(LifecycleModule.QUIT_SMOKING_PROBABILITY);
@@ -208,7 +210,7 @@ public class Person implements Serializable
 				person.attributes.put(LifecycleModule.QUIT_SMOKING_PROBABILITY, probability);
 			}
 			
-			if((boolean) person.attributes.getOrDefault(Person.ALCOHOLIC, false) && (boolean) chw.services.getOrDefault(CommunityHealthWorker.ALCOHOL_SCREENING, false)) {
+			if((boolean) person.attributes.getOrDefault(Person.ALCOHOLIC, false) && (boolean) chw.attributes.getOrDefault(CommunityHealthWorker.ALCOHOL_SCREENING, false)) {
 				double quit_alcoholism_chw_delta = Double.parseDouble( Config.get("lifecycle.quit_alcoholism.chw_delta", "0.3"));
 				double alcoholism_duration_factor_per_year = Double.parseDouble( Config.get("lifecycle.quit_alcoholism.alcoholism_duration_factor_per_year", "1.0"));
 				double probability = (double) person.attributes.get(LifecycleModule.QUIT_ALCOHOLISM_PROBABILITY);

--- a/src/main/java/org/mitre/synthea/world/Location.java
+++ b/src/main/java/org/mitre/synthea/world/Location.java
@@ -170,6 +170,6 @@ public class Location {
 
 		Random random = new Random();
 		String city = Location.randomCityName(random);
-		chw.services.put(CommunityHealthWorker.CITY, city);
+		chw.attributes.put(CommunityHealthWorker.CITY, city);
 	}
 }

--- a/src/main/java/org/mitre/synthea/world/Provider.java
+++ b/src/main/java/org/mitre/synthea/world/Provider.java
@@ -3,10 +3,7 @@ package org.mitre.synthea.world;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.swing.text.html.parser.Entity;
 
 import org.mitre.synthea.modules.Person;
 
@@ -32,14 +29,22 @@ public class Provider {
 	// Hash of services to Providers that provide them
 	private static HashMap<String, ArrayList<Provider>> services = new HashMap<String, ArrayList<Provider>>();
 	
-	private LinkedTreeMap attributes;
+	public Map<String,Object> attributes;
 	private Point coordinates;
 	private ArrayList<String> services_provided;
 	private Table<Integer, String, AtomicInteger> utilization; // row: year, column: type, value: count
 	
+	protected Provider()
+	{
+		// no-arg constructor provided for subclasses
+		attributes = new LinkedTreeMap<>();
+		utilization = HashBasedTable.create();
+		services_provided = new ArrayList<String>();
+	}
+	
 	public Provider(LinkedTreeMap p) {
-		LinkedTreeMap properties = (LinkedTreeMap) p.get("properties");
-		attributes = properties;
+		this();
+		attributes = (LinkedTreeMap) p.get("properties");
 		String resourceID = (String) p.get("resourceID");
 		attributes.put("resourceID", resourceID);
 
@@ -47,8 +52,7 @@ public class Provider {
 		Point coor = new GeometryFactory().createPoint(new Coordinate(coorList.get(0), coorList.get(1)));
 		coordinates = coor;
 		
-		services_provided = new ArrayList<String>();
-		String[] servicesList = ( (String) properties.get("services_provided") ).split(" ");
+		String[] servicesList = ( (String) attributes.get("services_provided") ).split(" ");
 		for(String s : servicesList){
 			services_provided.add(s);
 			// add provider to hash of services
@@ -61,8 +65,6 @@ public class Provider {
 				services.put(s, l);
 			}
 		}
-		
-		utilization = HashBasedTable.create();
 	}
 	
 	public static void clear(){
@@ -74,7 +76,7 @@ public class Provider {
 		return attributes.get("resourceID").toString();
 	}
 	
-	public LinkedTreeMap getAttributes(){
+	public Map<String,Object> getAttributes(){
 		return attributes;
 	}
 	

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -6,6 +6,7 @@ exporter.subfolders_by_id_substring = false
 
 exporter.fhir.export = true
 exporter.hospital.fhir.export = true
+exporter.cost_access_outcomes_report = true
 
 generate.log_patients.detail = simple
 # options are "none", "simple", or "detailed" (without quotes). defaults to simple if another value is used


### PR DESCRIPTION
Adds a Report exporter, to generate a "report" in JSON format containing info on the previous run of synthea, specifically including access, outcomes, and cost, as well as the config parameters that produced these results. Cost isn't in synthea yet but we have # of encounters for access, and QOL info for outcomes.

Sample report: 
[statistics-2017-09-11_09-25-19.json.txt](https://github.com/synthetichealth/synthea_java/files/1292676/statistics-2017-09-11_09-25-19.json.txt)

This report format will likely be iterated on multiple times before being finalized, but I wanted to get something in the repo asap.

Also, reworks the CommunityHealthWorker class to be a subclass of Provider, making it easier to track utilization.