### PR TITLE
Injuries screenings

### DIFF
--- a/src/main/java/org/mitre/synthea/modules/CommunityHealthWorker.java
+++ b/src/main/java/org/mitre/synthea/modules/CommunityHealthWorker.java
@@ -192,6 +192,10 @@ public class CommunityHealthWorker extends Provider {
 		aspirinMedication(person, time);
 		statinMedication(person, time);
 
+		fallsPreventionExercise(person, time);
+		fallsPreventionVitaminD(person, time);
+		osteoporosisScreening(person, time);
+
 		double adherence_chw_delta = Double.parseDouble( Config.get("lifecycle.aherence.chw_delta", "0.3"));
 		double probability = (double) person.attributes.get(LifecycleModule.ADHERENCE_PROBABILITY);
 		probability += (adherence_chw_delta);
@@ -592,6 +596,39 @@ public class CommunityHealthWorker extends Provider {
 				stroke_points = stroke_points - 2;
 				person.attributes.put("stroke_points", Math.max(0, stroke_points));
 			}
+		}
+	}
+
+	// The USPSTF recommends exercise or physical therapy to prevent falls
+	// in community-dwelling adults age 65 years and older who are at increased risk for falls.
+	private void fallsPreventionExercise(Person person, long time)
+	{
+		if (this.offers(EXERCISE_PT_INJURY_SCREENING))
+		{
+			// CHW interaction will decrease probability of injuries by f(x) % (this adds careplan for exercise)
+		}
+	}
+
+	// The USPSTF recommends vitamin D supplementation to prevent falls
+	// in community-dwelling adults age 65 years and older who are at increased risk for falls.
+	private void fallsPreventionVitaminD(Person person, long time)
+	{
+		if (this.offers(VITAMIN_D_INJURY_SCREENING))
+		{
+			// CHW interaction will decrease probability of injuries by g(x) % (this adds medication for vitamin D)
+		}
+	}
+
+	// The USPSTF recommends screening for osteoporosis in women age 65 years
+	// and older and in younger women whose fracture risk is equal
+	// to or greater than that of a 65-year-old white woman
+	// who has no additional risk factors.
+	private void osteoporosisScreening(Person person, long time)
+	{
+		if (this.offers(OSTEOPOROSIS_SCREENING))
+		{
+			// if(CHW interaction and osteoprosis = true) then increase adherence Fosamax.
+			// Modify injuries module to decrease the probability of injury if osteoporosis and adherence of Fosamax by foo(x) %.
 		}
 	}
 }

--- a/src/main/java/org/mitre/synthea/modules/CommunityHealthWorker.java
+++ b/src/main/java/org/mitre/synthea/modules/CommunityHealthWorker.java
@@ -515,7 +515,7 @@ public class CommunityHealthWorker extends Provider {
         // 6E-5x^3 - 0.0054x^2 - 0.8502x + 86.16
         // R^2 = 0.99978
 		double lifeExpectancy = ((0.00006 * Math.pow(age, 3)) - (0.0054 * Math.pow(age, 2)) - (0.8502 * age) + 86.16);
-		double tenYearStrokeRisk = (double) person.attributes.get("cardio_risk") * 3650;
+		double tenYearStrokeRisk = (double) person.attributes.getOrDefault("cardio_risk", 0.0) * 3650;
 
 		if(this.offers(ASPIRIN_MEDICATION) && age >= 50 && age < 60 && tenYearStrokeRisk >= .1 && lifeExpectancy >= 10){
 			
@@ -559,7 +559,7 @@ public class CommunityHealthWorker extends Provider {
 	private void statinMedication(Person person, long time){
 		int age = person.ageInYears(time);
 		
-		double tenYearStrokeRisk = (double) person.attributes.get("cardio_risk") * 3650;
+		double tenYearStrokeRisk = (double) person.attributes.getOrDefault("cardio_risk", 0.0) * 3650;
 		
 		boolean riskFactors = false;
 		

--- a/src/main/java/org/mitre/synthea/modules/CommunityHealthWorker.java
+++ b/src/main/java/org/mitre/synthea/modules/CommunityHealthWorker.java
@@ -637,9 +637,6 @@ public class CommunityHealthWorker extends Provider {
 				CarePlan exercise = person.record.careplanStart(time, "Physical activity target light exercise");
 				exercise.codes.add(new Code("SNOMED-CT", "408580007", "Physical activity target light exercise"));
 			}
-			
-			
-			// CHW interaction will decrease probability of injuries by f(x) % (this adds careplan for exercise)
 		}
 	}
 
@@ -683,12 +680,8 @@ public class CommunityHealthWorker extends Provider {
 			// note that a lot of this already exists in the injuries & osteoporosis modules
 			// TODO: ideally we would rework all 3 such that this CHW intervention would trigger an osteoporosis workup later
 			// but this is the approach for now
-			
-			// if(CHW interaction and osteoprosis = true) then increase adherence Fosamax.
-			// Modify injuries module to decrease the probability of injury if osteoporosis and adherence of Fosamax by foo(x) %.
-			
+
 			// bone density test
-			
 			Procedure proc = person.record.procedure(time, "Bone density scan (procedure)");
 			proc.codes.add(new Code("SNOMED-CT","312681000","Bone density scan (procedure)"));
 

--- a/src/main/java/org/mitre/synthea/modules/HealthRecord.java
+++ b/src/main/java/org/mitre/synthea/modules/HealthRecord.java
@@ -376,6 +376,11 @@ public class HealthRecord {
 		}
 	}
 	
+	public boolean conditionActive(String type)
+	{
+		return present.containsKey(type) && present.get(type).stop==0L;
+	}
+	
 	public Entry allergyStart(long time, String primaryCode) {
 		if(!present.containsKey(primaryCode)) {
 			Entry allergy = new Entry(time, primaryCode);

--- a/src/main/resources/modules/injuries.json
+++ b/src/main/resources/modules/injuries.json
@@ -278,7 +278,7 @@
               "transition": "Whiplash_Injury"
             },
             {
-              "distribution": 0.06,
+              "distribution": { "attribute" : "probability_of_fall_injury", "default" : 0.06 },
               "remarks": [
                 "Highest probability for elderly with osteoporosis.",
                 "see also http://www.shef.ac.uk/FRAX/charts.aspx",
@@ -338,7 +338,7 @@
               "transition": "Whiplash_Injury"
             },
             {
-              "distribution": 0.035,
+              "distribution": { "attribute" : "probability_of_fall_injury", "default" : 0.035 },
               "remarks": [
                 "Retain high probability for elderly - reduced somewhat here since these are the patients without osteoporosis"
               ],


### PR DESCRIPTION
Adds screenings related to the Injuries model and osteoporosis. Specifically this includes:
- Osteoporosis screening: women 
   - The USPSTF recommends screening for osteoporosis in women age 65 years and older and in younger women whose fracture risk is equal to or greater than that of a 65-year-old white woman who has no additional risk factors. 
 - Falls prevention in older adults: exercise or physical therapy 
   - The USPSTF recommends exercise or physical therapy to prevent falls in community-dwelling adults age 65 years and older who are at increased risk for falls. 
 - Falls prevention in older adults: vitamin D 
   - The USPSTF recommends vitamin D supplementation to prevent falls in community-dwelling adults age 65 years and older who are at increased risk for falls. 

The impacts of these is that fall injuries are reduced in the population > 65 -- see LifecycleModule.calculateFallRisk