### PR TITLE
Submodule history added to calling module history

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,8 @@ dependencies {
   testCompile fileTree(dir: 'lib/mdhtruntime/mdht', include: '*.jar')
   testCompile fileTree(dir: 'lib/mdhtruntime/non-mdht', include: '*.jar')
 	testCompile 'org.mockito:mockito-core:2.7.22'
+  testCompile 'org.powermock:powermock-module-junit4:1.7.1'
+  testCompile 'org.powermock:powermock-api-mockito2:1.7.1'
 	testCompile 'ca.uhn.hapi.fhir:hapi-fhir-validation-resources-dstu3:3.0.0'
 	testCompile 'com.phloc:phloc-schematron:2.7.1'
 	testCompile 'com.phloc:phloc-commons:4.4.11'

--- a/src/main/java/org/mitre/synthea/engine/Module.java
+++ b/src/main/java/org/mitre/synthea/engine/Module.java
@@ -38,7 +38,7 @@ import org.mitre.synthea.world.agents.Person;
  */
 public class Module {
 
-  private static Map<String, Module> modules = Collections.unmodifiableMap(loadModules());
+  private static final Map<String, Module> modules = loadModules();
 
   private static Map<String, Module> loadModules() {
     Map<String, Module> retVal = new ConcurrentHashMap<String, Module>();


### PR DESCRIPTION
Modifies the CallSubmodule state so that the history of a submodule is added to the history of the calling module, as is currently done in the Ruby version. This should be preserved even if the submodule delays across multiple timesteps.