### PR TITLE
Zip code & CSV fix

### DIFF
--- a/src/main/java/org/mitre/synthea/export/CSVExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CSVExporter.java
@@ -258,12 +258,20 @@ public class CSVExporter {
         Person.RACE,
         Person.ETHNICITY,
         Person.GENDER,
-        Person.BIRTHPLACE,
-        Person.ADDRESS
+        Person.BIRTHPLACE
     }) {
       String value = (String) person.attributes.getOrDefault(attribute, "");
       s.append(',').append(clean(value));
     }
+    
+    s.append(',');
+    
+    String address = (String) person.attributes.get(Person.ADDRESS) 
+            + " " + (String) person.attributes.get(Person.CITY)
+             + " " + (String) person.attributes.get(Person.STATE)
+              + " " + (String) person.attributes.get(Person.ZIP)
+               + " US";
+    s.append(clean(address));
 
     s.append(NEWLINE);
     write(s.toString(), patients);

--- a/src/test/java/org/mitre/synthea/helpers/TransitionMetricsTest.java
+++ b/src/test/java/org/mitre/synthea/helpers/TransitionMetricsTest.java
@@ -57,7 +57,7 @@ public class TransitionMetricsTest {
     assertEquals(1, m.current.get()); // and is still there
     
     metrics = new TransitionMetrics();
-    for (long seed : new long[] {999L, 0L, 12345L}) {
+    for (long seed : new long[] {16L, 0L, 12345L}) {
       // seeds chosen by experimentation, to ensure we hit "Pre_Examplitis" at least once
       person = new Person(seed); 
       person.attributes.put(Person.GENDER, "M");


### PR DESCRIPTION
Location.getZipCode() now actually returns the zip code for a city, rather than 00000. It uses the patient's source of randomness to pick a random value if there's more than one zip code for a city, so one of the unit tests had to have a seed change to still see the expected results.

Also I noticed the CSV file didn't have full addresses like the Ruby version, it just had street address, so I added the city, state, and zip to patients.csv. Sample attached:
[patients.csv.txt](https://github.com/synthetichealth/synthea_java/files/1482394/patients.csv.txt)
