### PR TITLE
Time Rewinding

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/Module.java
+++ b/src/main/java/org/mitre/synthea/engine/Module.java
@@ -182,10 +182,16 @@ public class Module {
     // probably more than one state
     String nextStateName = null;
     while (current.run(person, time)) {
+      Long exited = current.exited;      
       nextStateName = current.transition(person, time);
       // System.out.println(" Transitioning to " + nextStateName);
       current = states.get(nextStateName).clone(); // clone the state so we don't dirty the original
       person.history.add(0, current);
+      if (exited != null && exited < time) {
+        // This must be a delay state that expired between cycles, so temporarily rewind time
+        process(person, exited);
+        current = person.history.get(0);
+      }
     }
     person.attributes.remove(activeKey);
     return (current instanceof State.Terminal);

--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -140,7 +140,13 @@ public abstract class State implements Cloneable {
     boolean exit = process(person, time);
 
     if (exit) {
-      this.exited = time;
+      // Delay state returns a special value for exited,
+      // to indicate when the delay actually completed.
+      if (this instanceof Delay) {
+        this.exited = ((Delay)this).next;
+      } else {
+        this.exited = time;
+      }
     }
 
     return exit;
@@ -212,9 +218,13 @@ public abstract class State implements Cloneable {
         person.attributes.remove(submodule.name);
         // reset person.history to this module's history
         person.history = moduleHistory;
+        // add this state to history to indicate we returned to this module
+        person.history.add(0, this);
         
         return true;
       } else {
+        // reset person.history to this module's history
+        person.history = moduleHistory;
         // the submodule is still processing
         // next time we call this state it should pick up where it left off
         return false;
@@ -277,7 +287,8 @@ public abstract class State implements Cloneable {
         quantity = exact.get("quantity").getAsDouble();
       }
     }
-
+    
+    @Override
     public Delay clone() {
       Delay clone = (Delay) super.clone();
       clone.unit = unit;


### PR DESCRIPTION
Adds "time rewinding" so that delay states that expire between time steps lead to the next state at the correct time. For example, if a delay state is entered 1/1 and has a delay of 3 days, at the next timestep it will be 1/8, so we rewind time to 1/4 and enter the next state on 1/4 instead of 1/8.

A minor note is that CallSubmodule states need to be re-added to history when they complete for things to work out correctly.