### PR TITLE
Change reasons from Strings to Codes

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -563,10 +563,18 @@ public abstract class State implements Cloneable
 				diagnosePastConditions(person, time);
 				
 				if(reason != null) {
-					Object item = person.attributes.get(reason);
-					if(item instanceof Entry) {
-						// technically it shouldn't be anything else
-						encounter.reason = ((Entry) item).codes.get(0);
+					if(person.attributes.containsKey(reason)) {
+						Entry condition = (Entry) person.attributes.get(reason);
+						encounter.reason = condition.codes.get(0);
+					} else if(person.hadPriorState(reason)) {
+						// loop through the present conditions, the condition "name" will match
+						// the name of the ConditionOnset state (aka "reason")
+						for(Entry entry : person.record.present.values()) {
+							if(reason.equals(entry.name)) {
+								encounter.reason = entry.codes.get(0);
+								break;
+							}
+						}
 					}
 				}
 				

--- a/src/main/java/org/mitre/synthea/modules/CardiovascularDiseaseModule.java
+++ b/src/main/java/org/mitre/synthea/modules/CardiovascularDiseaseModule.java
@@ -225,6 +225,10 @@ public final class CardiovascularDiseaseModule extends Module
         LOOKUP.put( "atropine", new Code("RxNorm", "1190795", "Atropine Sulfate 1 MG/ML Injectable Solution")  );
         LOOKUP.put( "alteplase", new Code("RxNorm", "308056", "Alteplase 1 MG/ML Injectable Solution")  );
         
+        // reasons
+        LOOKUP.put( "stop_drug", new Code("SNOMED-CT", "182846007", "Dr stopped drug - medical aim achieved"));
+        LOOKUP.put( "cardiovascular_improved", new Code("SNOMED-CT", "413757005", "Cardiac status is consistent with or improved from preoperative baseline"));
+        
         EMERGENCY_MEDS = new HashMap<>();
         EMERGENCY_MEDS.put("myocardial_infarction", Arrays.asList("nitroglycerin", "atorvastatin", "captopril", "clopidogrel"));
         EMERGENCY_MEDS.put("stroke", Arrays.asList("clopidogrel", "alteplase"));
@@ -778,7 +782,7 @@ public final class CardiovascularDiseaseModule extends Module
 				if (person.record.medicationActive(med))
 				{
 					// This prescription can be stopped...
-		             person.record.medicationEnd(time, med, "cardiovascular_improved");
+		             person.record.medicationEnd(time, med, LOOKUP.get("cardiovascular_improved"));
 				}
 				else
 				{
@@ -816,7 +820,7 @@ public final class CardiovascularDiseaseModule extends Module
         				Procedure procedure = person.record.procedure(time, code.display);
         				procedure.name = "CardiovascularDisease_Encounter";
         				procedure.codes.add(code);
-        				procedure.reasons.add(reason);
+        				procedure.reasons.add(LOOKUP.get(reason));
         				
         				// increment number of procedures by respective hospital
         				Provider provider = person.getCurrentProvider("Cardiovascular Disease Module");
@@ -847,7 +851,7 @@ public final class CardiovascularDiseaseModule extends Module
           // increment number of prescriptions prescribed by respective hospital
     
           provider.incrementPrescriptions(year);
-          person.record.medicationEnd(time + TimeUnit.MINUTES.toMillis(15), med, "stop_drug");
+          person.record.medicationEnd(time + TimeUnit.MINUTES.toMillis(15), med, LOOKUP.get("stop_drug"));
         }
 
         for (String proc : EMERGENCY_PROCEDURES.get(diagnosis))
@@ -855,7 +859,7 @@ public final class CardiovascularDiseaseModule extends Module
         	Procedure procedure = person.record.procedure(time, proc);
         	procedure.name = "CardiovascularDisease_Emergency";
         	procedure.codes.add(LOOKUP.get(proc));
-        	procedure.reasons.add(diagnosis);
+        	procedure.reasons.add(LOOKUP.get(diagnosis));
           // increment number of procedures performed by respective hospital
           provider.incrementProcedures(year);
         }

--- a/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
@@ -117,34 +117,34 @@ public class HealthRecord {
 	}
 	
 	public class Medication extends Entry {
-		public Set<String> reasons;
-		public String stopReason;
+		public List<Code> reasons;
+		public Code stopReason;
 		public JsonObject prescriptionDetails;
 		public Claim claim;
 		public Medication(long time, String type) {
 			super(time, type);
-			this.reasons = new LinkedHashSet<String>();
+			this.reasons = new ArrayList<Code>();
 			this.claim = new Claim(this);
 		}
 	}
 	
 	public class Procedure extends Entry {
-		public Set<String> reasons;
+		public List<Code> reasons;
 		public Procedure(long time, String type) {
 			super(time, type);
-			this.reasons = new LinkedHashSet<String>();
+			this.reasons = new ArrayList<Code>();
 		}
 	}
 
 	public class CarePlan extends Entry {
 		public Set<Code> activities;
-		public Set<String> reasons;
+		public List<Code> reasons;
 		public Set<JsonObject> goals;
-		public String stopReason;
+		public Code stopReason;
 		public CarePlan(long time, String type) {
 			super(time, type);
 			this.activities = new LinkedHashSet<Code>();
-			this.reasons = new LinkedHashSet<String>();
+			this.reasons = new ArrayList<Code>();
 			this.goals = new LinkedHashSet<JsonObject>();
 		}
 	}
@@ -237,7 +237,7 @@ public class HealthRecord {
 		public List<Medication> medications;
 		public List<CarePlan> careplans;
 		public Claim claim; // for now assume 1 claim per encounter
-		public String reason;
+		public Code reason;
 		public Code discharge;
 		public Provider provider;
 		public CommunityHealthWorker chw;
@@ -483,7 +483,7 @@ public class HealthRecord {
 		return medication;
 	}
 	
-	public void medicationEnd(long time, String type, String reason) {
+	public void medicationEnd(long time, String type, Code reason) {
 		if(present.containsKey(type)) {
 			Medication medication = (Medication) present.get(type);
 			medication.stop = time;
@@ -492,7 +492,7 @@ public class HealthRecord {
 		}
 	}
 	
-	public void medicationEndByState(long time, String stateName, String reason) {
+	public void medicationEndByState(long time, String stateName, Code reason) {
 		Medication medication = null;
 		Iterator<Entry> iter = present.values().iterator();
 		while(iter.hasNext()) {
@@ -525,7 +525,7 @@ public class HealthRecord {
 		return careplan;
 	}
 	
-	public void careplanEnd(long time, String type, String reason) {
+	public void careplanEnd(long time, String type, Code reason) {
 		if(present.containsKey(type)) {
 			CarePlan careplan = (CarePlan) present.get(type);
 			careplan.stop = time;
@@ -534,7 +534,7 @@ public class HealthRecord {
 		}
 	}
 	
-	public void careplanEndByState(long time, String stateName, String reason) {
+	public void careplanEndByState(long time, String stateName, Code reason) {
 		CarePlan careplan = null;
 		Iterator<Entry> iter = present.values().iterator();
 		while(iter.hasNext()) {

--- a/src/test/java/org/mitre/synthea/engine/LogicTest.java
+++ b/src/test/java/org/mitre/synthea/engine/LogicTest.java
@@ -279,7 +279,7 @@ public class LogicTest {
 		time += Utilities.convertTime("years", 10);
 
 		person.record.careplanEnd(time, diabetesCode.code,
-				"diabetes well controlled");
+				new HealthRecord.Code("SNOMED-CT","444110003","Type II Diabetes Mellitus Well Controlled"));
 		assertFalse(doTest("diabetesCarePlanTest"));
 
 		HealthRecord.Code anginaCode = new HealthRecord.Code("SNOMED-CT",

--- a/src/test/java/org/mitre/synthea/engine/StateTest.java
+++ b/src/test/java/org/mitre/synthea/engine/StateTest.java
@@ -520,7 +520,8 @@ public class StateTest {
 	    HealthRecord.Encounter enc = person.record.encounters.get(0);
 	    assertEquals(time, enc.start);
 	    assertEquals(0L, enc.stop);
-	    assertEquals("73211009", enc.reason); // diabetes code
+	    assertEquals("73211009", enc.reason.code);
+	    assertEquals("Diabetes Mellitus", enc.reason.display);
 	    
 	    Code code = enc.codes.get(0);
 	    assertEquals("50849002", code.code);


### PR DESCRIPTION
Updates all `reason`s in HealthRecord.Entry classes to be Codes instead of Strings. This means that the relevant information is directly accessible and doesn't have to be looked up in arbitrary places.