### PR TITLE
Add CHW introduction year config setting

### DIFF
--- a/src/main/java/org/mitre/synthea/modules/CommunityHealthWorker.java
+++ b/src/main/java/org/mitre/synthea/modules/CommunityHealthWorker.java
@@ -47,6 +47,8 @@ public class CommunityHealthWorker extends Provider {
 	public static double emergency = Double.parseDouble(Config.get("generate.chw.emergency", "0.25"));
 	public static double postdischarge = Double.parseDouble(Config.get("generate.chw.postdischarge", "0.25"));
 
+	public static int yearIntroduced = Integer.parseInt(Config.get("generate.chw.year_introduced"));
+	
 	public static Map<String,List<CommunityHealthWorker>> workers = generateWorkers();
 	
 	private CommunityHealthWorker(String deploymentType)
@@ -119,6 +121,14 @@ public class CommunityHealthWorker extends Provider {
 
 	public static CommunityHealthWorker findNearbyCHW(Person person, long time, String deploymentType)
 	{
+		int year = Utilities.getYear(time);
+		
+		if (year < yearIntroduced)
+		{
+			// CHWs not introduced to the system yet
+			return null;
+		}
+
 		CommunityHealthWorker worker = null;
 		String city = (String) person.attributes.get(Person.CITY);
 

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -57,6 +57,9 @@ generate.insurance.mandate.year = 2006
 generate.insurance.mandate.occupation = 0.2
 generate.insurance.private.minimum_income = 24000
 
+generate.chw.year_introduced = 1900
+# no chw interactions can occur prior to this date
+
 #budget & cost information
 generate.chw.budget = 100000
 generate.chw.cost = 10


### PR DESCRIPTION
Add a config setting to change when Community Health Workers are introduced into the system. Default setting is 1900 to mean "CHWs always available"

(branch name should be chw_year_introduced not cvd, whoops)