### PR TITLE
Lung cancer intervention

### DIFF
--- a/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
+++ b/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
@@ -62,6 +62,7 @@ public final class LifecycleModule extends Module
 		}
 		Person.chwEncounter(person, time, CommunityHealthWorker.DEPLOYMENT_COMMUNITY);
 		startSmoking(person, time);
+		chanceOfLungCancer(person, time);
 		startAlcoholism(person, time);
 		quitSmoking(person, time);
 		quitAlcoholism(person, time);
@@ -348,6 +349,61 @@ public final class LifecycleModule extends Module
 		return ((year * -0.4865) + 996.41) / 100.0;
 	}
 	
+	private static void chanceOfLungCancer(Person person, long time)
+	{
+		// TODO - make this calculation more elaborate, based on duration smoking,
+		// timestep-dependent, etc
+
+        /*
+           Overall, the chance that a man will develop lung cancer in his lifetime is about 1 in 14; for a woman, the risk is about 1 in 17.
+            http://www.cancer.org/cancer/lungcancer-non-smallcell/detailedguide/non-small-cell-lung-cancer-key-statistics
+           Men who smoke are 23 times more likely to develop lung cancer. Women are 13 times more likely, compared to never smokers.
+            http://www.lung.org/lung-health-and-diseases/lung-disease-lookup/lung-cancer/learn-about-lung-cancer/lung-cancer-fact-sheet.html
+           In a 2006 European study, the risk of developing lung cancer was:
+              0.2 percent for men who never smoked (0.4% for women);
+              5.5 percent of male former smokers (2.6% in women);
+              15.9 percent of current male smokers (9.5% for women);
+              24.4 percent for male "heavy smokers" defined as smoking more than 5 cigarettes per day (18.5 percent for women)
+            https://www.verywell.com/what-percentage-of-smokers-get-lung-cancer-2248868
+        */
+
+		boolean isSmoker = (boolean) person.attributes.getOrDefault(Person.SMOKER, false);
+		boolean quitSmoking = person.attributes.containsKey(QUIT_SMOKING_AGE);
+		boolean isMale = "M".equals( person.attributes.get(Person.GENDER) );
+
+		double probabilityOfLungCancer;
+
+		if(isMale)
+		{
+			// male rates
+			if (isSmoker)
+			{
+				probabilityOfLungCancer = 0.244;
+			} else if (quitSmoking)
+			{
+				probabilityOfLungCancer = 0.055;
+			} else
+			{
+				probabilityOfLungCancer = 0.002;
+			}
+		} else
+		{
+			// female rates
+			if (isSmoker)
+			{
+				probabilityOfLungCancer = 0.185;
+			} else if (quitSmoking)
+			{
+				probabilityOfLungCancer = 0.026;
+			} else
+			{
+				probabilityOfLungCancer = 0.004;
+			}
+		}
+
+		person.attributes.put("probability_of_lung_cancer", probabilityOfLungCancer);
+	}
+
 	private static void startAlcoholism(Person person, long time)
 	{
 		// TODO there are various types of alcoholics with different characteristics

--- a/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
+++ b/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
@@ -60,7 +60,7 @@ public final class LifecycleModule extends Module
 		if( age(person, time) ) {
 			grow(person, time);
 		}
-		Person.chwEncounter(person, time, CommunityHealthWorker.DEPLOYMENT_COMMUNITY);
+		person.chwEncounter(time, CommunityHealthWorker.DEPLOYMENT_COMMUNITY);
 		startSmoking(person, time);
 		chanceOfLungCancer(person, time);
 		startAlcoholism(person, time);

--- a/src/main/java/org/mitre/synthea/modules/Person.java
+++ b/src/main/java/org/mitre/synthea/modules/Person.java
@@ -222,6 +222,11 @@ public class Person implements Serializable
 				person.attributes.put(LifecycleModule.QUIT_ALCOHOLISM_PROBABILITY, probability);
 			}
 			
+			if((boolean) person.attributes.getOrDefault("lung_cancer", false) && (boolean) chw.services.getOrDefault(CommunityHealthWorker.LUNG_CANCER_SCREENING, false))
+			{
+				person.attributes.put("probability_of_lung_cancer_treatment", 1.0); // screening caught lung cancer, send them to treatment
+			}
+
 			double adherence_chw_delta = Double.parseDouble( Config.get("lifecycle.aherence.chw_delta", "0.3"));
 			double probability = (double) person.attributes.get(LifecycleModule.ADHERENCE_PROBABILITY);
 			probability += (adherence_chw_delta);

--- a/src/main/java/org/mitre/synthea/modules/Person.java
+++ b/src/main/java/org/mitre/synthea/modules/Person.java
@@ -9,9 +9,7 @@ import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
-import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.modules.HealthRecord.Code;
-import org.mitre.synthea.modules.HealthRecord.Encounter;
 import org.mitre.synthea.world.Hospital;
 import org.mitre.synthea.world.Provider;
 
@@ -186,51 +184,12 @@ public class Person implements Serializable
 		return false;
 	}
 	
-	public static void chwEncounter(Person person, long time, String deploymentType){
-		CommunityHealthWorker chw = CommunityHealthWorker.findNearbyCHW(person, time, deploymentType);
-		if(chw != null) {
-
-			// encounter class doesn't fit into the FHIR-prescribed set
-			// so we use our own "community" encounter class
-			Encounter enc = person.record.encounterStart(time, "community");
-			enc.chw = chw;
-			// TODO - different codes based on different services offered?
-			enc.codes.add( new Code("SNOMED-CT","389067005","Community health procedure") );
-
-			enc.stop = time + TimeUnit.MINUTES.toMillis(35); // encounter lasts 35 minutes on avg
-			
-			chw.incrementEncounters(deploymentType, Utilities.getYear(time));
-
-			int chw_interventions = (int) person.attributes.getOrDefault(Person.CHW_INTERVENTION, 0);
-			chw_interventions++;
-			person.attributes.put(Person.CHW_INTERVENTION, chw_interventions);
-			if((boolean) person.attributes.getOrDefault(Person.SMOKER, false) && (boolean) chw.attributes.getOrDefault(CommunityHealthWorker.TOBACCO_SCREENING, false)) {
-				double quit_smoking_chw_delta = Double.parseDouble( Config.get("lifecycle.quit_smoking.chw_delta", "0.3"));
-				double smoking_duration_factor_per_year = Double.parseDouble( Config.get("lifecycle.quit_smoking.smoking_duration_factor_per_year", "1.0"));
-				double probability = (double) person.attributes.get(LifecycleModule.QUIT_SMOKING_PROBABILITY);
-				int numberOfYearsSmoking = (int) person.ageInYears(time) - 15;
-				probability += (quit_smoking_chw_delta / (smoking_duration_factor_per_year * numberOfYearsSmoking));
-				person.attributes.put(LifecycleModule.QUIT_SMOKING_PROBABILITY, probability);
-			}
-			
-			if((boolean) person.attributes.getOrDefault(Person.ALCOHOLIC, false) && (boolean) chw.attributes.getOrDefault(CommunityHealthWorker.ALCOHOL_SCREENING, false)) {
-				double quit_alcoholism_chw_delta = Double.parseDouble( Config.get("lifecycle.quit_alcoholism.chw_delta", "0.3"));
-				double alcoholism_duration_factor_per_year = Double.parseDouble( Config.get("lifecycle.quit_alcoholism.alcoholism_duration_factor_per_year", "1.0"));
-				double probability = (double) person.attributes.get(LifecycleModule.QUIT_ALCOHOLISM_PROBABILITY);
-				int numberOfYearsAlcoholic = (int) person.ageInYears(time) - 25;
-				probability += (quit_alcoholism_chw_delta / (alcoholism_duration_factor_per_year * numberOfYearsAlcoholic));
-				person.attributes.put(LifecycleModule.QUIT_ALCOHOLISM_PROBABILITY, probability);
-			}
-			
-			if((boolean) person.attributes.getOrDefault("lung_cancer", false) && (boolean) chw.attributes.getOrDefault(CommunityHealthWorker.LUNG_CANCER_SCREENING, false))
-			{
-				person.attributes.put("probability_of_lung_cancer_treatment", 1.0); // screening caught lung cancer, send them to treatment
-			}
-
-			double adherence_chw_delta = Double.parseDouble( Config.get("lifecycle.aherence.chw_delta", "0.3"));
-			double probability = (double) person.attributes.get(LifecycleModule.ADHERENCE_PROBABILITY);
-			probability += (adherence_chw_delta);
-			person.attributes.put(LifecycleModule.ADHERENCE_PROBABILITY, probability);
+	public void chwEncounter(long time, String deploymentType)
+	{
+		CommunityHealthWorker chw = CommunityHealthWorker.findNearbyCHW(this, time, deploymentType);
+		if(chw != null)
+		{
+			chw.performEncounter(this, time, deploymentType);
 		}
 	}
 	

--- a/src/main/java/org/mitre/synthea/modules/Person.java
+++ b/src/main/java/org/mitre/synthea/modules/Person.java
@@ -222,7 +222,7 @@ public class Person implements Serializable
 				person.attributes.put(LifecycleModule.QUIT_ALCOHOLISM_PROBABILITY, probability);
 			}
 			
-			if((boolean) person.attributes.getOrDefault("lung_cancer", false) && (boolean) chw.services.getOrDefault(CommunityHealthWorker.LUNG_CANCER_SCREENING, false))
+			if((boolean) person.attributes.getOrDefault("lung_cancer", false) && (boolean) chw.attributes.getOrDefault(CommunityHealthWorker.LUNG_CANCER_SCREENING, false))
 			{
 				person.attributes.put("probability_of_lung_cancer_treatment", 1.0); // screening caught lung cancer, send them to treatment
 			}

--- a/src/main/java/org/mitre/synthea/modules/State.java
+++ b/src/main/java/org/mitre/synthea/modules/State.java
@@ -217,7 +217,7 @@ public class State {
 
 				if(encounter_class.equals("emergency")) {
 					// if emergency room encounter and CHW policy is enabled for emergency rooms, add CHW interventions
-					Person.chwEncounter(person, time, CommunityHealthWorker.DEPLOYMENT_EMERGENCY);
+					person.chwEncounter(time, CommunityHealthWorker.DEPLOYMENT_EMERGENCY);
 				}
 
 				// find closest provider and increment encounters count
@@ -252,7 +252,7 @@ public class State {
 			if(encounter.type != EncounterType.WELLNESS.toString()) {
 				encounter.stop = time;
 				// if CHW policy is enabled for discharge follow up, add CHW interventions for all non-wellness encounters
-				Person.chwEncounter(person, time, CommunityHealthWorker.DEPLOYMENT_POSTDISCHARGE);
+				person.chwEncounter(time, CommunityHealthWorker.DEPLOYMENT_POSTDISCHARGE);
 			}
 			if(definition.has("discharge_disposition")) {
 				Code code = new Code((JsonObject) definition.get("discharge_disposition"));

--- a/src/main/resources/modules/lung_cancer.json
+++ b/src/main/resources/modules/lung_cancer.json
@@ -32,114 +32,14 @@
 
     "Lung Cancer Probabilities": {
       "type": "Simple",
-      "complex_transition": [
+      "distributed_transition": [
         {
-          "condition": {
-            "condition_type": "And",
-            "conditions": [
-              {
-                "condition_type": "Gender",
-                "gender": "M"
-              },
-              {
-                "condition_type": "Attribute",
-                "attribute": "smoker",
-                "operator": "==",
-                "value": false
-              }
-            ]
-          },
-          "distributions": [
-            {
-              "distribution": 0.002,
-              "transition": "Cough"
-            },
-            {
-              "distribution": 0.998,
-              "transition": "Terminal"
-            }
-          ]
+          "distribution": { "attribute" : "probability_of_lung_cancer", "default" : 0.0645 },
+          "transition": "Onset_Lung_Cancer"
         },
         {
-          "condition": {
-            "condition_type": "And",
-            "conditions": [
-              {
-                "condition_type": "Gender",
-                "gender": "M"
-              },
-              {
-                "condition_type": "Attribute",
-                "attribute": "smoker",
-                "operator": "==",
-                "value": true
-              }
-            ]
-          },
-          "distributions": [
-            {
-              "distribution": 0.244,
-              "transition": "Cough"
-            },
-            {
-              "distribution": 0.766,
-              "transition": "Terminal"
-            }
-          ]
-        },
-        {
-          "condition": {
-            "condition_type": "And",
-            "conditions": [
-              {
-                "condition_type": "Gender",
-                "gender": "F"
-              },
-              {
-                "condition_type": "Attribute",
-                "attribute": "smoker",
-                "operator": "==",
-                "value": false
-              }
-            ]
-          },
-          "distributions": [
-            {
-              "distribution": 0.004,
-              "transition": "Cough"
-            },
-            {
-              "distribution": 0.996,
-              "transition": "Terminal"
-            }
-          ]
-        },
-        {
-          "condition": {
-            "condition_type": "And",
-            "conditions": [
-              {
-                "condition_type": "Gender",
-                "gender": "F"
-              },
-              {
-                "condition_type": "Attribute",
-                "attribute": "smoker",
-                "operator": "==",
-                "value": true
-              }
-            ]
-          },
-          "distributions": [
-            {
-              "distribution": 0.185,
-              "transition": "Cough"
-            },
-            {
-              "distribution": 0.815,
-              "transition": "Terminal"
-            }
-          ]
+          "distribution": { "attribute" : "probability_of_no_lung_cancer", "default" : 0.93355 },
+          "transition": "Terminal"
         }
       ],
       "remarks": [
@@ -150,6 +50,42 @@
         "In a 2006 European study, the risk of developing lung cancer was: 0.2 percent for men who never smoked (0.4% for women); 5.5 percent of male former smokers (2.6% in women); 15.9 percent of current male smokers (9.5% for women); 24.4 percent for male “heavy smokers” defined as smoking more than 5 cigarettes per day (18.5 percent for women)",
         "https://www.verywell.com/what-percentage-of-smokers-get-lung-cancer-2248868"
       ]
+    },
+    
+    "Onset_Lung_Cancer" : {
+      "type" : "SetAttribute",
+      "attribute" : "lung_cancer",
+      "value" : true,
+      "direct_transition" : "Init_Lung_Cancer_Counter"
+    },
+    
+    "Init_Lung_Cancer_Counter" : {
+      "type" : "SetAttribute",
+      "attribute" : "lung_cancer_nondiagnosis_counter",
+      "value" : 0,
+      "direct_transition" : "Undiagnosed_Lung_Cancer"
+    },
+    
+    "Undiagnosed_Lung_Cancer" : {
+      "type" : "Delay",
+      "exact" : { "quantity" : 1, "unit" : "months" },
+      "distributed_transition" : [
+         {
+          "distribution": { "attribute" : "probability_of_lung_cancer_treatment", "default" : 0.2 },
+          "transition": "Cough"
+        },
+        {
+          "distribution": { "attribute" : "probability_of_no_lung_cancer_treatment", "default" : 0.8 },
+          "transition": "Increment_Counter"
+        }
+      ]
+    },
+    
+    "Increment_Counter" : {
+      "type" : "Counter",
+      "action" : "increment",
+      "attribute" : "lung_cancer_nondiagnosis_counter",
+      "direct_transition" : "Undiagnosed_Lung_Cancer"
     },
 
     "Cough": {
@@ -434,61 +370,44 @@
         "http://seer.cancer.gov/csr/1975_2013/browse_csr.php?sectionSEL=15&pageSEL=sect_15_table.14.html",
         "http://seer.cancer.gov/csr/1975_2013/browse_csr.php?sectionSEL=15&pageSEL=sect_15_table.13.html",
         "only 15 percent of lung cancer cases are diagnosed at an early stage.",
-        "http://www.lung.org/lung-health-and-diseases/lung-disease-lookup/lung-cancer/learn-about-lung-cancer/lung-cancer-fact-sheet.html"
+        "http://www.lung.org/lung-health-and-diseases/lung-disease-lookup/lung-cancer/learn-about-lung-cancer/lung-cancer-fact-sheet.html",
+    "updated remarks 2017-08-31:",
+    "http://oregon.providence.org/our-services/a/ask-a-providence-expert/forms-and-information/ask-an-expert-lung-cancer-growth-and-spread/",
+    "It takes at least 30 divisions of one cancer cell to create a tumor that is 1 centimeter in size (about half an inch).",
+    "That is the smallest size likely to be seen on an X-ray. It takes about three to six months for most lung cancers to double their size. ",
+    "Therefore, it could take several years for a typical lung cancer to reach a size at which it could be diagnosed on a chest X-ray. "
       ],
-      "complex_transition": [
+    "conditional_transition" : [
         {
           "condition": {
             "condition_type": "Attribute",
-            "attribute": "Lung Cancer Type",
-            "operator": "==",
-            "value": "NSCLC"
+            "attribute" : "lung_cancer_nondiagnosis_counter",
+            "operator": "<=",
+            "value": 36
           },
-          "distributions": [
-            {
-              "distribution": 0.19,
-              "transition": "Stage I"
-            },
-            {
-              "distribution": 0.12,
-              "transition": "Stage II"
-            },
-            {
-              "distribution": 0.12,
-              "transition": "Stage III"
-            },
-            {
-              "distribution": 0.55,
-              "transition": "Stage IV"
-            }
-          ]
+        "transition" : "Stage I"
+      },
+      {
+        "condition": {
+          "condition_type": "Attribute",
+          "attribute" : "lung_cancer_nondiagnosis_counter",
+          "operator": "<=",
+          "value": 72
         },
-        {
-          "condition": {
-            "condition_type": "Attribute",
-            "attribute": "Lung Cancer Type",
-            "operator": "==",
-            "value": "SCLC"
-          },
-          "distributions": [
-            {
-              "distribution": 0.04,
-              "transition": "Stage I"
-            },
-            {
-              "distribution": 0.1,
-              "transition": "Stage II"
-            },
-            {
-              "distribution": 0.1,
-              "transition": "Stage III"
-            },
-            {
-              "distribution": 0.74,
-              "transition": "Stage IV"
-            }
-          ]
-        }
+        "transition" : "Stage II"
+      },
+      {
+        "condition": {
+          "condition_type": "Attribute",
+          "attribute" : "lung_cancer_nondiagnosis_counter",
+          "operator": "<=",
+          "value": 108
+        },
+        "transition" : "Stage III"
+      },
+      {
+        "transition" : "Stage IV"
+      }
       ]
     },
 


### PR DESCRIPTION
Updates the Lung Cancer module to take into account lung cancer screening interventions.
CHW encounter performs a Low-dost CT scan if they offer the service and the patient meets the necessary criteria.

The Lung Cancer module is updated so that the screening will affect the stage of cancer the person has when they start treatment. This is accomplished by adding a counter to the start of the module, counting the duration of how long the person has undetected lung cancer. This loop can either be broken out of randomly, or if they get the screening provided by a CHW.

The numbers will likely need to be tweaked but this is a first pass.

Updated module image:
![lung cancer](https://user-images.githubusercontent.com/13512036/30383588-08da2394-9870-11e7-8897-9f9da88163e7.png)
