### PR TITLE
Update cleanOutput task so it doesn't run before every task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,9 @@ task graphviz(type: JavaExec) {
 }
 
 task cleanOutput {
-  delete fileTree(dir: 'output' , include: '**/*')
+  doLast {
+    delete fileTree(dir: 'output' , include: '**/*')
+  }
 }
 
 // Define the main class for the application


### PR DESCRIPTION
The way the `cleanOutput` task is defined it currently runs before every task, ex if you `gradle run` and then `gradle test`, it will delete all the output files from the run.

This change updates the task so it only runs when specifically called, ex `gradle cleanOutput`