### PR TITLE
Fix bug causing excessive CVD medications

### DIFF
--- a/src/main/java/org/mitre/synthea/modules/CardiovascularDiseaseModule.java
+++ b/src/main/java/org/mitre/synthea/modules/CardiovascularDiseaseModule.java
@@ -732,7 +732,7 @@ public final class CardiovascularDiseaseModule extends Module
 	
 	private static void stopMedication(String med, Person person, long time)
 	{
-		if (!person.record.medicationActive(med))
+		if (person.record.medicationActive(med))
 		{
 			// add med to med_changes
 			List<String> medChanges = (List<String>)person.attributes.get("cardiovascular_disease_med_changes");


### PR DESCRIPTION
There's a bug in the CardiovascularDiseaseModule where patients are prescribed medications dozens of times. Just a copy&paste issue - the `prescribeMedication` method is supposed to add a medication to a list to be prescribed, if they aren't already taking it, and the `stopMedication` method is supposed to add a medication to a list to be ended, if they **are** already taking it. 