### PR TITLE
Add numbers to names

### DIFF
--- a/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
+++ b/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
@@ -37,6 +37,9 @@ public final class LifecycleModule extends Module {
   public static final String QUIT_ALCOHOLISM_AGE = "quit alcoholism age";
   public static final String ADHERENCE_PROBABILITY = "adherence probability";
 
+  private static final boolean appendNumbersToNames =
+      Boolean.parseBoolean(Config.get("generate.append_numbers_to_person_names", "false"));
+
   public LifecycleModule() {
     this.name = "Lifecycle";
   }
@@ -96,12 +99,21 @@ public final class LifecycleModule extends Module {
 
     String firstName = faker.name().firstName();
     String lastName = faker.name().lastName();
+    if (appendNumbersToNames) {
+      // randInt(1000) produces 1-3 digits
+      firstName = firstName + person.randInt(1000);
+      lastName = lastName + person.randInt(1000);
+    }
     attributes.put(Person.FIRST_NAME, firstName);
     attributes.put(Person.LAST_NAME, lastName);
     attributes.put(Person.NAME, firstName + " " + lastName);
 
     String motherFirstName = faker.name().firstName();
     String motherLastName = faker.name().lastName();
+    if (appendNumbersToNames) {
+      motherFirstName = motherFirstName + person.randInt(1000);
+      motherLastName = motherLastName + person.randInt(1000);
+    }
     attributes.put(Person.NAME_MOTHER, motherFirstName + " " + motherLastName);
 
     double prevalenceOfTwins = 
@@ -196,6 +208,9 @@ public final class LifecycleModule extends Module {
               person.attributes.put(Person.MAIDEN_NAME, person.attributes.get(Person.LAST_NAME));
               String firstName = ((String) person.attributes.get(Person.FIRST_NAME));
               String newLastName = faker.name().lastName();
+              if (appendNumbersToNames) {
+                newLastName = newLastName + person.randInt(1000);
+              }
               person.attributes.put(Person.LAST_NAME, newLastName);
               person.attributes.put(Person.NAME, firstName + " " + newLastName);
             }

--- a/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
+++ b/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
@@ -101,8 +101,8 @@ public final class LifecycleModule extends Module {
     String lastName = faker.name().lastName();
     if (appendNumbersToNames) {
       // randInt(1000) produces 1-3 digits
-      firstName = firstName + person.randInt(1000);
-      lastName = lastName + person.randInt(1000);
+      firstName = addHash(firstName);
+      lastName = addHash(lastName);
     }
     attributes.put(Person.FIRST_NAME, firstName);
     attributes.put(Person.LAST_NAME, lastName);
@@ -111,8 +111,8 @@ public final class LifecycleModule extends Module {
     String motherFirstName = faker.name().firstName();
     String motherLastName = faker.name().lastName();
     if (appendNumbersToNames) {
-      motherFirstName = motherFirstName + person.randInt(1000);
-      motherLastName = motherLastName + person.randInt(1000);
+      motherFirstName = addHash(motherFirstName);
+      motherLastName = addHash(motherLastName);
     }
     attributes.put(Person.NAME_MOTHER, motherFirstName + " " + motherLastName);
 
@@ -151,6 +151,15 @@ public final class LifecycleModule extends Module {
     person.attributes.put(ADHERENCE_PROBABILITY, adherenceBaseline);
 
     grow(person, time); // set initial height and weight from percentiles
+  }
+  
+  /**
+   * Adds a 1- to 3-digit hashcode to the end of the name.
+   * @param name Person's name
+   * @return The name with a hash appended, ex "John123" or "Smith22"
+   */
+  private static String addHash(String name) {
+    return name + Integer.toString(Math.abs(name.hashCode() % 1000));
   }
 
   /**
@@ -209,7 +218,7 @@ public final class LifecycleModule extends Module {
               String firstName = ((String) person.attributes.get(Person.FIRST_NAME));
               String newLastName = faker.name().lastName();
               if (appendNumbersToNames) {
-                newLastName = newLastName + person.randInt(1000);
+                newLastName = addHash(newLastName);
               }
               person.attributes.put(Person.LAST_NAME, newLastName);
               person.attributes.put(Person.NAME, firstName + " " + newLastName);

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -43,6 +43,9 @@ generate.demographics.real_world_population = 6794422
 # note that this may significantly slow down processing, and is intended primarily for debugging
 generate.track_detailed_transition_metrics = false
 
+# If true, person names have numbers appended to them to make them more obviously fake
+generate.append_numbers_to_person_names = true
+
 # these should add up to 1.0
 # weighting and categories are inspired by the following but there are no specific hard numbers to point to
 # http://www.ncbi.nlm.nih.gov/pmc/articles/PMC1694190/pdf/amjph00543-0042.pdf

--- a/src/test/java/org/mitre/synthea/helpers/TransitionMetricsTest.java
+++ b/src/test/java/org/mitre/synthea/helpers/TransitionMetricsTest.java
@@ -10,6 +10,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
 import org.mitre.synthea.TestHelper;
+import org.mitre.synthea.engine.Event;
 import org.mitre.synthea.engine.Module;
 import org.mitre.synthea.helpers.TransitionMetrics.Metric;
 import org.mitre.synthea.modules.EncounterModule;
@@ -57,14 +58,15 @@ public class TransitionMetricsTest {
     assertEquals(1, m.current.get()); // and is still there
     
     metrics = new TransitionMetrics();
-    for (long seed : new long[] {16L, 0L, 12345L}) {
+    for (long seed : new long[] {31255L, 0L, 12345L}) {
       // seeds chosen by experimentation, to ensure we hit "Pre_Examplitis" at least once
       person = new Person(seed); 
       person.attributes.put(Person.GENDER, "M");
       person.setAmbulatoryProvider(Mockito.mock(Hospital.class));
       time = System.currentTimeMillis();
-      LifecycleModule.birth(person, time);
-      
+      person.attributes.put(Person.BIRTHDATE, time);
+      person.events.create(time, Event.BIRTH, "transition metrics test", true);
+
       time = run(person, example, time);
       metrics.recordStats(person, time, modules);
     }


### PR DESCRIPTION
Adds 1-3 random numbers to the end of people's names, to make them more obviously fake. Unlike the ruby version which uses a few characters from the hash of the string, this just picks a random number between 0-999. (Is there a reason we would need all people with the same name to get the same number?)
This setting is configurable, `generate.append_numbers_to_person_names` , enabled by default.

Examples with it enabled:

> 6 -- Dovie291 Bauch348 (13 y/o) Framingham 
> 4 -- Ashlee792 Kling333 (8 y/o) Acton 
> 2 -- Allie427 Kovacek502 (24 y/o) North Andover 
> 1 -- Royce613 Stroman567 (21 y/o) Whitman 
> 3 -- Joaquin191 Feil113 (49 y/o) Newton 
> 10 -- Virginie157 Ratke350 (15 y/o) Franklin 

Examples with it disabled:

> 6 -- Ramona Koepp (45 y/o) Kingston 
> 4 -- Dena Waters (26 y/o) Burlington 
> 1 -- Wendell Schaefer (10 y/o) Newton 
> 3 -- Karianne Hamill (13 y/o) Methuen 
> 8 -- Judge Connelly (26 y/o) Westford 
> 7 -- Micah Kris (54 y/o) Taunton DECEASED

Also this updates a test case to be hopefully less flaky and not break every time we add a new random call.