### PR TITLE
Fix reversed if/else

### DIFF
--- a/src/main/java/org/mitre/synthea/modules/CardiovascularDiseaseModule.java
+++ b/src/main/java/org/mitre/synthea/modules/CardiovascularDiseaseModule.java
@@ -628,12 +628,12 @@ public final class CardiovascularDiseaseModule extends Module
 		
 		if (stroke_points >= ten_year_stroke_risk[genderIndex].length)
 		{
-			ten_stroke_risk = ten_year_stroke_risk[genderIndex][stroke_points];
-		} else
-		{
 			// off the charts
 			int worst_case = ten_year_stroke_risk[genderIndex].length - 1;
 			ten_stroke_risk = ten_year_stroke_risk[genderIndex][worst_case];
+		} else
+		{
+			ten_stroke_risk = ten_year_stroke_risk[genderIndex][stroke_points];
 		}
 		
 		// divide 10 year risk by 365 * 10 to get daily risk.


### PR DESCRIPTION
Fix an if/else where the contents of the blocks were reversed. If a number is greater than or equal to the size of a list/array, it should not be used as an array index. This bug probably also had the effect of making strokes far more likely than usual.