### PR TITLE
Concept inventory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ task graphviz(type: JavaExec) {
 }
 
 task concepts(type: JavaExec) {
-  description 'Create a list of simulated conceptsn'
+  description 'Create a list of simulated concepts'
   classpath sourceSets.main.runtimeClasspath
   main = "org.mitre.synthea.helpers.Concepts"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,12 @@ task graphviz(type: JavaExec) {
 	main = "Graphviz"
 }
 
+task concepts(type: JavaExec) {
+  description 'Create a list of simulated conceptsn'
+  classpath sourceSets.main.runtimeClasspath
+  main = "Concepts"
+}
+
 task versionTxt() {
     doLast {
       // the ruby version uses `git rev-parse HEAD` which just produces the long commit hash.

--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,7 @@ task graphviz(type: JavaExec) {
 task concepts(type: JavaExec) {
   description 'Create a list of simulated conceptsn'
   classpath sourceSets.main.runtimeClasspath
-  main = "Concepts"
+  main = "org.mitre.synthea.helpers.Concepts"
 }
 
 task versionTxt() {

--- a/src/main/java/Concepts.java
+++ b/src/main/java/Concepts.java
@@ -1,0 +1,139 @@
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.stream.JsonReader;
+
+import org.mitre.synthea.modules.CardiovascularDiseaseModule;
+import org.mitre.synthea.modules.DeathModule;
+import org.mitre.synthea.modules.EncounterModule;
+import org.mitre.synthea.modules.Immunizations;
+import org.mitre.synthea.modules.LifecycleModule;
+import org.mitre.synthea.world.concepts.HealthRecord.Code;
+
+/**
+ * Task class to export a report of all clinical concepts
+ * (aka Codes) that Synthea is aware of.
+ * Format is "system,code,display".
+ */
+public class Concepts {
+  public static void main(String[] args) throws IOException, URISyntaxException {
+    System.out.println("Performing an inventory of concepts into `output/concepts.csv`...");
+    
+    Table<String,String,String> concepts = HashBasedTable.create();
+
+    URL modulesFolder = ClassLoader.getSystemClassLoader().getResource("modules");
+    Path path = Paths.get(modulesFolder.toURI());
+    Files.walk(path, Integer.MAX_VALUE).filter(Files::isReadable).filter(Files::isRegularFile)
+        .filter(f -> f.toString().endsWith(".json")).forEach(modulePath -> {
+          try (JsonReader reader = new JsonReader(new FileReader(modulePath.toString()))){
+            JsonObject module = new JsonParser().parse(reader).getAsJsonObject();
+            inventoryModule(concepts, module);
+          } catch (IOException e) {
+            
+          }
+        });
+
+    inventoryCodes(concepts, CardiovascularDiseaseModule.getAllCodes() );
+    inventoryCodes(concepts, DeathModule.getAllCodes() );
+    inventoryCodes(concepts, EncounterModule.getAllCodes() );
+    // HealthInsuranceModule has no codes
+    inventoryCodes(concepts, Immunizations.getAllCodes() );
+    inventoryCodes(concepts, LifecycleModule.getAllCodes() );
+    // QualityOfLifeModule adds no new codes to patients
+    
+    int count = 0;
+    StringBuilder output = new StringBuilder();
+    for (String system : concepts.rowKeySet()) {
+      Map<String,String> codesInSystem = concepts.row(system);
+      
+      for (String code : codesInSystem.keySet()) {
+        String display = codesInSystem.get(code);
+        display = display.replaceAll("\\r\\n|\\r|\\n|,", " ").trim();
+        count++;
+        output.append(system).append(',')
+              .append(code).append(',')
+              .append(display).append(System.lineSeparator());
+      }
+    }
+    
+    Path outFilePath = new File("./output/concepts.csv").toPath();
+    
+    Files.write(outFilePath, Collections.singleton(output.toString()), StandardOpenOption.CREATE);
+    
+    System.out.println("Cataloged " + count + " concepts.");
+    System.out.println("Done.");
+  }
+  
+  /**
+   * Catalog all concepts from the given module into the given Table.
+   * 
+   * @param concepts Table of concepts to add to
+   * @param module Module to parse for concepts and codes
+   */
+  public static void inventoryModule(Table<String, String, String> concepts, JsonObject module) {
+    JsonObject states = module.get("states").getAsJsonObject();
+    for (Entry<String, JsonElement> entry : states.entrySet()) {
+      JsonObject state = entry.getValue().getAsJsonObject();
+      inventoryState(concepts, state);
+    }
+  }
+  
+  /**
+   * Catalog all concepts from the given state into the given Table.
+   * 
+   * @param concepts Table of concepts to add to
+   * @param module State to parse for concepts and codes
+   */
+  public static void inventoryState(Table<String, String, String> concepts, JsonObject state) {
+    // TODO - how can we make this more generic
+    // and not have to remember to update this if we add new codes in another field?
+    if (state.has("codes")) {
+      List<Code> codes = Code.fromJson(state.getAsJsonArray("codes"));
+      inventoryCodes(concepts, codes);
+    }
+
+    if (state.has("activities")) {
+      List<Code> codes = Code.fromJson(state.getAsJsonArray("activities"));
+      inventoryCodes(concepts, codes);
+    }
+
+    if (state.has("prescription")) {
+      JsonObject prescription = state.getAsJsonObject("prescription");
+      if (prescription.has("instructions")) {
+        List<Code> codes = Code.fromJson(prescription.getAsJsonArray("instructions"));
+        inventoryCodes(concepts, codes);
+      }
+    }
+
+    if (state.has("discharge_disposition")) {
+      Code code = new Code(state.getAsJsonObject("discharge_disposition"));
+      inventoryCodes(concepts, Collections.singleton(code));
+    }
+  }
+  
+  /**
+   * Add the Codes in the given Collection to the given inventory of concepts.
+   * @param concepts Table of concepts to add to
+   * @param codes Collection of codes to add
+   */
+  public static void inventoryCodes(Table<String, String, String> concepts, Collection<Code> codes) {
+    codes.forEach( code -> concepts.put(code.system, code.code, code.display) );
+  }
+}

--- a/src/main/java/org/mitre/synthea/helpers/Concepts.java
+++ b/src/main/java/org/mitre/synthea/helpers/Concepts.java
@@ -1,3 +1,4 @@
+package org.mitre.synthea.helpers;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;

--- a/src/main/java/org/mitre/synthea/helpers/Concepts.java
+++ b/src/main/java/org/mitre/synthea/helpers/Concepts.java
@@ -64,7 +64,7 @@ public class Concepts {
 
     URL modulesFolder = ClassLoader.getSystemClassLoader().getResource("modules");
     Path path = Paths.get(modulesFolder.toURI());
-    Files.walk(path, Integer.MAX_VALUE).filter(Files::isReadable).filter(Files::isRegularFile)
+    Files.walk(path).filter(Files::isReadable).filter(Files::isRegularFile)
         .filter(f -> f.toString().endsWith(".json")).forEach(modulePath -> {
           try (JsonReader reader = new JsonReader(new FileReader(modulePath.toString()))) {
             JsonObject module = new JsonParser().parse(reader).getAsJsonObject();

--- a/src/main/java/org/mitre/synthea/helpers/Concepts.java
+++ b/src/main/java/org/mitre/synthea/helpers/Concepts.java
@@ -15,6 +15,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -43,6 +44,22 @@ public class Concepts {
   public static void main(String[] args) throws Exception {
     System.out.println("Performing an inventory of concepts into `output/concepts.csv`...");
     
+    List<String> output = getConceptInventory();
+    
+    Path outFilePath = new File("./output/concepts.csv").toPath();
+    
+    Files.write(outFilePath, output, StandardOpenOption.CREATE);
+    
+    System.out.println("Cataloged " + output.size() + " concepts.");
+    System.out.println("Done.");
+  }
+  
+  /**
+   * Get the list of all concepts in Synthea, as a list of CSV strings.
+   * @return list of CSV strings
+   * @throws Exception if any exception occurs in reading the modules.
+   */
+  public static List<String> getConceptInventory() throws Exception {
     Table<String,String,String> concepts = HashBasedTable.create();
 
     URL modulesFolder = ClassLoader.getSystemClassLoader().getResource("modules");
@@ -65,27 +82,24 @@ public class Concepts {
     inventoryCodes(concepts, LifecycleModule.getAllCodes());
     // QualityOfLifeModule adds no new codes to patients
     
-    int count = 0;
-    StringBuilder output = new StringBuilder();
+    List<String> conceptList = new ArrayList<>();
+    
     for (String system : concepts.rowKeySet()) {
       Map<String,String> codesInSystem = concepts.row(system);
       
       for (String code : codesInSystem.keySet()) {
         String display = codesInSystem.get(code);
         display = display.replaceAll("\\r\\n|\\r|\\n|,", " ").trim();
-        count++;
+        StringBuilder output = new StringBuilder();
         output.append(system).append(',')
               .append(code).append(',')
               .append(display).append(System.lineSeparator());
+        
+        conceptList.add(output.toString());
       }
     }
     
-    Path outFilePath = new File("./output/concepts.csv").toPath();
-    
-    Files.write(outFilePath, Collections.singleton(output.toString()), StandardOpenOption.CREATE);
-    
-    System.out.println("Cataloged " + count + " concepts.");
-    System.out.println("Done.");
+    return conceptList;
   }
   
   /**

--- a/src/main/java/org/mitre/synthea/modules/CardiovascularDiseaseModule.java
+++ b/src/main/java/org/mitre/synthea/modules/CardiovascularDiseaseModule.java
@@ -1,6 +1,7 @@
 package org.mitre.synthea.modules;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -809,5 +810,14 @@ public final class CardiovascularDiseaseModule extends Module {
       Entry historyCond = person.record.conditionStart(time, cond);
       historyCond.codes.add(LOOKUP.get(cond));
     }
+  }
+
+  /**
+   * Get all of the Codes this module uses, for inventory purposes.
+   * 
+   * @return Collection of all codes and concepts this module uses
+   */
+  public static Collection<Code> getAllCodes() {
+    return LOOKUP.values();
   }
 }

--- a/src/main/java/org/mitre/synthea/modules/DeathModule.java
+++ b/src/main/java/org/mitre/synthea/modules/DeathModule.java
@@ -1,5 +1,8 @@
 package org.mitre.synthea.modules;
 
+import java.util.Arrays;
+import java.util.Collection;
+
 import org.mitre.synthea.world.agents.Person;
 import org.mitre.synthea.world.concepts.HealthRecord.Code;
 import org.mitre.synthea.world.concepts.HealthRecord.Encounter;
@@ -13,7 +16,8 @@ public class DeathModule {
       "Cause of Death [US Standard Certificate of Death]");
   public static final Code DEATH_CERTIFICATE = new Code("LOINC", "69409-1",
       "U.S. standard certificate of death - 2003 revision");
-
+  // NOTE: if new codes are added, be sure to update getAllCodes below
+  
   public static void process(Person person, long time) {
     if (!person.alive(time) && person.attributes.containsKey(Person.CAUSE_OF_DEATH)) {
       // create an encounter, diagnostic report, and observation
@@ -29,5 +33,14 @@ public class DeathModule {
       Report deathCert = person.record.report(time, DEATH_CERTIFICATE.code, 1);
       deathCert.codes.add(DEATH_CERTIFICATE);
     }
+  }
+
+  /**
+   * Get all of the Codes this module uses, for inventory purposes.
+   * 
+   * @return Collection of all codes and concepts this module uses
+   */
+  public static Collection<Code> getAllCodes() {
+    return Arrays.asList(DEATH_CERTIFICATION, CAUSE_OF_DEATH_CODE, DEATH_CERTIFICATE);
   }
 }

--- a/src/main/java/org/mitre/synthea/modules/EncounterModule.java
+++ b/src/main/java/org/mitre/synthea/modules/EncounterModule.java
@@ -1,5 +1,7 @@
 package org.mitre.synthea.modules;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
 import org.mitre.synthea.engine.Event;
@@ -24,6 +26,7 @@ public final class EncounterModule extends Module {
       "Well child visit (procedure)");
   public static final Code GENERAL_EXAM = new Code("SNOMED-CT", "162673000",
       "General examination of patient (procedure)");
+  // NOTE: if new codes are added, be sure to update getAllCodes below
 
   public EncounterModule() {
     this.name = "Encounter";
@@ -140,6 +143,16 @@ public final class EncounterModule extends Module {
   public void endWellnessEncounter(Person person, long time) {
     person.record.encounterEnd(time, EncounterType.WELLNESS.toString());
     person.attributes.remove(ACTIVE_WELLNESS_ENCOUNTER);
+  }
+
+  /**
+   * Get all of the Codes this module uses, for inventory purposes.
+   * 
+   * @return Collection of all codes and concepts this module uses
+   */
+  public static Collection<Code> getAllCodes() {
+    return Arrays.asList(ENCOUNTER_CHECKUP, ENCOUNTER_EMERGENCY, 
+                         WELL_CHILD_VISIT, GENERAL_EXAM);
   }
 
 }

--- a/src/main/java/org/mitre/synthea/modules/Immunizations.java
+++ b/src/main/java/org/mitre/synthea/modules/Immunizations.java
@@ -3,14 +3,17 @@ package org.mitre.synthea.modules;
 import com.google.gson.Gson;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.world.agents.Person;
 import org.mitre.synthea.world.concepts.HealthRecord;
+import org.mitre.synthea.world.concepts.HealthRecord.Code;
 
 /**
  * This is a complete, but fairly simplistic approach to synthesizing immunizations. It is encounter
@@ -127,5 +130,27 @@ public class Immunizations {
 
     // 3) see if there are any recommended doses remaining that this patient is old enough for
     return !atMonths.isEmpty() && ageInMonths >= (double) atMonths.get(0);
+  }
+
+  /**
+   * Get all of the Codes this module uses, for inventory purposes.
+   * 
+   * @return Collection of all codes and concepts this module uses
+   */
+  @SuppressWarnings( "rawtypes" )
+  public static Collection<Code> getAllCodes() {
+    List<Map> rawCodes = (List<Map>) immunizationSchedule.values().stream().map(m -> (Map)m.get("code")).collect(Collectors.toList());
+    
+    List<Code> convertedCodes = new ArrayList<Code>( rawCodes.size() );
+    
+    for (Map m : rawCodes) {
+      Code immCode = new Code(m.get("system").toString(),
+                              m.get("code").toString(), 
+                              m.get("display").toString());
+      
+      convertedCodes.add(immCode);
+    }
+
+    return convertedCodes;
   }
 }

--- a/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
+++ b/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
@@ -4,6 +4,8 @@ import com.github.javafaker.Faker;
 import com.google.gson.Gson;
 
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -764,4 +766,12 @@ public final class LifecycleModule extends Module {
     }
   }
 
+  /**
+   * Get all of the Codes this module uses, for inventory purposes.
+   * 
+   * @return Collection of all codes and concepts this module uses
+   */
+  public static Collection<Code> getAllCodes() {
+    return Collections.singleton(NATURAL_CAUSES);
+  }
 }

--- a/src/test/java/org/mitre/synthea/helpers/ConceptsTest.java
+++ b/src/test/java/org/mitre/synthea/helpers/ConceptsTest.java
@@ -1,0 +1,86 @@
+package org.mitre.synthea.helpers;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.stream.JsonReader;
+
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mitre.synthea.world.concepts.HealthRecord.Code;
+
+public class ConceptsTest {
+  private Table<String,String,String> concepts;
+
+  @Before
+  public void setup() {
+    concepts = HashBasedTable.create();
+  }
+
+  @Test
+  public void testInventoryModule() throws FileNotFoundException {
+    Path modulesFolder = Paths.get("src/test/resources/generic");
+    Path modulePath = modulesFolder.resolve("example_module.json");
+    
+    JsonReader reader = new JsonReader(new FileReader(modulePath.toString()));
+    JsonObject module = new JsonParser().parse(reader).getAsJsonObject();
+    
+    // example_module has 4 codes:
+    // Examplitis condition
+    // Examplitol medication
+    // Examplotomy_Encounter
+    // Examplotomy procedure
+    
+    
+    Concepts.inventoryModule(concepts, module);
+    
+    assertEquals(4, concepts.cellSet().size());
+    assertEquals("Examplitis", concepts.get("SNOMED-CT", "123"));
+    assertEquals("Examplitol", concepts.get("RxNorm", "456"));
+    assertEquals("Examplotomy Encounter", concepts.get("SNOMED-CT", "ABC"));
+    assertEquals("Examplotomy", concepts.get("SNOMED-CT", "789"));
+  }
+
+  @Test
+  public void testInventoryState() throws FileNotFoundException {
+    Path modulesFolder = Paths.get("src/test/resources/generic");
+    Path modulePath = modulesFolder.resolve("condition_onset.json");
+    
+    JsonReader reader = new JsonReader(new FileReader(modulePath.toString()));
+    JsonObject module = new JsonParser().parse(reader).getAsJsonObject();
+    JsonObject state = module.getAsJsonObject("states").getAsJsonObject("Appendicitis");
+    
+    Concepts.inventoryState(concepts, state);
+    
+    assertEquals(1, concepts.cellSet().size());
+    assertEquals("Rupture of appendix", concepts.get("SNOMED-CT", "47693006"));
+  }
+  
+  @Test
+  public void testInventoryCodes() {
+    List<Code> codes = new ArrayList<Code>();
+    
+    codes.add(new Code("SNOMED-CT","230690007","Stroke"));
+    codes.add(new Code("SNOMED-CT","22298006","Myocardial Infarction"));
+    codes.add(new Code("RxNorm","834060","Penicillin V Potassium 250 MG"));
+    codes.add(new Code("RxNorm","834060","Penicillin V Potassium 250 MG")); 
+    // note duplicate code here!! ex, same code in multiple modules
+    
+    Concepts.inventoryCodes(concepts, codes);
+    
+    assertEquals(3, concepts.cellSet().size());
+    assertEquals("Stroke", concepts.get("SNOMED-CT", "230690007"));
+    assertEquals("Myocardial Infarction", concepts.get("SNOMED-CT", "22298006"));
+    assertEquals("Penicillin V Potassium 250 MG", concepts.get("RxNorm", "834060"));
+  }
+}

--- a/src/test/java/org/mitre/synthea/helpers/ConceptsTest.java
+++ b/src/test/java/org/mitre/synthea/helpers/ConceptsTest.java
@@ -14,17 +14,35 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.mitre.synthea.world.concepts.HealthRecord.Code;
 
 public class ConceptsTest {
   private Table<String,String,String> concepts;
+  
+  /**
+   * Temporary folder for any exported files, guaranteed to be deleted at the end of the test.
+   */
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
 
   @Before
   public void setup() {
     concepts = HashBasedTable.create();
+  }
+  
+  @Test
+  public void testConcepts() throws Exception {
+    List<String> concepts = Concepts.getConceptInventory();
+    // just intended to ensure no exceptions or anything
+    // make sure simpleCSV can parse it
+    String csv = concepts.stream().collect(Collectors.joining("\n"));
+    SimpleCSV.parse(csv);
   }
 
   @Test

--- a/src/test/java/org/mitre/synthea/helpers/ConceptsTest.java
+++ b/src/test/java/org/mitre/synthea/helpers/ConceptsTest.java
@@ -17,19 +17,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 import org.mitre.synthea.world.concepts.HealthRecord.Code;
 
 public class ConceptsTest {
   private Table<String,String,String> concepts;
-  
-  /**
-   * Temporary folder for any exported files, guaranteed to be deleted at the end of the test.
-   */
-  @Rule
-  public TemporaryFolder tempFolder = new TemporaryFolder();
 
   @Before
   public void setup() {


### PR DESCRIPTION
Catalog all codes & concepts into a CSV file. Runnable using `./gradlew concepts`.
This is a clone of the Ruby version, which scans through the JSON modules to find codes. For the few Java modules we have there's a new method to get all the codes used. It's not perfect for the Java modules but I don't want to recreate the shared "LOOKUP" from the ruby version.

Sample file is attached:

[concepts.csv.txt](https://github.com/synthetichealth/synthea_java/files/1521665/concepts.csv.txt)
