### PR TITLE
Only Dead Patients config setting

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/Generator.java
+++ b/src/main/java/org/mitre/synthea/engine/Generator.java
@@ -227,9 +227,13 @@ public class Generator {
         // TODO - export is DESTRUCTIVE when it filters out data
         // this means export must be the LAST THING done with the person
         Exporter.export(person, time);
-      } while (isAlive == onlyDeadPatients);
-      // IOW, continue if the patient is alive and we only want dead ones, 
-      // or if the patient is dead and we want live ones
+      } while (!isAlive && !onlyDeadPatients);
+      // if the patient is alive and we want only dead ones => loop & try again
+      //  (and dont even export, handled above)
+      // if the patient is dead and we only want dead ones => done
+      // if the patient is dead and we want live ones => loop & try again
+      //  (but do export the record anyway)
+      // if the patient is alive and we want live ones => done
     } catch (Throwable e) {
       // lots of fhir things throw errors for some reason
       e.printStackTrace();

--- a/src/main/java/org/mitre/synthea/engine/Generator.java
+++ b/src/main/java/org/mitre/synthea/engine/Generator.java
@@ -203,6 +203,7 @@ public class Generator {
         if (isAlive && onlyDeadPatients) {
           continue;
           // skip the other stuff if the patient is alive and we only want dead patients
+          // note that this skips ahead to the while check and doesn't automatically re-loop
         }
 
         if (database != null) {
@@ -227,9 +228,9 @@ public class Generator {
         // TODO - export is DESTRUCTIVE when it filters out data
         // this means export must be the LAST THING done with the person
         Exporter.export(person, time);
-      } while (!isAlive && !onlyDeadPatients);
+      } while ((!isAlive && !onlyDeadPatients) || (isAlive && onlyDeadPatients));
       // if the patient is alive and we want only dead ones => loop & try again
-      //  (and dont even export, handled above)
+      //  (and dont even export, see above)
       // if the patient is dead and we only want dead ones => done
       // if the patient is dead and we want live ones => loop & try again
       //  (but do export the record anyway)

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -42,6 +42,8 @@ generate.demographics.default_file = geography/towns.json
 generate.demographics.real_world_population = 6794422
 #sum of the jsons in the config folder
 
+generate.only_dead_patients = false
+
 # if true, tracks and prints out details of transition tables for each module upon completion
 # note that this may significantly slow down processing, and is intended primarily for debugging
 generate.track_detailed_transition_metrics = false

--- a/src/test/java/org/mitre/synthea/engine/GeneratorTest.java
+++ b/src/test/java/org/mitre/synthea/engine/GeneratorTest.java
@@ -3,19 +3,24 @@ package org.mitre.synthea.engine;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.mitre.synthea.TestHelper;
 import org.mitre.synthea.helpers.Config;
 
 public class GeneratorTest {
+  @Before
+  public void setup() {
+    TestHelper.exportOff();
+    Config.set("generate.only_dead_patients", "false");
+  }
+
   @Test
   public void testGeneratorCreatesPeople() throws Exception {
     int numberOfPeople = 1;
-    TestHelper.exportOff();
     Generator generator = new Generator(numberOfPeople);
     generator.run();
     assertEquals(numberOfPeople, generator.stats.get("alive").longValue());
-    // there may be more than the requested number of people, because we re-generate on death
 
     numberOfPeople = 3;
     Config.set("generate.default_population", Integer.toString(numberOfPeople));
@@ -26,7 +31,6 @@ public class GeneratorTest {
 
   @Test
   public void testGenerateWithDatabase() throws Exception {
-    TestHelper.exportOff();
     int numberOfPeople = 1;
     Config.set("generate.database_type", "in-memory");
     Generator generator = new Generator(numberOfPeople, 0L);
@@ -38,7 +42,6 @@ public class GeneratorTest {
 
   @Test
   public void testGenerateWithMetrics() throws Exception {
-    TestHelper.exportOff();
     int numberOfPeople = 1;
     Config.set("generate.track_detailed_transition_metrics", "true");
     Generator generator = new Generator(numberOfPeople, 0L);
@@ -50,12 +53,21 @@ public class GeneratorTest {
 
   @Test
   public void testGenerateWithDetailedLogLevel() throws Exception {
-    TestHelper.exportOff();
     int numberOfPeople = 1;
     Config.set("generate.log_patients.detail", "detailed");
     Generator generator = new Generator(numberOfPeople, 0L);
     Config.set("generate.log_patients.detail", "simple");
     generator.run();
     assertEquals(numberOfPeople, generator.stats.get("alive").longValue());
+  }
+  
+  @Test
+  public void testGenerateOnlyDeadPatients() throws Exception {
+    Config.set("generate.only_dead_patients", "true");
+    int numberOfPeople = 2;
+    Generator generator = new Generator(numberOfPeople);
+    generator.run();
+    assertEquals(0, generator.stats.get("alive").longValue());
+    assertEquals(numberOfPeople, generator.stats.get("dead").longValue());
   }
 }


### PR DESCRIPTION
Adds an "only dead patients" config setting, (disabled by default) which flips the generation logic such that only dead patients are exported and reported. The normal process still runs and produces "living" patients, but if this setting is enabled then those living patients are simply discarded, and another patient is generated to try to get a dead one. There should be no noticeable change to normal execution, where both living and dead patients are exported.
Note that this setting may significantly increase runtime for large patient cohorts because on average only about 1 in 5 generated patients dies.

Sample output with the setting disabled (normal usage):
```
4 -- Alvera113 Nicolas769 (18 y/o) Boston
1 -- Luciano237 Willms744 (90 y/o) Pepperell DECEASED
3 -- Athena83 Dibbert990 (46 y/o) Rochester
5 -- Elouise806 Dickinson688 (56 y/o) Watertown
2 -- Josiah310 Ullrich385 (58 y/o) Carver
1 -- Elmira442 Schiller186 (72 y/o) Pepperell
{alive=5, dead=1}
Number of Towns: 0
Number of CHWs: 0

BUILD SUCCESSFUL in 7s
```

Sample output with the setting enabled:

```
3 -- Merlin721 Heller342 (34 y/o) Shrewsbury DECEASED
4 -- Ashleigh941 Dibbert990 (48 y/o) Boston DECEASED
2 -- Elsa29 White193 (66 y/o) Blackstone DECEASED
1 -- Orville751 Lind531 (38 y/o) Leominster DECEASED
5 -- Zora492 Koss676 (73 y/o) Worcester DECEASED
{alive=0, dead=5}
Number of Towns: 0
Number of CHWs: 0

BUILD SUCCESSFUL in 10s
```