### PR TITLE
Export filtering, destructive version

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/Generator.java
+++ b/src/main/java/org/mitre/synthea/engine/Generator.java
@@ -196,7 +196,6 @@ public class Generator {
 
         DeathModule.process(person, time);
 
-        Exporter.export(person, time);
         if (database != null) {
           database.store(person);
         }
@@ -217,6 +216,10 @@ public class Generator {
         count.incrementAndGet();
 
         totalGeneratedPopulation.incrementAndGet();
+        
+        // TODO - export is DESTRUCTIVE when it filters out data
+        // this means export must be the LAST THING done with the person
+        Exporter.export(person, time);
       } while (!isAlive);
     } catch (Throwable e) {
       // lots of fhir things throw errors for some reason

--- a/src/main/java/org/mitre/synthea/export/Exporter.java
+++ b/src/main/java/org/mitre/synthea/export/Exporter.java
@@ -8,11 +8,19 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
+import java.util.function.Predicate;
 
 import org.mitre.synthea.engine.Generator;
 import org.mitre.synthea.helpers.Config;
+import org.mitre.synthea.helpers.Utilities;
+import org.mitre.synthea.modules.DeathModule;
 import org.mitre.synthea.world.agents.Person;
+import org.mitre.synthea.world.concepts.HealthRecord;
+import org.mitre.synthea.world.concepts.HealthRecord.Encounter;
+import org.mitre.synthea.world.concepts.HealthRecord.Observation;
+import org.mitre.synthea.world.concepts.HealthRecord.Report;
 
 public abstract class Exporter {
   /**
@@ -23,7 +31,10 @@ public abstract class Exporter {
    * @param stopTime Time at which the simulation stopped
    */
   public static void export(Person person, long stopTime) {
-    // TODO: filter for export
+    int yearsOfHistory = Integer.parseInt(Config.get("exporter.years_of_history"));
+    if (yearsOfHistory > 0) {
+      person = filterForExport(person, yearsOfHistory, stopTime);
+    }
     if (Boolean.parseBoolean(Config.get("exporter.fhir.export"))) {
       String bundleJson = FhirStu3.convertToFHIR(person, stopTime);
       File outDirectory = getOutputFolder("fhir", person);
@@ -90,7 +101,125 @@ public abstract class Exporter {
         e.printStackTrace();
       }
     }
+  }
+  
+  public static Person filterForExport(Person original, int yearsToKeep, long endTime) {
+    // filter the patient's history to only the last __ years
+    // but also include relevant history from before that. Exclude
+    // any history that occurs after the specified end_time -- typically
+    // this is the current time/System.currentTimeMillis().
 
+    long cutoffDate = endTime - Utilities.convertTime("years", yearsToKeep);
+
+    Predicate<HealthRecord.Entry> notFutureDated = e -> e.start <= endTime;
+    
+    // TODO: clone the patient so that we export only the last _ years 
+    // but the rest still exists, just in case
+    Person filtered = original; //.clone();
+    //filtered.record = original.record.clone();
+
+    final HealthRecord record = filtered.record;
+    
+    for (Encounter encounter : record.encounters) { 
+      // keep conditions if still active, regardless of start date
+      Predicate<HealthRecord.Entry> conditionActive = c -> record.conditionActive(c.type);
+      // or if the condition was active at any point since the cutoff date
+      Predicate<HealthRecord.Entry> activeWithinCutoff = c -> c.stop != 0L && c.stop > cutoffDate;
+      Predicate<HealthRecord.Entry> keepCondition = conditionActive.or(activeWithinCutoff); 
+      filterEntries(encounter.conditions, cutoffDate, endTime, keepCondition);
+
+      // allergies are essentially the same as conditions
+      filterEntries(encounter.allergies, cutoffDate, endTime, keepCondition);
+
+      // some of the "future death" logic could potentially add a future-dated death certificate
+      Predicate<Observation> isCauseOfDeath =
+          o -> DeathModule.CAUSE_OF_DEATH_CODE.code.equals(o.type);
+      // keep cause of death unless it's future dated
+      Predicate<Observation> keepObservation = isCauseOfDeath.and(notFutureDated);
+      filterEntries(encounter.observations, cutoffDate, endTime, keepObservation);
+
+      // keep all death certificates, unless they are future-dated
+      Predicate<Report> isDeathCertificate = r -> DeathModule.DEATH_CERTIFICATE.code.equals(r.type);
+      Predicate<Report> keepReport = isDeathCertificate.and(notFutureDated);
+      filterEntries(encounter.reports, cutoffDate, endTime, keepReport);
+
+      filterEntries(encounter.procedures, cutoffDate, endTime, null);
+
+      // keep medications if still active, regardless of start date
+      filterEntries(encounter.medications, cutoffDate, endTime, 
+          med -> record.medicationActive(med.type));
+
+      filterEntries(encounter.immunizations, cutoffDate, endTime, null);
+
+      // keep careplans if they are still active, regardless of start date
+      filterEntries(encounter.careplans, cutoffDate, endTime, cp -> record.careplanActive(cp.type));
+    }
+
+    Predicate<Encounter> encounterNotEmpty = e ->
+        !e.conditions.isEmpty() && !e.allergies.isEmpty()
+        && !e.observations.isEmpty() && !e.reports.isEmpty()
+        && !e.procedures.isEmpty() && !e.medications.isEmpty()
+        && !e.immunizations.isEmpty() && !e.careplans.isEmpty();
+
+    Predicate<Encounter> isDeathCertification = 
+        e -> !e.codes.isEmpty() && DeathModule.DEATH_CERTIFICATION.equals(e.codes.get(0));
+    Predicate<Encounter> keepEncounter = 
+        encounterNotEmpty.or(isDeathCertification.and(notFutureDated));
+
+    // finally filter out any empty encounters
+    filterEntries(record.encounters, cutoffDate, endTime, keepEncounter);
+
+    return filtered;
+  }
+
+  /**
+   * Helper function to filter entries from a list. Entries are kept if their date range falls
+   * within the provided range or if `keepFunction` is provided, and returns `true` for the given
+   * entry.
+   * 
+   * @param entries
+   *          List of `Entry`s to filter
+   * @param cutoffDate
+   *          Minimum date, entries older than this may be discarded
+   * @param endTime
+   *          Maximum date, entries newer than this may be discarded
+   * @param keepFunction
+   *          Keep function, if this function returns `true` for an entry then it will be kept
+   */
+  private static <E extends HealthRecord.Entry> void filterEntries(List<E> entries,
+      long cutoffDate, long endTime, Predicate<E> keepFunction) {
+    Iterator<E> iterator = entries.iterator();
+    // iterator allows us to use the remove() method
+    while (iterator.hasNext()) {
+      E entry = iterator.next();
+      // if the entry is not within the keep time range,
+      // and the special keep function (if provided) doesn't say keep it
+      // remove it from the list
+      if (!entryWithinTimeRange(entry, cutoffDate, endTime) 
+          && (keepFunction == null || !keepFunction.test(entry))) {
+        iterator.remove();
+      }
+    }
+  }
+  
+  private static boolean entryWithinTimeRange(HealthRecord.Entry e, long cutoffDate, long endTime) {
+    if (e.start > cutoffDate && e.start <= endTime) {
+      return true; // trivial case, when we're within the last __ years
+    }
+
+    // if the entry has a stop time, check if the effective date range overlapped the last __ years
+    if (e.stop != 0L && e.stop > cutoffDate) {
+      
+      if (e.stop > endTime) {
+        // If any entries have an end date in the future but are within the cutoffDate,
+        // remove the end date but keep the entry (since it's still active).
+        e.stop = 0L;
+      }
+      
+      return true;
+    }
+    
+    return false;
   }
 
   public static File getOutputFolder(String folderName, Person person) {
@@ -121,6 +250,5 @@ public abstract class Exporter {
       return person.attributes.get(Person.NAME) + "_" + person.attributes.get(Person.ID) + "."
           + extension;
     }
-
   }
 }

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -3,6 +3,9 @@
 exporter.baseDirectory = ./output/
 exporter.use_uuid_filenames = false
 exporter.subfolders_by_id_substring = false
+exporter.years_of_history = 10
+# number of years of history to keep in exported records, anything older than this may be filtered out
+# set years_of_history = 0 to skip filtering altogether and keep the entire history
 exporter.ccda.export = false
 exporter.fhir.export = true
 exporter.hospital.fhir.export = true

--- a/src/test/java/org/mitre/synthea/export/ExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/ExporterTest.java
@@ -1,0 +1,177 @@
+package org.mitre.synthea.export;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mitre.synthea.helpers.Utilities;
+import org.mitre.synthea.modules.DeathModule;
+import org.mitre.synthea.world.agents.Person;
+import org.mitre.synthea.world.concepts.HealthRecord;
+import org.mitre.synthea.world.concepts.HealthRecord.Encounter;
+
+public class ExporterTest {
+
+  private long time;
+  private long endTime;
+  private int yearsToKeep;
+  private Person patient;
+  private HealthRecord record;
+  
+  private static final HealthRecord.Code DUMMY_CODE = new HealthRecord.Code("", "", "");
+  
+  /**
+   * Setup test data.
+   */
+  @Before public void setup() {
+    endTime = time = System.currentTimeMillis();
+    yearsToKeep = 5;
+    patient = new Person(12345L);
+    record = patient.record;
+    record.encounterStart(endTime, "dummy encounter");
+  }
+
+  @Test public void test_export_filter_simple_cutoff() {
+    record.observation(time - years(8), "height", 64);
+    record.observation(time - years(4), "weight", 128);
+
+    // observations should be filtered to the cutoff date
+
+    Person filtered = Exporter.filterForExport(patient, yearsToKeep, endTime);
+
+    Encounter encounter = filtered.record.currentEncounter(time);
+    assertEquals(1, encounter.observations.size());
+    assertEquals("weight", encounter.observations.get(0).type);
+    assertEquals(time - years(4), encounter.observations.get(0).start);
+    assertEquals(128, encounter.observations.get(0).value);
+  }
+
+  @Test public void test_export_filter_should_keep_old_active_medication() {
+    record.medicationStart(time - years(10), "fakeitol");
+
+    record.medicationStart(time - years(8), "placebitol");
+    record.medicationEnd(time - years(6), "placebitol", DUMMY_CODE);
+
+    Person filtered = Exporter.filterForExport(patient, yearsToKeep, endTime);
+
+    Encounter encounter = filtered.record.currentEncounter(time);
+    assertEquals(1, encounter.medications.size());
+    assertEquals("fakeitol", encounter.medications.get(0).type);
+    assertEquals(time - years(10), encounter.medications.get(0).start);
+  }
+
+  @Test public void test_export_filter_should_keep_medication_that_ended_during_target() {
+    record.medicationStart(time - years(10), "dimoxinil");
+    record.medicationEnd(time - years(9), "dimoxinil", DUMMY_CODE);
+
+    record.medicationStart(time - years(8), "placebitol");
+    record.medicationEnd(time - years(4), "placebitol", DUMMY_CODE);
+
+    Person filtered = Exporter.filterForExport(patient, yearsToKeep, endTime);
+
+    Encounter encounter = filtered.record.currentEncounter(time);
+    assertEquals(1, encounter.medications.size());
+    assertEquals("placebitol", encounter.medications.get(0).type);
+    assertEquals(time - years(8), encounter.medications.get(0).start);
+    assertEquals(time - years(4), encounter.medications.get(0).stop);
+  }
+
+  @Test public void test_export_filter_should_keep_old_active_careplan() {
+    record.careplanStart(time - years(10), "stop_smoking");
+    record.careplanEnd(time - years(8), "stop_smoking", DUMMY_CODE);
+
+    record.careplanStart(time - years(12), "healthy_diet");
+
+    Person filtered = Exporter.filterForExport(patient, yearsToKeep, endTime);
+
+    Encounter encounter = filtered.record.currentEncounter(time);
+    assertEquals(1, encounter.careplans.size());
+    assertEquals("healthy_diet", encounter.careplans.get(0).type);
+    assertEquals(time - years(12), encounter.careplans.get(0).start);
+  }
+
+  @Test public void test_export_filter_should_keep_careplan_that_ended_during_target() {
+    record.careplanStart(time - years(10), "stop_smoking");
+    record.careplanEnd(time - years(1), "stop_smoking", DUMMY_CODE);
+
+    Person filtered = Exporter.filterForExport(patient, yearsToKeep, endTime);
+
+    Encounter encounter = filtered.record.currentEncounter(time);
+    assertEquals(1, encounter.careplans.size());
+    assertEquals("stop_smoking", encounter.careplans.get(0).type);
+    assertEquals(time - years(10), encounter.careplans.get(0).start);
+    assertEquals(time - years(1), encounter.careplans.get(0).stop);
+  }
+
+  @Test public void test_export_filter_should_keep_old_active_conditions() {
+    record.conditionStart(time - years(10), "fakitis");
+    record.conditionEnd(time - years(8), "fakitis");
+
+    record.conditionStart(time - years(10), "fakosis");
+
+    Person filtered = Exporter.filterForExport(patient, yearsToKeep, endTime);
+
+    Encounter encounter = filtered.record.currentEncounter(time);
+    assertEquals(1, encounter.conditions.size());
+    assertEquals("fakosis", encounter.conditions.get(0).type);
+    assertEquals(time - years(10), encounter.conditions.get(0).start);
+  }
+
+  @Test public void test_export_filter_should_keep_condition_that_ended_during_target() {
+    record.conditionStart(time - years(10), "boneitis");
+    record.conditionEnd(time - years(2), "boneitis");
+
+    record.conditionStart(time - years(10), "smallpox");
+    record.conditionEnd(time - years(9), "smallpox");
+
+    Person filtered = Exporter.filterForExport(patient, yearsToKeep, endTime);
+
+    Encounter encounter = filtered.record.currentEncounter(time);
+    assertEquals(1, encounter.conditions.size());
+    assertEquals("boneitis", encounter.conditions.get(0).type);
+    assertEquals(time - years(10), encounter.conditions.get(0).start);
+  }
+
+  @Test public void test_export_filter_should_keep_cause_of_death() {
+    record.encounters.clear(); // delete that dummy encounter
+    
+    HealthRecord.Code causeOfDeath = 
+        new HealthRecord.Code("SNOMED-CT", "Todo-lookup-code", "Rabies");
+    patient.recordDeath(time - years(20), causeOfDeath, "death");
+    
+    DeathModule.process(patient, time - years(20));
+    Person filtered = Exporter.filterForExport(patient, yearsToKeep, endTime);
+
+    assertEquals(1, filtered.record.encounters.size());
+    Encounter encounter = filtered.record.encounters.get(0);
+    assertEquals(DeathModule.DEATH_CERTIFICATION, encounter.codes.get(0));
+    assertEquals(time - years(20), encounter.start);
+
+    assertEquals(1, encounter.observations.size());
+    assertEquals(DeathModule.CAUSE_OF_DEATH_CODE.code, encounter.observations.get(0).type);
+    assertEquals(time - years(20), encounter.observations.get(0).start);
+
+    assertEquals(1, encounter.reports.size());
+    assertEquals(DeathModule.DEATH_CERTIFICATE.code, encounter.reports.get(0).type);
+    assertEquals(time - years(20), encounter.reports.get(0).start);
+  }
+
+  @Test public void test_export_filter_should_not_keep_old_stuff() {
+    record.encounters.clear(); // delete that dummy encounter
+
+    record.encounterStart(time - years(18), "er_visit");
+    record.procedure(time - years(20), "appendectomy");
+    record.immunization(time - years(12), "flu_shot");
+    record.observation(time - years(10), "weight", 123);
+    
+
+    Person filtered = Exporter.filterForExport(patient, yearsToKeep, endTime);
+    
+    assertTrue(filtered.record.encounters.isEmpty());
+  }
+  
+  private static long years(long numYears) {
+    return Utilities.convertTime("years", numYears);
+  }
+}


### PR DESCRIPTION
Filters records for exporting, by keeping only the most recent 10 years of history (configurable). This is intended to mirror real health records which are frequently missing data.

Filtering is performed as follows:
- keep entries that are currently active (no end date)
- keep entries that were active at any point within the past 10 years (ie, end date is less than 10 years ago)
- delete encounters that are "empty" (no conditions, procedures, etc) and older than 10 years
- keep "cause of death" and related codes even if > 10 yrs old

This version is "destructive" in the sense that the entries are deleted from the record itself. As long as the export process is the last thing done to the Person object, this should have no negative impact.