### PR TITLE
Replace resource reading with a helper method

### DIFF
--- a/src/main/java/org/mitre/synthea/export/FhirStu3.java
+++ b/src/main/java/org/mitre/synthea/export/FhirStu3.java
@@ -7,9 +7,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.vividsolutions.jts.geom.Point;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -17,7 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import org.hl7.fhir.dstu3.model.Address;
 import org.hl7.fhir.dstu3.model.BooleanType;
@@ -109,11 +105,9 @@ public class FhirStu3 {
 
   @SuppressWarnings("rawtypes")
   private static Map loadRaceEthnicityCodes() {
-    String filename = "/race_ethnicity_codes.json";
+    String filename = "race_ethnicity_codes.json";
     try {
-      InputStream stream = FhirStu3.class.getResourceAsStream(filename);
-      String json = new BufferedReader(new InputStreamReader(stream)).lines().parallel()
-          .collect(Collectors.joining("\n"));
+      String json = Utilities.readResource(filename);
       Gson g = new Gson();
       return g.fromJson(json, HashMap.class);
     } catch (Exception e) {
@@ -125,11 +119,9 @@ public class FhirStu3 {
 
   @SuppressWarnings("rawtypes")
   private static Map loadLanguageLookup() {
-    String filename = "/language_lookup.json";
+    String filename = "language_lookup.json";
     try {
-      InputStream stream = FhirStu3.class.getResourceAsStream(filename);
-      String json = new BufferedReader(new InputStreamReader(stream)).lines().parallel()
-          .collect(Collectors.joining("\n"));
+      String json = Utilities.readResource(filename);
       Gson g = new Gson();
       return g.fromJson(json, HashMap.class);
     } catch (Exception e) {

--- a/src/main/java/org/mitre/synthea/export/PrevalenceReport.java
+++ b/src/main/java/org/mitre/synthea/export/PrevalenceReport.java
@@ -1,9 +1,6 @@
 package org.mitre.synthea.export;
 
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -14,10 +11,10 @@ import java.sql.SQLException;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.mitre.synthea.engine.Generator;
 import org.mitre.synthea.helpers.SimpleCSV;
+import org.mitre.synthea.helpers.Utilities;
 
 public class PrevalenceReport {
 
@@ -43,11 +40,7 @@ public class PrevalenceReport {
       return;
     }
 
-    InputStream stream = PrevalenceReport.class.getResourceAsStream("/prevalence_template.csv");
-    // read all text into a string
-    String csvData = new BufferedReader(new InputStreamReader(stream)).lines().parallel()
-        .collect(Collectors.joining("\n"));
-
+    String csvData = Utilities.readResource("prevalence_template.csv");
     List<LinkedHashMap<String, String>> data = SimpleCSV.parse(csvData);
 
     try (Connection connection = generator.database.getConnection()) {

--- a/src/main/java/org/mitre/synthea/helpers/Utilities.java
+++ b/src/main/java/org/mitre/synthea/helpers/Utilities.java
@@ -4,6 +4,7 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import com.google.gson.JsonPrimitive;
 
+import java.io.IOException;
 import java.net.URL;
 import java.util.Calendar;
 import java.util.TimeZone;
@@ -184,8 +185,7 @@ public class Utilities {
     
     try {
       // see build.gradle for version.txt format
-      URL url = Resources.getResource("version.txt");
-      String text = Resources.toString(url, Charsets.UTF_8);
+      String text = readResource("version.txt");
       if (text != null && text.length() > 0) {
         version = text;
       }
@@ -194,5 +194,16 @@ public class Utilities {
       e.printStackTrace();
     }
     return version;
+  }
+  
+  /**
+   * Read the entire contents of a file in resources into a String.
+   * @param filename Path to the file, relative to src/main/resources.
+   * @return The entire text contents of the file.
+   * @throws IOException if any error occurs reading the file
+   */
+  public static final String readResource(String filename) throws IOException {
+    URL url = Resources.getResource(filename);
+    return Resources.toString(url, Charsets.UTF_8);
   }
 }

--- a/src/main/java/org/mitre/synthea/modules/Immunizations.java
+++ b/src/main/java/org/mitre/synthea/modules/Immunizations.java
@@ -2,15 +2,11 @@ package org.mitre.synthea.modules;
 
 import com.google.gson.Gson;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.world.agents.Person;
@@ -34,11 +30,9 @@ public class Immunizations {
 
   @SuppressWarnings("rawtypes")
   private static Map loadImmunizationSchedule() {
-    String filename = "/immunization_schedule.json";
+    String filename = "immunization_schedule.json";
     try {
-      InputStream stream = LifecycleModule.class.getResourceAsStream(filename);
-      String json = new BufferedReader(new InputStreamReader(stream)).lines().parallel()
-          .collect(Collectors.joining("\n"));
+      String json = Utilities.readResource(filename);
       Gson g = new Gson();
       return g.fromJson(json, HashMap.class);
     } catch (Exception e) {

--- a/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
+++ b/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
@@ -3,16 +3,12 @@ package org.mitre.synthea.modules;
 import com.github.javafaker.Faker;
 import com.google.gson.Gson;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import org.mitre.synthea.engine.Event;
 import org.mitre.synthea.engine.Module;
@@ -46,11 +42,9 @@ public final class LifecycleModule extends Module {
 
   @SuppressWarnings("rawtypes")
   private static Map loadGrowthChart() {
-    String filename = "/cdc_growth_charts.json";
+    String filename = "cdc_growth_charts.json";
     try {
-      InputStream stream = LifecycleModule.class.getResourceAsStream(filename);
-      String json = new BufferedReader(new InputStreamReader(stream)).lines().parallel()
-          .collect(Collectors.joining("\n"));
+      String json = Utilities.readResource(filename);
       Gson g = new Gson();
       return g.fromJson(json, HashMap.class);
     } catch (Exception e) {

--- a/src/main/java/org/mitre/synthea/modules/QualityOfLifeModule.java
+++ b/src/main/java/org/mitre/synthea/modules/QualityOfLifeModule.java
@@ -2,16 +2,12 @@ package org.mitre.synthea.modules;
 
 import com.google.gson.Gson;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import org.mitre.synthea.engine.Module;
 import org.mitre.synthea.helpers.Utilities;
@@ -60,11 +56,9 @@ public class QualityOfLifeModule extends Module {
 
   @SuppressWarnings("unchecked")
   private static Map<String, Map<String, Object>> loadDisabilityWeights() {
-    String filename = "/gbd_disability_weights.json";
+    String filename = "gbd_disability_weights.json";
     try {
-      InputStream stream = QualityOfLifeModule.class.getResourceAsStream(filename);
-      String json = new BufferedReader(new InputStreamReader(stream)).lines().parallel()
-          .collect(Collectors.joining("\n"));
+      String json = Utilities.readResource(filename);
       Gson g = new Gson();
       return g.fromJson(json, HashMap.class);
     } catch (Exception e) {

--- a/src/main/java/org/mitre/synthea/world/agents/Hospital.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Hospital.java
@@ -4,14 +4,12 @@ import com.google.gson.Gson;
 import com.google.gson.internal.LinkedTreeMap;
 import com.vividsolutions.jts.geom.Point;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map.Entry;
 import java.util.UUID;
-import java.util.stream.Collectors;
+
+import org.mitre.synthea.helpers.Utilities;
 
 public class Hospital extends Provider {
 
@@ -28,13 +26,10 @@ public class Hospital extends Provider {
 
   @SuppressWarnings("unchecked")
   public static void loadHospitals() {
-    String filename = "/geography/healthcare_facilities.json";
+    String filename = "geography/healthcare_facilities.json";
 
     try {
-      InputStream stream = Hospital.class.getResourceAsStream(filename);
-      // read all text into a string
-      String json = new BufferedReader(new InputStreamReader(stream)).lines().parallel()
-          .collect(Collectors.joining("\n"));
+      String json = Utilities.readResource(filename);
       Gson g = new Gson();
       HashMap<String, LinkedTreeMap> gson = g.fromJson(json, HashMap.class);
       for (Entry<String, LinkedTreeMap> entry : gson.entrySet()) {

--- a/src/main/java/org/mitre/synthea/world/concepts/BillingConcept.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/BillingConcept.java
@@ -2,13 +2,11 @@ package org.mitre.synthea.world.concepts;
 
 import com.google.gson.Gson;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
+
+import org.mitre.synthea.helpers.Utilities;
 
 public class BillingConcept {
   // HashMap of all codes in synthea
@@ -32,12 +30,9 @@ public class BillingConcept {
   @SuppressWarnings("unchecked")
   public static void loadConceptMappings() {
 
-    String filename = "/concept_mappings.json";
+    String filename = "concept_mappings.json";
     try {
-      InputStream stream = BillingConcept.class.getResourceAsStream(filename);
-      // read all text into a string
-      String json = new BufferedReader(new InputStreamReader(stream)).lines().parallel()
-          .collect(Collectors.joining("\n"));
+      String json = Utilities.readResource(filename);
       Gson g = new Gson();
       HashMap<String, Map<String, ?>> gson = g.fromJson(json, HashMap.class);
       for (Entry<String, ?> entry : gson.entrySet()) {

--- a/src/main/java/org/mitre/synthea/world/concepts/BiometricsConfig.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/BiometricsConfig.java
@@ -1,12 +1,9 @@
 package org.mitre.synthea.world.concepts;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.mitre.synthea.helpers.SimpleYML;
+import org.mitre.synthea.helpers.Utilities;
 
 /**
  * Class exposing various configurable biometric settings, 
@@ -28,11 +25,7 @@ public abstract class BiometricsConfig {
    */
   private static final SimpleYML loadYML() {
     try {
-      InputStream stream = BiometricsConfig.class.getResourceAsStream("/biometrics.yml");
-      //read all text into a string
-      String yml = new BufferedReader(new InputStreamReader(stream)).lines()
-          .collect(Collectors.joining("\n"));
-
+      String yml = Utilities.readResource("biometrics.yml");
       return new SimpleYML(yml);
       
     } catch (Exception e) {

--- a/src/main/java/org/mitre/synthea/world/concepts/GeographicalPracticeCostIndex.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/GeographicalPracticeCostIndex.java
@@ -3,12 +3,10 @@ package org.mitre.synthea.world.concepts;
 import com.google.gson.Gson;
 import com.google.gson.internal.LinkedTreeMap;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.HashMap;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
+
+import org.mitre.synthea.helpers.Utilities;
 
 public class GeographicalPracticeCostIndex {
 
@@ -54,12 +52,9 @@ public class GeographicalPracticeCostIndex {
   @SuppressWarnings({ "unchecked", "rawtypes" })
   public static void loadGpciData() {
 
-    String filename = "/geographical_practice_cost_index.json";
+    String filename = "geographical_practice_cost_index.json";
     try {
-      InputStream stream = GeographicalPracticeCostIndex.class.getResourceAsStream(filename);
-      // read all text into a string
-      String json = new BufferedReader(new InputStreamReader(stream)).lines().parallel()
-          .collect(Collectors.joining("\n"));
+      String json = Utilities.readResource(filename);
       Gson g = new Gson();
 
       LinkedTreeMap<String, LinkedTreeMap> gson = g.fromJson(json, LinkedTreeMap.class);

--- a/src/main/java/org/mitre/synthea/world/concepts/RelativeValueUnit.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/RelativeValueUnit.java
@@ -3,12 +3,10 @@ package org.mitre.synthea.world.concepts;
 import com.google.gson.Gson;
 import com.google.gson.internal.LinkedTreeMap;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.HashMap;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
+
+import org.mitre.synthea.helpers.Utilities;
 
 public class RelativeValueUnit {
 
@@ -61,12 +59,9 @@ public class RelativeValueUnit {
   @SuppressWarnings({ "unchecked", "rawtypes" })
   public static void loadRVUs() {
 
-    String filename = "/relative_value_units.json";
+    String filename = "relative_value_units.json";
     try {
-      InputStream stream = RelativeValueUnit.class.getResourceAsStream(filename);
-      // read all text into a string
-      String json = new BufferedReader(new InputStreamReader(stream)).lines().parallel()
-          .collect(Collectors.joining("\n"));
+      String json = Utilities.readResource(filename);
       Gson g = new Gson();
       LinkedTreeMap<String, LinkedTreeMap> gson = g.fromJson(json, LinkedTreeMap.class);
       for (Entry<String, LinkedTreeMap> entry : gson.entrySet()) {

--- a/src/main/java/org/mitre/synthea/world/geography/Demographics.java
+++ b/src/main/java/org/mitre/synthea/world/geography/Demographics.java
@@ -2,17 +2,14 @@ package org.mitre.synthea.world.geography;
 
 import com.google.gson.Gson;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
-import java.util.stream.Collectors;
 
 import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.helpers.RandomCollection;
+import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.world.agents.Person;
 
 /**
@@ -374,10 +371,7 @@ public class Demographics {
    *           if the file could not be found or read
    */
   public static Map<String, Demographics> loadByName(String filename) throws IOException {
-    InputStream stream = Location.class.getResourceAsStream(filename);
-    // read all text into a string
-    String json = new BufferedReader(new InputStreamReader(stream)).lines()
-        .collect(Collectors.joining("\n"));
+    String json = Utilities.readResource(filename);
     return loadByContent(json);
   }
 

--- a/src/main/java/org/mitre/synthea/world/geography/Location.java
+++ b/src/main/java/org/mitre/synthea/world/geography/Location.java
@@ -8,16 +8,13 @@ import com.vividsolutions.jts.geom.MultiPolygon;
 import com.vividsolutions.jts.geom.Point;
 import com.vividsolutions.jts.geom.Polygon;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.stream.Collectors;
 
+import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.world.agents.CommunityHealthWorker;
 import org.mitre.synthea.world.agents.Person;
 import org.wololo.geojson.Feature;
@@ -37,18 +34,14 @@ public class Location {
 
   static {
     // load the GeoJSON once so we can use it for all patients
-    String filename = "/geography/ma_geo.json";
+    String filename = "geography/ma_geo.json";
 
     long runningPopulation = 0;
     populationByCity = new LinkedHashMap<>(); // linked to ensure consistent iteration order
     featuresByName = new HashMap<>();
 
     try {
-      InputStream stream = Location.class.getResourceAsStream(filename);
-      // read all text into a string
-      String json = new BufferedReader(new InputStreamReader(stream)).lines().parallel()
-          .collect(Collectors.joining("\n"));
-
+      String json = Utilities.readResource(filename);
       cities = (FeatureCollection) GeoJSONFactory.create(json);
 
       for (Feature f : cities.getFeatures()) {
@@ -69,13 +62,8 @@ public class Location {
     }
 
     try {
-      filename = "/geography/ma_zip.json";
-      
-      InputStream stream = Location.class.getResourceAsStream(filename);
-      // read all text into a string
-      String json = new BufferedReader(new InputStreamReader(stream)).lines().parallel()
-          .collect(Collectors.joining("\n"));
-      
+      filename = "geography/ma_zip.json";
+      String json = Utilities.readResource(filename);
       Gson g = new Gson();
       zipCodes = g.fromJson(json, LinkedTreeMap.class);
       

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -34,7 +34,7 @@ generate.database_type = in-memory
 
 # default demographics is all of Massachusetts
 # can be changed to any county, ex "/geography/Middlesex_County.json"
-generate.demographics.default_file = /geography/towns.json
+generate.demographics.default_file = geography/towns.json
 
 generate.demographics.real_world_population = 6794422
 #sum of the jsons in the config folder


### PR DESCRIPTION
Currently files in src/main/resources get read into a String using an awful copy&pasted code snippet that looks like this:
```
InputStream stream = FhirStu3.class.getResourceAsStream(filename);
String json = new BufferedReader(new InputStreamReader(stream)).lines().parallel()
          .collect(Collectors.joining("\n"));
```

This is awful and exists in too many places so I added a helper method Utilities.readResource() which takes a filename and returns the content of the file as a String.